### PR TITLE
feat(deamon): added --debug flag

### DIFF
--- a/crates/daemon/src/main.rs
+++ b/crates/daemon/src/main.rs
@@ -123,6 +123,9 @@ struct Args {
         default_value = "8"
     )]
     num_io_threads: i32,
+
+    #[arg(long, help = "Enable debug logging", default_value = "false")]
+    debug: bool,
 }
 
 fn main() -> Result<(), Report> {
@@ -136,7 +139,11 @@ fn main() -> Result<(), Report> {
         .with_file(true)
         .with_line_number(true)
         .with_thread_names(true)
-        .with_max_level(tracing::Level::INFO)
+        .with_max_level(if args.debug {
+            tracing::Level::DEBUG
+        } else {
+            tracing::Level::INFO
+        })
         .finish();
     tracing::subscriber::set_global_default(main_subscriber)
         .expect("Unable to set configure logging");


### PR DESCRIPTION
Output with `--debug` looks as follows (spoiler for why I needed this):

```
2024-05-25T19:56:20.021697Z DEBUG moor-eventfd-listen moor_rdb::paging::page_storage: crates/rdb/src/paging/page_storage.rs:119: Synced all pages to disk? true
2024-05-25T19:56:20.021730Z DEBUG moor-eventfd-listen moor_rdb::paging::page_storage: crates/rdb/src/paging/page_storage.rs:119: Synced all pages to disk? true
2024-05-25T19:56:20.021762Z DEBUG moor-eventfd-listen moor_rdb::paging::page_storage: crates/rdb/src/paging/page_storage.rs:119: Synced all pages to disk? true
2024-05-25T19:56:20.021795Z DEBUG moor-eventfd-listen moor_rdb::paging::page_storage: crates/rdb/src/paging/page_storage.rs:119: Synced all pages to disk? true
2024-05-25T19:56:20.021827Z DEBUG moor-eventfd-listen moor_rdb::paging::page_storage: crates/rdb/src/paging/page_storage.rs:119: Synced all pages to disk? true
```