### PR TITLE
Add tests for `eval` built-in

### DIFF
--- a/crates/db/src/db_worldstate.rs
+++ b/crates/db/src/db_worldstate.rs
@@ -192,7 +192,6 @@ impl WorldState for DbTxWorldState {
         } else if pname == "owner" {
             return self.owner_of(obj).map(Var::from);
         } else if pname == "programmer" {
-            // TODO these can be set, too.
             let flags = self.flags_of(obj)?;
             return if flags.contains(ObjFlag::Programmer) {
                 Ok(v_int(1))
@@ -360,9 +359,17 @@ impl WorldState for DbTxWorldState {
             // Gott get and then set flags
             let mut flags = self.flags_of(obj)?;
             if pname == "programmer" {
-                flags.set(ObjFlag::Programmer);
+                if value.is_true() {
+                    flags.set(ObjFlag::Programmer);
+                } else {
+                    flags.clear(ObjFlag::Programmer);
+                }
             } else if pname == "wizard" {
-                flags.set(ObjFlag::Wizard);
+                if value.is_true() {
+                    flags.set(ObjFlag::Wizard);
+                } else {
+                    flags.clear(ObjFlag::Wizard);
+                }
             }
 
             self.tx.set_object_flags(obj, flags)?;

--- a/crates/kernel/Cargo.toml
+++ b/crates/kernel/Cargo.toml
@@ -22,6 +22,10 @@ unindent.workspace = true
 name = "basic-testsuite"
 path = "testsuite/basic_suite.rs"
 
+[[test]]
+name = "eval-testsuite"
+path = "testsuite/eval_suite.rs"
+
 [[bench]]
 name = "vm_benches"
 harness = false

--- a/crates/kernel/Cargo.toml
+++ b/crates/kernel/Cargo.toml
@@ -20,7 +20,7 @@ unindent.workspace = true
 
 [[test]]
 name = "basic-testsuite"
-path = "testsuite/basic/basic_suite.rs"
+path = "testsuite/basic_suite.rs"
 
 [[bench]]
 name = "vm_benches"

--- a/crates/kernel/Cargo.toml
+++ b/crates/kernel/Cargo.toml
@@ -26,6 +26,10 @@ path = "testsuite/basic_suite.rs"
 name = "eval-testsuite"
 path = "testsuite/eval_suite.rs"
 
+[[test]]
+name = "regression-suite"
+path = "testsuite/regression_suite.rs"
+
 [[bench]]
 name = "vm_benches"
 harness = false

--- a/crates/kernel/src/builtins/bf_server.rs
+++ b/crates/kernel/src/builtins/bf_server.rs
@@ -766,6 +766,10 @@ pub const BF_SERVER_EVAL_TRAMPOLINE_START_INITIALIZE: usize = 0;
 pub const BF_SERVER_EVAL_TRAMPOLINE_RESUME: usize = 1;
 
 fn bf_eval(bf_args: &mut BfCallState<'_>) -> Result<BfRet, Error> {
+    bf_args
+        .task_perms()?
+        .check_programmer()
+        .map_err(world_state_err)?;
     if bf_args.args.len() != 1 {
         return Err(E_ARGS);
     }

--- a/crates/kernel/src/builtins/bf_server.rs
+++ b/crates/kernel/src/builtins/bf_server.rs
@@ -24,7 +24,7 @@ use tracing::{debug, error, info, warn};
 
 use moor_values::model::ObjFlag;
 use moor_values::model::{world_state_err, NarrativeEvent, WorldStateError};
-use moor_values::var::Error::{E_INVARG, E_PERM, E_TYPE};
+use moor_values::var::Error::{E_ARGS, E_INVARG, E_PERM, E_TYPE};
 use moor_values::var::Variant;
 use moor_values::var::{v_bool, v_int, v_list, v_none, v_objid, v_str, v_string, Var};
 use moor_values::var::{v_listv, Error};
@@ -767,7 +767,7 @@ pub const BF_SERVER_EVAL_TRAMPOLINE_RESUME: usize = 1;
 
 fn bf_eval(bf_args: &mut BfCallState<'_>) -> Result<BfRet, Error> {
     if bf_args.args.len() != 1 {
-        return Err(E_INVARG);
+        return Err(E_ARGS);
     }
     let Variant::Str(program_code) = bf_args.args[0].variant() else {
         return Err(E_TYPE);

--- a/crates/kernel/src/tasks/mod.rs
+++ b/crates/kernel/src/tasks/mod.rs
@@ -64,7 +64,7 @@ pub mod vm_test_utils {
     use crate::vm::VmExecParams;
     use moor_compiler::Program;
     use moor_values::model::WorldState;
-    use moor_values::var::Var;
+    use moor_values::var::{Objid, Var};
     use moor_values::SYSTEM_OBJECT;
     use std::sync::Arc;
     use std::time::Duration;
@@ -158,10 +158,11 @@ pub mod vm_test_utils {
     pub fn call_eval_builtin(
         world_state: &mut dyn WorldState,
         session: Arc<dyn Session>,
+        player: Objid,
         program: Program,
     ) -> ExecResult {
         execute(world_state, session, |_world_state, vm_host| {
-            vm_host.start_eval(0, SYSTEM_OBJECT, program);
+            vm_host.start_eval(0, player, program);
         })
     }
 }

--- a/crates/kernel/src/tasks/mod.rs
+++ b/crates/kernel/src/tasks/mod.rs
@@ -75,6 +75,31 @@ pub mod vm_test_utils {
         Exception(UncaughtException),
     }
 
+    impl ExecResult {
+        pub fn unwrap(self) -> Var {
+            match self {
+                ExecResult::Success(v) => v,
+                ExecResult::Exception(e) => panic!("Unwrapping exception: {:?}", e),
+            }
+        }
+
+        pub fn unwrap_err(self) -> UncaughtException {
+            match self {
+                ExecResult::Success(v) => panic!("Unwrapping success: {:?}", v),
+                ExecResult::Exception(e) => e,
+            }
+        }
+    }
+
+    impl<T> From<T> for ExecResult
+    where
+        T: Into<Var>,
+    {
+        fn from(t: T) -> Self {
+            ExecResult::Success(t.into())
+        }
+    }
+
     fn execute<F>(world_state: &mut dyn WorldState, session: Arc<dyn Session>, fun: F) -> ExecResult
     where
         F: FnOnce(&mut dyn WorldState, &mut VmHost),
@@ -161,8 +186,8 @@ pub mod vm_test_utils {
         player: Objid,
         program: Program,
     ) -> ExecResult {
-        execute(world_state, session, |_world_state, vm_host| {
-            vm_host.start_eval(0, player, program);
+        execute(world_state, session, |world_state, vm_host| {
+            vm_host.start_eval(0, player, program, world_state);
         })
     }
 }

--- a/crates/kernel/src/tasks/task.rs
+++ b/crates/kernel/src/tasks/task.rs
@@ -326,7 +326,8 @@ impl Task {
             }
             TaskStart::StartEval { player, program } => {
                 self.scheduled_start_time = None;
-                self.vm_host.start_eval(self.task_id, player, program);
+                self.vm_host
+                    .start_eval(self.task_id, player, program, self.world_state.as_ref());
             }
         };
         true

--- a/crates/kernel/src/vm/activation.rs
+++ b/crates/kernel/src/vm/activation.rs
@@ -12,6 +12,7 @@
 // this program. If not, see <https://www.gnu.org/licenses/>.
 //
 
+use moor_values::var::v_empty_str;
 use moor_values::NOTHING;
 use uuid::Uuid;
 
@@ -345,17 +346,17 @@ impl Activation {
             temp: v_none(),
         };
         set_constants(&mut frame);
-        frame.set_gvar(GlobalName::this, v_objid(player));
+        frame.set_gvar(GlobalName::this, v_objid(NOTHING));
         frame.set_gvar(GlobalName::player, v_objid(player));
         frame.set_gvar(GlobalName::caller, v_objid(player));
-        frame.set_gvar(GlobalName::verb, v_str("eval"));
+        frame.set_gvar(GlobalName::verb, v_empty_str());
         frame.set_gvar(GlobalName::args, v_empty_list());
-        frame.set_gvar(GlobalName::argstr, v_str(""));
+        frame.set_gvar(GlobalName::argstr, v_empty_str());
         frame.set_gvar(GlobalName::dobj, v_objid(NOTHING));
-        frame.set_gvar(GlobalName::dobjstr, v_str(""));
-        frame.set_gvar(GlobalName::prepstr, v_str(""));
+        frame.set_gvar(GlobalName::dobjstr, v_empty_str());
+        frame.set_gvar(GlobalName::prepstr, v_empty_str());
         frame.set_gvar(GlobalName::iobj, v_objid(NOTHING));
-        frame.set_gvar(GlobalName::iobjstr, v_str(""));
+        frame.set_gvar(GlobalName::iobjstr, v_empty_str());
 
         Self {
             frame,

--- a/crates/kernel/testsuite/README.md
+++ b/crates/kernel/testsuite/README.md
@@ -1,4 +1,3 @@
-This is a port of (part of) the regression suite bundled with Stunt MOO:
+This is mostly a port of (part of) the regression suite bundled with Stunt MOO:
 
 https://github.com/toddsundsted/stunt/tree/master/test
-

--- a/crates/kernel/testsuite/basic_suite.rs
+++ b/crates/kernel/testsuite/basic_suite.rs
@@ -13,7 +13,7 @@
 //
 
 mod common;
-use common::{create_db, eval, testsuite_dir};
+use common::{create_db, eval, testsuite_dir, WIZARD};
 use pretty_assertions::assert_eq;
 
 fn run_basic_test(test_dir: &str) {
@@ -35,8 +35,12 @@ fn run_basic_test(test_dir: &str) {
     // Zip
     let zipped = in_lines.zip(out_lines);
     for (line_num, (input, expected_str)) in zipped.enumerate() {
-        let actual = eval(db.clone(), &format!("return {};", input.trim()));
-        let expected = eval(db.clone(), &format!("return {};", expected_str.trim()));
+        let actual = eval(db.clone(), WIZARD, &format!("return {};", input.trim()));
+        let expected = eval(
+            db.clone(),
+            WIZARD,
+            &format!("return {};", expected_str.trim()),
+        );
         assert_eq!(actual, expected, "{test_dir}: line {line_num}: {input}")
     }
 }

--- a/crates/kernel/testsuite/basic_suite.rs
+++ b/crates/kernel/testsuite/basic_suite.rs
@@ -1,0 +1,73 @@
+// Copyright (C) 2024 Ryan Daum <ryan.daum@gmail.com>
+//
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free Software
+// Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program. If not, see <https://www.gnu.org/licenses/>.
+//
+
+mod common;
+use common::{create_db, eval, testsuite_dir};
+use pretty_assertions::assert_eq;
+
+fn run_basic_test(test_dir: &str) {
+    let abs_test_dir = testsuite_dir().join("basic").join(test_dir);
+
+    let test_in = abs_test_dir.join("test.in");
+    let test_out = abs_test_dir.join("test.out");
+
+    // Read the lines from both files, the first is an input expression, the second the
+    // expected output. Both as MOO expressions. # of lines must be identical in each.
+    let input = std::fs::read_to_string(test_in).unwrap();
+    let in_lines = input.lines();
+    let output = std::fs::read_to_string(test_out).unwrap();
+    let out_lines = output.lines();
+    assert_eq!(in_lines.clone().count(), out_lines.clone().count());
+
+    let db = create_db();
+
+    // Zip
+    let zipped = in_lines.zip(out_lines);
+    for (line_num, (input, expected_str)) in zipped.enumerate() {
+        let actual = eval(db.clone(), &format!("return {};", input.trim()));
+        let expected = eval(db.clone(), &format!("return {};", expected_str.trim()));
+        assert_eq!(actual, expected, "{test_dir}: line {line_num}: {input}")
+    }
+}
+
+fn main() {}
+#[test]
+fn basic_arithmetic() {
+    run_basic_test("arithmetic");
+}
+
+#[test]
+fn basic_value() {
+    run_basic_test("value");
+}
+
+#[test]
+fn basic_string() {
+    run_basic_test("string");
+}
+
+#[test]
+fn basic_list() {
+    run_basic_test("list");
+}
+
+#[test]
+fn basic_property() {
+    run_basic_test("property");
+}
+
+#[test]
+fn basic_object() {
+    run_basic_test("object");
+}

--- a/crates/kernel/testsuite/common/mod.rs
+++ b/crates/kernel/testsuite/common/mod.rs
@@ -32,20 +32,27 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use uuid::Uuid;
 
-fn testsuite_dir() -> PathBuf {
+pub fn testsuite_dir() -> PathBuf {
     let manifest_dir = env!("CARGO_MANIFEST_DIR");
     Path::new(manifest_dir).join("testsuite")
 }
 
 /// Create a minimal Db to support the test harness.
-fn load_textdump(db: Arc<dyn Database>) {
+pub fn load_textdump(db: Arc<dyn Database>) {
     let tx = db.loader_client().unwrap();
     textdump_load(tx.clone(), testsuite_dir().join("Minimal.db")).expect("Could not load textdump");
     assert_eq!(tx.commit().unwrap(), CommitResult::Success);
 }
 
+pub fn create_db() -> Arc<RelBoxWorldState> {
+    let (db, _) = RelBoxWorldState::open(None, 1 << 30);
+    let db = Arc::new(db);
+    load_textdump(db.clone());
+    db
+}
+
 #[allow(unused)]
-fn compile_verbs(db: Arc<dyn WorldStateSource>, verbs: &[(&str, &Program)]) {
+pub fn compile_verbs(db: Arc<dyn WorldStateSource>, verbs: &[(&str, &Program)]) {
     let mut tx = db.new_world_state().unwrap();
     for (verb_name, program) in verbs {
         let binary = program.make_copy_as_vec().unwrap();
@@ -77,7 +84,7 @@ fn compile_verbs(db: Arc<dyn WorldStateSource>, verbs: &[(&str, &Program)]) {
 }
 
 #[allow(unused)]
-fn run_as_verb(db: Arc<dyn WorldStateSource>, expression: &str) -> ExecResult {
+pub fn run_as_verb(db: Arc<dyn WorldStateSource>, expression: &str) -> ExecResult {
     let binary = compile(format!("return {expression};").as_str()).unwrap();
     let verb_uuid = Uuid::new_v4().to_string();
     compile_verbs(db.clone(), &[(&verb_uuid, &binary)]);
@@ -92,79 +99,10 @@ fn run_as_verb(db: Arc<dyn WorldStateSource>, expression: &str) -> ExecResult {
     result
 }
 
-fn eval(db: Arc<dyn WorldStateSource>, expression: &str) -> ExecResult {
+pub fn eval(db: Arc<dyn WorldStateSource>, expression: &str) -> ExecResult {
     let binary = compile(expression).unwrap();
     let mut state = db.new_world_state().unwrap();
     let result = call_eval_builtin(state.as_mut(), Arc::new(NoopClientSession::new()), binary);
     state.commit().unwrap();
     result
-}
-
-fn run_basic_test(test_dir: &str) {
-    let manifest_dir = env!("CARGO_MANIFEST_DIR");
-    let basic_arith_dir = Path::new(manifest_dir)
-        .join("testsuite")
-        .join("basic")
-        .join(test_dir);
-
-    let test_in = basic_arith_dir.join("test.in");
-    let test_out = basic_arith_dir.join("test.out");
-
-    // Read the lines from both files, the first is an input expression, the second the
-    // expected output. Both as MOO expressions. # of lines must be identical in each.
-    let input = std::fs::read_to_string(test_in).unwrap();
-    let in_lines = input.lines();
-    let output = std::fs::read_to_string(test_out).unwrap();
-    let out_lines = output.lines();
-    assert_eq!(in_lines.clone().count(), out_lines.clone().count());
-
-    // Zip
-    let zipped = in_lines.zip(out_lines);
-
-    // Frustratingly the individual test lines are not independent, so we need to run them in a
-    // single database.
-    let (db, _) = RelBoxWorldState::open(None, 1 << 30);
-    let db = Arc::new(db);
-    load_textdump(db.clone());
-    for (line_num, (input, expected_str)) in zipped.enumerate() {
-        let actual = eval(db.clone(), &format!("return {};", input.trim()));
-        let expected = eval(db.clone(), &format!("return {};", expected_str.trim()));
-        assert_eq!(
-            actual,
-            expected,
-            "{test_dir}: line {}: {input}",
-            line_num + 1
-        );
-    }
-}
-
-fn main() {}
-#[test]
-fn basic_arithmetic() {
-    run_basic_test("arithmetic");
-}
-
-#[test]
-fn basic_value() {
-    run_basic_test("value");
-}
-
-#[test]
-fn basic_string() {
-    run_basic_test("string");
-}
-
-#[test]
-fn basic_list() {
-    run_basic_test("list");
-}
-
-#[test]
-fn basic_property() {
-    run_basic_test("property");
-}
-
-#[test]
-fn basic_object() {
-    run_basic_test("object");
 }

--- a/crates/kernel/testsuite/common/mod.rs
+++ b/crates/kernel/testsuite/common/mod.rs
@@ -32,6 +32,8 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use uuid::Uuid;
 
+pub const WIZARD: Objid = Objid(3);
+
 pub fn testsuite_dir() -> PathBuf {
     let manifest_dir = env!("CARGO_MANIFEST_DIR");
     Path::new(manifest_dir).join("testsuite")
@@ -99,10 +101,15 @@ pub fn run_as_verb(db: Arc<dyn WorldStateSource>, expression: &str) -> ExecResul
     result
 }
 
-pub fn eval(db: Arc<dyn WorldStateSource>, expression: &str) -> ExecResult {
+pub fn eval(db: Arc<dyn WorldStateSource>, player: Objid, expression: &str) -> ExecResult {
     let binary = compile(expression).unwrap();
     let mut state = db.new_world_state().unwrap();
-    let result = call_eval_builtin(state.as_mut(), Arc::new(NoopClientSession::new()), binary);
+    let result = call_eval_builtin(
+        state.as_mut(),
+        Arc::new(NoopClientSession::new()),
+        player,
+        binary,
+    );
     state.commit().unwrap();
     result
 }

--- a/crates/kernel/testsuite/eval_suite.rs
+++ b/crates/kernel/testsuite/eval_suite.rs
@@ -13,97 +13,77 @@
 //
 
 mod common;
-use common::{create_db, eval, WIZARD};
+use common::{create_db, AssertEval, WIZARD};
 use moor_values::{
     var::{
-        v_empty_list, v_empty_str,
+        v_empty_list, v_empty_str, v_none,
         Error::{E_ARGS, E_PERM, E_TYPE},
     },
     NOTHING,
 };
-use pretty_assertions::assert_eq;
 
 #[test]
 fn test_that_eval_cannot_be_called_by_non_programmers() {
     let db = create_db();
-    eval(db.clone(), WIZARD, "player.programmer = 0;");
-    assert_eq!(eval(db.clone(), WIZARD, r#"return 5;"#), E_PERM.into());
+    db.assert_eval(WIZARD, "player.programmer = 0;", v_none());
+    db.assert_eval(WIZARD, "return 5;", E_PERM);
 }
 
 #[test]
 fn test_bf_eval_cannot_be_called_by_non_programmers() {
     let db = create_db();
-    assert_eq!(
-        eval(
-            db.clone(),
-            WIZARD,
-            r#"player.programmer = 0; return eval("return 5;");"#
-        )
-        .unwrap_err()
-        .code,
-        E_PERM
+    db.assert_eval_exception(
+        WIZARD,
+        r#"player.programmer = 0; return eval("return 5;");"#,
+        E_PERM,
     );
 }
 
 #[test]
 fn test_that_bf_eval_requires_at_least_one_argument() {
     let db = create_db();
-    assert_eq!(eval(db, WIZARD, "return eval();").unwrap_err().code, E_ARGS);
+    db.assert_eval_exception(WIZARD, "return eval();", E_ARGS);
 }
 
 #[test]
 fn test_that_eval_requires_string_arguments() {
     let db = create_db();
-    assert_eq!(
-        eval(db.clone(), WIZARD, "return eval(1);")
-            .unwrap_err()
-            .code,
-        E_TYPE
-    );
+    db.assert_eval_exception(WIZARD, "return eval(1);", E_TYPE);
     // TODO uncomment when `eval()` gets support for multiple arguments
-    // assert_eq!(eval(db, WIZARD, "return eval(1, 2);"), E_ARGS.into());
-    assert_eq!(
-        eval(db, WIZARD, "return eval({});").unwrap_err().code,
-        E_TYPE
-    );
+    // db.assert_eval_exception(WIZARD, "return eval(1, 2);", E_TYPE);
+    db.assert_eval_exception(WIZARD, "return eval({});", E_TYPE);
 }
 
 #[test]
 #[ignore = "We don't currently support multiple args to eval()"]
 fn test_that_eval_evaluates_multiple_strings() {
     let db = create_db();
-    assert_eq!(
-        eval(
-            db,
-            WIZARD,
-            r#"return eval("x = 0;", "for i in [1..5]", "x = x + i;", "endfor", "return x;");"#
-        ),
-        [1, 15].into()
+    db.assert_eval(
+        WIZARD,
+        r#"return eval("x = 0;", "for i in [1..5]", "x = x + i;", "endfor", "return x;");"#,
+        [1, 15],
     );
 }
 
 #[test]
 fn test_that_eval_evaluates_a_single_string() {
     let db = create_db();
-    assert_eq!(
-        eval(db, WIZARD, r#"return eval("return 5;");"#),
-        [1, 5].into()
-    );
+    db.assert_eval(WIZARD, r#"return eval("return 5;");"#, [1, 5]);
 }
 
 #[test]
 fn test_eval_builtin_variables() {
     // As seen on https://stunt.io/ProgrammersManual.html#Language
     let db = create_db();
-    assert_eq!(eval(db.clone(), WIZARD, "return player;"), WIZARD.into());
-    assert_eq!(eval(db.clone(), WIZARD, "return this;"), NOTHING.into());
-    assert_eq!(eval(db.clone(), WIZARD, "return caller;"), WIZARD.into());
-    assert_eq!(eval(db.clone(), WIZARD, "return args;"), v_empty_list());
-    assert_eq!(eval(db.clone(), WIZARD, "return argstr;"), v_empty_str());
-    assert_eq!(eval(db.clone(), WIZARD, "return verb;"), v_empty_str());
-    assert_eq!(eval(db.clone(), WIZARD, "return dobjstr;"), v_empty_str());
-    assert_eq!(eval(db.clone(), WIZARD, "return dobj;"), NOTHING.into());
-    assert_eq!(eval(db.clone(), WIZARD, "return prepstr;"), v_empty_str());
-    assert_eq!(eval(db.clone(), WIZARD, "return iobjstr;"), v_empty_str());
-    assert_eq!(eval(db.clone(), WIZARD, "return iobj;"), NOTHING.into());
+    db.assert_eval(WIZARD, "return player;", WIZARD);
+    db.assert_eval(WIZARD, "return this;", NOTHING);
+    db.assert_eval(WIZARD, "return caller;", WIZARD);
+    db.assert_eval(WIZARD, "return args;", v_empty_list());
+    db.assert_eval(WIZARD, "return argstr;", v_empty_str());
+    db.assert_eval(WIZARD, "return verb;", v_empty_str());
+    db.assert_eval(WIZARD, "return dobjstr;", v_empty_str());
+    db.assert_eval(WIZARD, "return dobj;", NOTHING);
+    db.assert_eval(WIZARD, "return prepstr;", v_empty_str());
+    db.assert_eval(WIZARD, "return iobjstr;", v_empty_str());
+    db.assert_eval(WIZARD, "return iobj;", NOTHING);
 }

--- a/crates/kernel/testsuite/eval_suite.rs
+++ b/crates/kernel/testsuite/eval_suite.rs
@@ -14,7 +14,13 @@
 
 mod common;
 use common::{create_db, eval, WIZARD};
-use moor_values::var::Error::{E_ARGS, E_PERM, E_TYPE};
+use moor_values::{
+    var::{
+        v_empty_list, v_empty_str,
+        Error::{E_ARGS, E_PERM, E_TYPE},
+    },
+    NOTHING,
+};
 use pretty_assertions::assert_eq;
 
 #[test]
@@ -83,4 +89,21 @@ fn test_that_eval_evaluates_a_single_string() {
         eval(db, WIZARD, r#"return eval("return 5;");"#),
         [1, 5].into()
     );
+}
+
+#[test]
+fn test_eval_builtin_variables() {
+    // As seen on https://stunt.io/ProgrammersManual.html#Language
+    let db = create_db();
+    assert_eq!(eval(db.clone(), WIZARD, "return player;"), WIZARD.into());
+    assert_eq!(eval(db.clone(), WIZARD, "return this;"), NOTHING.into());
+    assert_eq!(eval(db.clone(), WIZARD, "return caller;"), WIZARD.into());
+    assert_eq!(eval(db.clone(), WIZARD, "return args;"), v_empty_list());
+    assert_eq!(eval(db.clone(), WIZARD, "return argstr;"), v_empty_str());
+    assert_eq!(eval(db.clone(), WIZARD, "return verb;"), v_empty_str());
+    assert_eq!(eval(db.clone(), WIZARD, "return dobjstr;"), v_empty_str());
+    assert_eq!(eval(db.clone(), WIZARD, "return dobj;"), NOTHING.into());
+    assert_eq!(eval(db.clone(), WIZARD, "return prepstr;"), v_empty_str());
+    assert_eq!(eval(db.clone(), WIZARD, "return iobjstr;"), v_empty_str());
+    assert_eq!(eval(db.clone(), WIZARD, "return iobj;"), NOTHING.into());
 }

--- a/crates/kernel/testsuite/eval_suite.rs
+++ b/crates/kernel/testsuite/eval_suite.rs
@@ -21,47 +21,45 @@ use pretty_assertions::assert_eq;
 fn test_that_eval_cannot_be_called_by_non_programmers() {
     let db = create_db();
     eval(db.clone(), WIZARD, "player.programmer = 0;");
-    assert_eq!(
-        eval(db.clone(), WIZARD, r#"return eval("return 5;");"#),
-        E_PERM.into()
-    );
-}
-
-#[test]
-#[ignore = "This is currently broken, which is *extremely weird* - note the lack of extra eval(...)"]
-fn test_direct_eval_cannot_be_called_by_non_programmers() {
-    let db = create_db();
-    eval(db.clone(), WIZARD, "player.programmer = 0;");
     assert_eq!(eval(db.clone(), WIZARD, r#"return 5;"#), E_PERM.into());
 }
 
 #[test]
-#[ignore = "This is currently broken, which is *extremely weird* - note the lack of extra eval(...)"]
-fn test_direct_eval_cannot_be_called_by_non_programmers_nonself() {
+fn test_bf_eval_cannot_be_called_by_non_programmers() {
     let db = create_db();
-
-    let obj_var = eval(db.clone(), WIZARD, "return create(#2);");
-    let obj = match obj_var.variant() {
-        moor_values::var::Variant::Obj(obj) => obj,
-        _ => panic!("Expected an object"),
-    };
-
-    assert_eq!(eval(db.clone(), *obj, r#"return 5;"#), E_PERM.into());
+    assert_eq!(
+        eval(
+            db.clone(),
+            WIZARD,
+            r#"player.programmer = 0; return eval("return 5;");"#
+        )
+        .unwrap_err()
+        .code,
+        E_PERM
+    );
 }
 
 #[test]
-fn test_that_eval_requires_at_least_one_argument() {
+fn test_that_bf_eval_requires_at_least_one_argument() {
     let db = create_db();
-    assert_eq!(eval(db, WIZARD, "return eval();"), E_ARGS.into());
+    assert_eq!(eval(db, WIZARD, "return eval();").unwrap_err().code, E_ARGS);
 }
 
 #[test]
 fn test_that_eval_requires_string_arguments() {
     let db = create_db();
-    assert_eq!(eval(db.clone(), WIZARD, "return eval(1);"), E_TYPE.into());
+    assert_eq!(
+        eval(db.clone(), WIZARD, "return eval(1);")
+            .unwrap_err()
+            .code,
+        E_TYPE
+    );
     // TODO uncomment when `eval()` gets support for multiple arguments
     // assert_eq!(eval(db, WIZARD, "return eval(1, 2);"), E_ARGS.into());
-    assert_eq!(eval(db, WIZARD, "return eval({});"), E_TYPE.into());
+    assert_eq!(
+        eval(db, WIZARD, "return eval({});").unwrap_err().code,
+        E_TYPE
+    );
 }
 
 #[test]

--- a/crates/kernel/testsuite/eval_suite.rs
+++ b/crates/kernel/testsuite/eval_suite.rs
@@ -1,0 +1,64 @@
+// Copyright (C) 2024 Ryan Daum <ryan.daum@gmail.com>
+//
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free Software
+// Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program. If not, see <https://www.gnu.org/licenses/>.
+//
+
+mod common;
+use common::{create_db, eval, WIZARD};
+use moor_values::var::Error::{E_ARGS, E_PERM, E_TYPE};
+use pretty_assertions::assert_eq;
+
+#[test]
+#[ignore = "This check is not currently implemented"]
+fn test_that_eval_cannot_be_called_by_non_programmers() {
+    let db = create_db();
+    eval(db.clone(), WIZARD, "player.programmer = 0;");
+    assert_eq!(eval(db, WIZARD, "return 5;"), E_PERM.into());
+}
+
+#[test]
+fn test_that_eval_requires_at_least_one_argument() {
+    let db = create_db();
+    assert_eq!(eval(db, WIZARD, "return eval();"), E_ARGS.into());
+}
+
+#[test]
+fn test_that_eval_requires_string_arguments() {
+    let db = create_db();
+    assert_eq!(eval(db.clone(), WIZARD, "return eval(1);"), E_TYPE.into());
+    // TODO uncomment when `eval()` gets support for multiple arguments
+    // assert_eq!(eval(db, WIZARD, "return eval(1, 2);"), E_ARGS.into());
+    assert_eq!(eval(db, WIZARD, "return eval({});"), E_TYPE.into());
+}
+
+#[test]
+#[ignore = "We don't currently support multiple args to eval()"]
+fn test_that_eval_evaluates_multiple_strings() {
+    let db = create_db();
+    assert_eq!(
+        eval(
+            db,
+            WIZARD,
+            r#"return eval("x = 0;", "for i in [1..5]", "x = x + i;", "endfor", "return x;");"#
+        ),
+        [1, 15].into()
+    );
+}
+
+#[test]
+fn test_that_eval_evaluates_a_single_string() {
+    let db = create_db();
+    assert_eq!(
+        eval(db, WIZARD, r#"return eval("return 5;");"#),
+        [1, 5].into()
+    );
+}

--- a/crates/kernel/testsuite/regression_suite.rs
+++ b/crates/kernel/testsuite/regression_suite.rs
@@ -1,0 +1,65 @@
+// Copyright (C) 2024 Ryan Daum <ryan.daum@gmail.com>
+//
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free Software
+// Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program. If not, see <https://www.gnu.org/licenses/>.
+//
+
+mod common;
+use common::{create_db, eval, WIZARD};
+use pretty_assertions::assert_eq;
+
+#[test]
+fn test_changing_programmer_and_wizard_flags() {
+    let db = create_db();
+
+    // Create an object we can work with
+    let obj = eval(db.clone(), WIZARD, "return create(#2);");
+
+    // Start: it's neither a programmer nor a wizard
+    assert_eq!(
+        eval(
+            db.clone(),
+            WIZARD,
+            &format!("return {{ {obj}.programmer, {obj}.wizard }};")
+        ),
+        [0, 0].into()
+    );
+
+    // Set both, verify
+    eval(
+        db.clone(),
+        WIZARD,
+        &format!("{obj}.programmer = 1; {obj}.wizard = 1;"),
+    );
+    assert_eq!(
+        eval(
+            db.clone(),
+            WIZARD,
+            &format!("return {{ {obj}.programmer, {obj}.wizard }};")
+        ),
+        [1, 1].into()
+    );
+
+    // Clear both, verify
+    eval(
+        db.clone(),
+        WIZARD,
+        &format!("{obj}.programmer = 0; {obj}.wizard = 0;"),
+    );
+    assert_eq!(
+        eval(
+            db.clone(),
+            WIZARD,
+            &format!("return {{ {obj}.programmer, {obj}.wizard }};")
+        ),
+        [0, 0].into()
+    );
+}

--- a/crates/kernel/testsuite/regression_suite.rs
+++ b/crates/kernel/testsuite/regression_suite.rs
@@ -14,7 +14,7 @@
 
 mod common;
 use common::{create_db, eval, AssertEval, AssertRunAsVerb, WIZARD};
-use moor_values::var::{v_empty_list, v_none, Var, Variant};
+use moor_values::var::{v_empty_list, v_none, Error::E_PROPNF, Var, Variant};
 
 #[test]
 fn test_changing_programmer_and_wizard_flags() {
@@ -86,4 +86,12 @@ fn test_properties_does_not_list_parent_props() {
         format!("return properties({objid});"),
         v_empty_list(),
     );
+}
+
+#[test]
+#[ignore = "Currently broken"]
+fn test_setting_undefined_property_fails() {
+    let db = create_db();
+
+    db.assert_eval(WIZARD, "#2.x = 42;", E_PROPNF);
 }

--- a/crates/kernel/testsuite/regression_suite.rs
+++ b/crates/kernel/testsuite/regression_suite.rs
@@ -13,8 +13,8 @@
 //
 
 mod common;
-use common::{create_db, eval, AssertEval, WIZARD};
-use moor_values::var::v_none;
+use common::{create_db, eval, AssertEval, AssertRunAsVerb, WIZARD};
+use moor_values::var::{v_empty_list, v_none, Var, Variant};
 
 #[test]
 fn test_changing_programmer_and_wizard_flags() {
@@ -52,5 +52,38 @@ fn test_changing_programmer_and_wizard_flags() {
         WIZARD,
         format!("return {{ {obj}.programmer, {obj}.wizard }};"),
         [0, 0],
+    );
+}
+
+#[test]
+fn test_testhelper_verb_redefinition() {
+    let db = create_db();
+    db.assert_run_as_verb("return 42;", 42);
+    db.assert_run_as_verb("return create(#2).name;", "");
+    db.assert_run_as_verb("return 200;", 200);
+}
+
+#[test]
+#[ignore = "Currently broken"]
+fn test_properties_does_not_list_parent_props() {
+    let db = create_db();
+
+    let obj_var = eval(db.clone(), WIZARD, "return create(#2);").unwrap();
+    let objid = match obj_var.variant() {
+        Variant::Obj(objid) => objid,
+        _ => panic!("Expected an object"),
+    };
+
+    db.assert_eval(
+        WIZARD,
+        r#"add_property(#2, "prop1", 0, {player, "rwc" });"#,
+        v_none(),
+    );
+    db.assert_eval(WIZARD, "#2.prop1 = 1;;", v_none());
+    db.assert_eval(WIZARD, "return properties(#2);", vec![Var::from("prop1")]);
+    db.assert_eval(
+        WIZARD,
+        format!("return properties({objid});"),
+        v_empty_list(),
     );
 }

--- a/crates/kernel/testsuite/regression_suite.rs
+++ b/crates/kernel/testsuite/regression_suite.rs
@@ -21,7 +21,7 @@ fn test_changing_programmer_and_wizard_flags() {
     let db = create_db();
 
     // Create an object we can work with
-    let obj = eval(db.clone(), WIZARD, "return create(#2);");
+    let obj = eval(db.clone(), WIZARD, "return create(#2);").unwrap();
 
     // Start: it's neither a programmer nor a wizard
     assert_eq!(

--- a/crates/kernel/testsuite/regression_suite.rs
+++ b/crates/kernel/testsuite/regression_suite.rs
@@ -13,8 +13,8 @@
 //
 
 mod common;
-use common::{create_db, eval, WIZARD};
-use pretty_assertions::assert_eq;
+use common::{create_db, eval, AssertEval, WIZARD};
+use moor_values::var::v_none;
 
 #[test]
 fn test_changing_programmer_and_wizard_flags() {
@@ -24,42 +24,33 @@ fn test_changing_programmer_and_wizard_flags() {
     let obj = eval(db.clone(), WIZARD, "return create(#2);").unwrap();
 
     // Start: it's neither a programmer nor a wizard
-    assert_eq!(
-        eval(
-            db.clone(),
-            WIZARD,
-            &format!("return {{ {obj}.programmer, {obj}.wizard }};")
-        ),
-        [0, 0].into()
+    db.assert_eval(
+        WIZARD,
+        format!("return {{ {obj}.programmer, {obj}.wizard }};"),
+        [0, 0],
     );
 
     // Set both, verify
-    eval(
-        db.clone(),
+    db.assert_eval(
         WIZARD,
-        &format!("{obj}.programmer = 1; {obj}.wizard = 1;"),
+        format!("{obj}.programmer = 1; {obj}.wizard = 1;"),
+        v_none(),
     );
-    assert_eq!(
-        eval(
-            db.clone(),
-            WIZARD,
-            &format!("return {{ {obj}.programmer, {obj}.wizard }};")
-        ),
-        [1, 1].into()
+    db.assert_eval(
+        WIZARD,
+        format!("return {{ {obj}.programmer, {obj}.wizard }};"),
+        [1, 1],
     );
 
     // Clear both, verify
-    eval(
-        db.clone(),
+    db.assert_eval(
         WIZARD,
-        &format!("{obj}.programmer = 0; {obj}.wizard = 0;"),
+        format!("{obj}.programmer = 0; {obj}.wizard = 0;"),
+        v_none(),
     );
-    assert_eq!(
-        eval(
-            db.clone(),
-            WIZARD,
-            &format!("return {{ {obj}.programmer, {obj}.wizard }};")
-        ),
-        [0, 0].into()
+    db.assert_eval(
+        WIZARD,
+        format!("return {{ {obj}.programmer, {obj}.wizard }};"),
+        [0, 0],
     );
 }

--- a/crates/values/src/model/permissions.rs
+++ b/crates/values/src/model/permissions.rs
@@ -98,7 +98,7 @@ impl Perms {
     }
 
     pub fn check_wizard(&self) -> Result<(), WorldStateError> {
-        if self.flags.contains(ObjFlag::Wizard) {
+        if self.check_is_wizard()? {
             return Ok(());
         }
         Err(WorldStateError::ObjectPermissionDenied)
@@ -106,6 +106,20 @@ impl Perms {
 
     pub fn check_is_wizard(&self) -> Result<bool, WorldStateError> {
         if self.flags.contains(ObjFlag::Wizard) {
+            return Ok(true);
+        }
+        Ok(false)
+    }
+
+    pub fn check_programmer(&self) -> Result<(), WorldStateError> {
+        if self.check_is_programmer()? {
+            return Ok(());
+        }
+        Err(WorldStateError::ObjectPermissionDenied)
+    }
+
+    pub fn check_is_programmer(&self) -> Result<bool, WorldStateError> {
+        if self.flags.contains(ObjFlag::Programmer) {
             return Ok(true);
         }
         Ok(false)

--- a/crates/values/src/var/mod.rs
+++ b/crates/values/src/var/mod.rs
@@ -342,6 +342,11 @@ impl From<i64> for Var {
         v_int(i)
     }
 }
+impl From<&i64> for Var {
+    fn from(i: &i64) -> Self {
+        v_int(*i)
+    }
+}
 
 impl From<f64> for Var {
     fn from(f: f64) -> Self {
@@ -358,6 +363,15 @@ impl From<Objid> for Var {
 impl From<Vec<Self>> for Var {
     fn from(l: Vec<Self>) -> Self {
         v_listv(l)
+    }
+}
+
+impl<T, const COUNT: usize> From<[T; COUNT]> for Var
+where
+    for<'a> Var: From<&'a T>,
+{
+    fn from(a: [T; COUNT]) -> Self {
+        v_list(&a.iter().map(|v| v.into()).collect::<Vec<_>>())
     }
 }
 


### PR DESCRIPTION
This is a huge pile of changes that ends up with: we have solid tests for the `eval()` built-in. Interesting stops along the way:

* Fix the test harness logic for executing code in fake verbs (previously we only ever re-executed the very first command for each call, per db)
* Switch tests from using a fake verb to instead `eval()`
* Add permission checks to `eval()` (both the `bf_eval` and the trampoline implementations)
* Fix clearing `programmer` and `wizard` flags
* Small fixes in built-in variables under `eval`

Each commit should be easy to review on its own. If it helps, I can split this up into self-contained PRs as well.