### PR TITLE
feat(rdb): Limit event_fd_listen_thread to looping every 100ms

### DIFF
--- a/crates/rdb/src/paging/page_storage.rs
+++ b/crates/rdb/src/paging/page_storage.rs
@@ -23,7 +23,7 @@ use std::path::PathBuf;
 use std::pin::Pin;
 use std::sync::atomic::{AtomicBool, AtomicU64};
 use std::sync::{Arc, Mutex};
-use std::thread::{yield_now, JoinHandle};
+use std::thread::{self, yield_now, JoinHandle};
 use std::time::Duration;
 
 use io_uring::squeue::Flags;
@@ -117,6 +117,7 @@ fn event_fd_listen_thread(event_fd: &Fd, ps: Arc<PageStore>, running_flag: Arc<A
         let completed = ps.clone().process_completions();
 
         debug!("Synced all pages to disk? {}", completed);
+        thread::sleep(Duration::from_millis(100));
     }
     info!("Shutting down eventfd listener");
 }


### PR DESCRIPTION
I noticed the daemon ate up 100% CPU. A quick check with `flamegraph` shows it's all in `event_fd_listen_thread`: we're *continuously* getting update events for some reason, and so this is effectively a busy-loop.

I'm pretty sure there's something going wrong - either my system's missing some config `moor` expects, or in `moor` proper. Either way, *regardless* of what's triggering this, I think limiting syncs to every 100ms seems generally a good idea?

Even with this change, debug logs are completely swamped by:

```
2024-05-25T20:07:27.678138Z DEBUG     moor-eventfd-listen moor_rdb::paging::page_storage: crates/rdb/src/paging/page_storage.rs:119: Synced all pages to disk? true
2024-05-25T20:07:27.745656Z DEBUG     moor-eventfd-listen moor_rdb::paging::page_storage: crates/rdb/src/paging/page_storage.rs:119: Synced all pages to disk? true
2024-05-25T20:07:27.778271Z DEBUG     moor-eventfd-listen moor_rdb::paging::page_storage: crates/rdb/src/paging/page_storage.rs:119: Synced all pages to disk? true
2024-05-25T20:07:27.845783Z DEBUG     moor-eventfd-listen moor_rdb::paging::page_storage: crates/rdb/src/paging/page_storage.rs:119: Synced all pages to disk? true
2024-05-25T20:07:27.878397Z DEBUG     moor-eventfd-listen moor_rdb::paging::page_storage: crates/rdb/src/paging/page_storage.rs:119: Synced all pages to disk? true
2024-05-25T20:07:27.945899Z DEBUG     moor-eventfd-listen moor_rdb::paging::page_storage: crates/rdb/src/paging/page_storage.rs:119: Synced all pages to disk? true
2024-05-25T20:07:27.978513Z DEBUG     moor-eventfd-listen moor_rdb::paging::page_storage: crates/rdb/src/paging/page_storage.rs:119: Synced all pages to disk? true
2024-05-25T20:07:28.046029Z DEBUG     moor-eventfd-listen moor_rdb::paging::page_storage: crates/rdb/src/paging/page_storage.rs:119: Synced all pages to disk? true
```

But at least it's not eating 100% CPU anymore :D