### PR TITLE
ci: Update to `actions/checkout` `v4`

### DIFF
--- a/.github/workflows/rust-buiild.yml
+++ b/.github/workflows/rust-buiild.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Build
       run: cargo build --verbose
     - name: Run tests
@@ -24,7 +24,7 @@ jobs:
   clippy_check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - run: rustup component add clippy
       - uses: actions-rs/clippy-check@v1
         with:

--- a/.github/workflows/todo-issues.yml
+++ b/.github/workflows/todo-issues.yml
@@ -13,7 +13,7 @@ jobs:
   build:
     runs-on: "ubuntu-latest"
     steps:
-      - uses: "actions/checkout@v3"
+      - uses: "actions/checkout@v4"
       - name: "TODO to Issue"
         uses: "alstr/todo-to-issue-action@master"
         env:


### PR DESCRIPTION
This will switch to using Node 20 within GitHub Actions and get rid of some warnings about the older stuff being deprecated.