### PR TITLE
Fix property resolution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1461,9 +1461,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.154"
+version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae743338b92ff9146ce83992f766a31066a91a8c84a45e0e9f21e7cf6de6d346"
+checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
 name = "linux-raw-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,25 +2,25 @@
 resolver = "2"
 
 members = [
-  "crates/values",
-  "crates/compiler",
-  "crates/kernel",
-  "crates/rdb",
-  "crates/db",
-  "crates/rpc-common",
-  "crates/rpc-sync-client",
-  "crates/rpc-async-client",
-  "crates/daemon",
-  "crates/telnet-host",
-  "crates/web-host",
-  "crates/console-host",
+    "crates/values",
+    "crates/compiler",
+    "crates/kernel",
+    "crates/rdb",
+    "crates/db",
+    "crates/rpc-common",
+    "crates/rpc-sync-client",
+    "crates/rpc-async-client",
+    "crates/daemon",
+    "crates/telnet-host",
+    "crates/web-host",
+    "crates/console-host",
 ]
 
 [workspace.package]
 edition = "2021"
 authors = [
-  "Ryan Daum <ryan.daum@gmail.com>",
-  "Norman Nunley <nnunley@gmail.com>",
+    "Ryan Daum <ryan.daum@gmail.com>",
+    "Norman Nunley <nnunley@gmail.com>",
 ]
 repository = "https://github.com/rdaum/moor.git"
 license = "GPL-3"
@@ -38,10 +38,10 @@ serde = { version = "1.0.200", features = ["derive"] }
 serde_derive = "1.0.200"
 serde_json = "1.0.116"
 tower-http = { version = "0.5.2", features = [
-  "add-extension",
-  "auth",
-  "compression-full",
-  "trace",
+    "add-extension",
+    "auth",
+    "compression-full",
+    "trace",
 ] }
 
 ## Asynchronous transaction processing & networking
@@ -111,7 +111,7 @@ bincode = "2.0.0-rc.3"     # For serializing/deserializing values
 hi_sparse_bitset = "0.6.0" # For buffer pool allocator in the DB
 im = "15.1.0"              # Immutable data structures
 io-uring = "0.6.4"
-libc = "0.2.154"
+libc = "0.2.155"
 okaywal = "0.3.1"
 text_io = "0.1.12"         # Used for reading text dumps.
 
@@ -126,9 +126,9 @@ escargot = "0.5.10"
 
 # Auth/Auth
 ed25519-dalek = { version = "2.1.1", features = [
-  "zeroize",
-  "pkcs8",
-  "rand_core",
+    "zeroize",
+    "pkcs8",
+    "rand_core",
 ] }
 pem = "3.0.4"
 rusty_paseto = { version = "0.6.1" }

--- a/crates/daemon/src/rpc_server.rs
+++ b/crates/daemon/src/rpc_server.rs
@@ -15,7 +15,7 @@
 use std::path::PathBuf;
 /// The core of the server logic for the RPC daemon
 use std::sync::{Arc, Mutex};
-use std::time::{Instant, SystemTime};
+use std::time::SystemTime;
 
 use eyre::{Context, Error};
 
@@ -57,15 +57,6 @@ pub struct RpcServer {
     world_state_source: Arc<dyn WorldStateSource>,
     scheduler: Arc<Scheduler>,
     connections: Arc<dyn ConnectionsDB + Send + Sync>,
-}
-
-#[derive(Debug, Clone, Eq, PartialEq)]
-struct ConnectionRecord {
-    client_id: Uuid,
-    player: Objid,
-    name: String,
-    last_activity: Instant,
-    connect_time: Instant,
 }
 
 pub(crate) fn make_response(result: Result<RpcResponse, RpcRequestError>) -> Vec<u8> {

--- a/crates/db/src/loader.rs
+++ b/crates/db/src/loader.rs
@@ -14,13 +14,13 @@
 
 use uuid::Uuid;
 
-use moor_values::model::ObjAttrs;
 use moor_values::model::ObjSet;
 use moor_values::model::PropFlag;
 use moor_values::model::VerbArgsSpec;
 use moor_values::model::VerbDefs;
 use moor_values::model::VerbFlag;
 use moor_values::model::{CommitResult, WorldStateError};
+use moor_values::model::{ObjAttrs, PropPerms};
 use moor_values::model::{PropDef, PropDefs};
 use moor_values::util::BitEnum;
 use moor_values::var::Objid;
@@ -92,12 +92,16 @@ pub trait LoaderInterface {
     /// Get the properties defined on a given object
     fn get_object_properties(&self, objid: Objid) -> Result<PropDefs, WorldStateError>;
 
-    fn get_property_value(&self, obj: Objid, uuid: Uuid) -> Result<Option<Var>, WorldStateError>;
+    fn get_property_value(
+        &self,
+        obj: Objid,
+        uuid: Uuid,
+    ) -> Result<(Option<Var>, PropPerms), WorldStateError>;
 
     /// Returns all the property values from the root of the inheritance hierarchy down to the
     /// bottom, for the given object.
     fn get_all_property_values(
         &self,
         objid: Objid,
-    ) -> Result<Vec<(PropDef, Option<Var>)>, WorldStateError>;
+    ) -> Result<Vec<(PropDef, (Option<Var>, PropPerms))>, WorldStateError>;
 }

--- a/crates/db/src/odb/object_relations.rs
+++ b/crates/db/src/odb/object_relations.rs
@@ -66,9 +66,12 @@ pub enum WorldStateRelation {
     /// Object->Properties (Propdefs)
     #[strum(props(DomainType = "Integer", CodomainType = "Bytes", IndexType = "Hash"))]
     ObjectPropDefs = 7,
-    /// Property UUID->PropertyValue (Var)
+    /// (Objid, Property UUID)->PropertyValue (Var)
     #[strum(props(DomainType = "Bytes", CodomainType = "Bytes", IndexType = "Hash"))]
     ObjectPropertyValue = 8,
+    /// (Objid, Property UUID)->PropPerms
+    #[strum(props(DomainType = "Bytes", CodomainType = "Bytes", IndexType = "Hash"))]
+    ObjectPropertyPermissions = 9,
 }
 
 impl From<WorldStateRelation> for RelationId {

--- a/crates/kernel/src/builtins/bf_properties.rs
+++ b/crates/kernel/src/builtins/bf_properties.rs
@@ -40,12 +40,12 @@ fn bf_property_info(bf_args: &mut BfCallState<'_>) -> Result<BfRet, Error> {
     let Variant::Str(prop_name) = bf_args.args[1].variant() else {
         return Err(E_TYPE);
     };
-    let property_info = bf_args
+    let (_, perms) = bf_args
         .world_state
         .get_property_info(bf_args.task_perms_who(), *obj, prop_name.as_str())
         .map_err(world_state_err)?;
-    let owner = property_info.owner();
-    let flags = property_info.flags();
+    let owner = perms.owner();
+    let flags = perms.flags();
 
     // Turn perm flags into string: r w c
     let mut perms = String::new();

--- a/crates/kernel/src/textdump/load_db.rs
+++ b/crates/kernel/src/textdump/load_db.rs
@@ -128,9 +128,7 @@ pub fn read_textdump<T: io::Read>(
                     // .parent(o.parent)
                     .flags(flags),
             )
-            .map_err(|e| {
-                TextdumpReaderError::LoadError(format!("creating object {}", objid), e.clone())
-            })?;
+            .expect(format!("creating object {}", objid).as_str());
     }
 
     info!("Setting object attributes (parent/location/owner)");
@@ -144,9 +142,7 @@ pub fn read_textdump<T: io::Read>(
         })?;
         loader
             .set_object_location(*objid, o.location)
-            .map_err(|e| {
-                TextdumpReaderError::LoadError(format!("setting location of {}", objid), e.clone())
-            })?;
+            .expect(format!("setting location of {}", objid).as_str());
     }
 
     info!("Defining properties...");
@@ -170,12 +166,7 @@ pub fn read_textdump<T: io::Read>(
                         flags,
                         value,
                     )
-                    .map_err(|e| {
-                        TextdumpReaderError::LoadError(
-                            format!("defining property on {}", objid),
-                            e.clone(),
-                        )
-                    })?;
+                    .expect(format!("defining property on {}", objid).as_str());
             }
         }
     }
@@ -190,12 +181,7 @@ pub fn read_textdump<T: io::Read>(
 
             loader
                 .set_property(*objid, resolved.name.as_str(), p.owner, flags, value)
-                .map_err(|e| {
-                    TextdumpReaderError::LoadError(
-                        format!("setting property on {}", objid),
-                        e.clone(),
-                    )
-                })?;
+                .expect(format!("setting property on {}", objid).as_str());
         }
     }
 

--- a/crates/kernel/src/textdump/write_db.rs
+++ b/crates/kernel/src/textdump/write_db.rs
@@ -202,13 +202,6 @@ pub fn make_textdump(tx: Rc<dyn LoaderInterface>, version: Option<&str>) -> Text
             );
         }
 
-        // let db_propdefs = tx.get_object_properties(*db_objid).unwrap();
-        // let propdefs: Vec<_> = db_propdefs
-        //     .iter()
-        //     .filter(|p| p.definer() == *db_objid && p.location() == *db_objid)
-        //     .map(|p| p.name().into())
-        //     .collect();
-
         // propvals have wonky logic which resolve relative to position in the inheritance hierarchy of
         // propdefs up to the root. So we grab that all from the loader_client, and then we can just
         // iterate through them all.
@@ -223,12 +216,12 @@ pub fn make_textdump(tx: Rc<dyn LoaderInterface>, version: Option<&str>) -> Text
         }
 
         let mut propvals = vec![];
-        for (p, value) in properties {
-            let owner = p.owner();
-            let flags = p.flags().to_u16() as u8;
-            let is_clear = value.is_none();
+        for (_, (pval, perms)) in properties {
+            let owner = perms.owner();
+            let flags = perms.flags().to_u16() as u8;
+            let is_clear = pval.is_none();
             propvals.push(Propval {
-                value: value.unwrap_or(v_none()),
+                value: pval.unwrap_or(v_none()),
                 owner,
                 flags,
                 is_clear,

--- a/crates/kernel/src/vm/vm_test.rs
+++ b/crates/kernel/src/vm/vm_test.rs
@@ -32,7 +32,7 @@ mod tests {
     use moor_values::{AsByteBuffer, SYSTEM_OBJECT};
 
     use crate::tasks::sessions::NoopClientSession;
-    use crate::tasks::vm_test_utils::call_verb;
+    use crate::tasks::vm_test_utils::{call_verb, ExecResult};
     use moor_compiler::compile;
     use moor_compiler::Names;
     use moor_compiler::Op;
@@ -107,7 +107,7 @@ mod tests {
         let mut state = state_source.new_world_state().unwrap();
         let session = Arc::new(NoopClientSession::new());
         let result = call_verb(state.as_mut(), session, "test", vec![]);
-        assert_eq!(result, v_none());
+        assert_eq!(result, ExecResult::Success(v_none()));
     }
 
     #[test]
@@ -124,7 +124,7 @@ mod tests {
         let session = Arc::new(NoopClientSession::new());
         let result = call_verb(state.as_mut(), session, "test", vec![]);
 
-        assert_eq!(result, v_str("e"));
+        assert_eq!(result, ExecResult::Success(v_str("e")));
     }
 
     #[test]
@@ -149,7 +149,7 @@ mod tests {
         let session = Arc::new(NoopClientSession::new());
         let result = call_verb(state.as_mut(), session, "test", vec![]);
 
-        assert_eq!(result, v_str("ell"));
+        assert_eq!(result, ExecResult::Success(v_str("ell")));
     }
 
     #[test]
@@ -167,7 +167,7 @@ mod tests {
         let session = Arc::new(NoopClientSession::new());
         let result = call_verb(state.as_mut(), session, "test", vec![]);
 
-        assert_eq!(result, v_int(222));
+        assert_eq!(result, ExecResult::Success(v_int(222)));
     }
 
     #[test]
@@ -195,7 +195,10 @@ mod tests {
         .unwrap();
         let session = Arc::new(NoopClientSession::new());
         let result = call_verb(state.as_mut(), session, "test", vec![]);
-        assert_eq!(result, v_list(&[222.into(), 333.into()]));
+        assert_eq!(
+            result,
+            ExecResult::Success(v_list(&[222.into(), 333.into()]))
+        );
     }
 
     #[test]
@@ -236,7 +239,10 @@ mod tests {
         .unwrap();
         let session = Arc::new(NoopClientSession::new());
         let result = call_verb(state.as_mut(), session, "test", vec![]);
-        assert_eq!(result, v_list(&[111.into(), 321.into(), 123.into()]));
+        assert_eq!(
+            result,
+            ExecResult::Success(v_list(&[111.into(), 321.into(), 123.into()]))
+        );
     }
 
     #[test]
@@ -248,7 +254,10 @@ mod tests {
             .unwrap();
         let session = Arc::new(NoopClientSession::new());
         let result = call_verb(state.as_mut(), session, "test", vec![]);
-        assert_eq!(result, v_list(&[2.into(), 3.into(), 4.into()]));
+        assert_eq!(
+            result,
+            ExecResult::Success(v_list(&[2.into(), 3.into(), 4.into()]))
+        );
     }
 
     #[test]
@@ -259,7 +268,7 @@ mod tests {
             .unwrap();
         let session = Arc::new(NoopClientSession::new());
         let result = call_verb(state.as_mut(), session, "test", vec![]);
-        assert_eq!(result, v_int(1));
+        assert_eq!(result, ExecResult::Success(v_int(1)));
     }
 
     #[test]
@@ -296,7 +305,7 @@ mod tests {
         .unwrap();
         let session = Arc::new(NoopClientSession::new());
         let result = call_verb(state.as_mut(), session, "test", vec![]);
-        assert_eq!(result, v_str("manbozorian"));
+        assert_eq!(result, ExecResult::Success(v_str("manbozorian")));
     }
 
     #[test]
@@ -326,7 +335,7 @@ mod tests {
         }
         let session = Arc::new(NoopClientSession::new());
         let result = call_verb(state.as_mut(), session, "test", vec![]);
-        assert_eq!(result, v_int(666));
+        assert_eq!(result, ExecResult::Success(v_int(666)));
     }
 
     #[test]
@@ -362,7 +371,7 @@ mod tests {
         let session = Arc::new(NoopClientSession::new());
         let result = call_verb(state.as_mut(), session, "test_call_verb", vec![]);
 
-        assert_eq!(result, v_int(666));
+        assert_eq!(result, ExecResult::Success(v_int(666)));
     }
 
     fn world_with_test_program(program: &str) -> Box<dyn WorldState> {
@@ -378,7 +387,7 @@ mod tests {
         let mut state = world_with_test_program(program);
         let session = Arc::new(NoopClientSession::new());
         let result = call_verb(state.as_mut(), session, "test", vec![]);
-        assert_eq!(result, v_int(3));
+        assert_eq!(result, ExecResult::Success(v_int(3)));
     }
 
     #[test]
@@ -388,7 +397,7 @@ mod tests {
         let mut state = world_with_test_program(program);
         let session = Arc::new(NoopClientSession::new());
         let result = call_verb(state.as_mut(), session, "test", vec![]);
-        assert_eq!(result, v_int(75));
+        assert_eq!(result, ExecResult::Success(v_int(75)));
     }
 
     #[test]
@@ -399,7 +408,7 @@ mod tests {
         let session = Arc::new(NoopClientSession::new());
         let result = call_verb(state.as_mut(), session, "test", vec![]);
 
-        assert_eq!(result, v_int(50));
+        assert_eq!(result, ExecResult::Success(v_int(50)));
     }
 
     #[test]
@@ -409,7 +418,7 @@ mod tests {
         let session = Arc::new(NoopClientSession::new());
         let result = call_verb(state.as_mut(), session, "test", vec![]);
 
-        assert_eq!(result, v_int(50));
+        assert_eq!(result, ExecResult::Success(v_int(50)));
     }
 
     #[test]
@@ -432,7 +441,7 @@ mod tests {
         let session = Arc::new(NoopClientSession::new());
         let result = call_verb(state.as_mut(), session, "test", vec![]);
 
-        assert_eq!(result, v_int(50));
+        assert_eq!(result, ExecResult::Success(v_int(50)));
     }
 
     #[test]
@@ -454,7 +463,10 @@ mod tests {
         let session = Arc::new(NoopClientSession::new());
         let result = call_verb(state.as_mut(), session, "test", vec![]);
 
-        assert_eq!(result, v_list(&[v_int(3), v_int(2), v_int(1)]));
+        assert_eq!(
+            result,
+            ExecResult::Success(v_list(&[v_int(3), v_int(2), v_int(1)]))
+        );
     }
 
     #[test]
@@ -474,7 +486,7 @@ mod tests {
         let session = Arc::new(NoopClientSession::new());
         let result = call_verb(state.as_mut(), session, "test", vec![]);
 
-        assert_eq!(result, v_int(6));
+        assert_eq!(result, ExecResult::Success(v_int(6)));
     }
 
     #[test]
@@ -500,7 +512,7 @@ mod tests {
             vec![v_objid(SYSTEM_OBJECT), v_obj(32)],
         );
 
-        assert_eq!(result, v_int(0));
+        assert_eq!(result, ExecResult::Success(v_int(0)));
     }
 
     #[test]
@@ -511,7 +523,7 @@ mod tests {
         let mut state = world_with_test_program(program);
         let session = Arc::new(NoopClientSession::new());
         let result = call_verb(state.as_mut(), session.clone(), "test", vec![]);
-        assert_eq!(result, v_int(5));
+        assert_eq!(result, ExecResult::Success(v_int(5)));
     }
 
     /// A VM body that is empty should return v_none() and not panic.
@@ -530,7 +542,7 @@ mod tests {
             .unwrap();
         let session = Arc::new(NoopClientSession::new());
         let result = call_verb(state.as_mut(), session.clone(), "test", vec![]);
-        assert_eq!(result, v_none());
+        assert_eq!(result, ExecResult::Success(v_none()));
     }
 
     #[test_case("return 1;", v_int(1); "simple return")]
@@ -627,6 +639,6 @@ mod tests {
         let mut state = world_with_test_program(program);
         let session = Arc::new(NoopClientSession::new());
         let result = call_verb(state.as_mut(), session, "test", vec![]);
-        assert_eq!(result, expected_result);
+        assert_eq!(result, ExecResult::Success(expected_result));
     }
 }

--- a/crates/kernel/tests/textdump.rs
+++ b/crates/kernel/tests/textdump.rs
@@ -318,23 +318,24 @@ mod test {
                     o,
                     p1.name()
                 );
+
+                let (value1, perms1) = tx1.get_property_value(o, p1.uuid()).unwrap();
+                let (value2, perms2) = tx2.get_property_value(o, p2.uuid()).unwrap();
+
                 assert_eq!(
-                    p1.flags(),
-                    p2.flags(),
+                    perms1.flags(),
+                    perms2.flags(),
                     "{}.{}, flags mismatch",
                     o,
                     p1.name(),
                 );
                 assert_eq!(
-                    p1.owner(),
-                    p2.owner(),
+                    perms1.owner(),
+                    perms2.owner(),
                     "{}.{}, owner mismatch",
                     o,
                     p1.name(),
                 );
-
-                let value1 = tx1.get_property_value(o, p1.uuid()).unwrap();
-                let value2 = tx2.get_property_value(o, p2.uuid()).unwrap();
 
                 assert_eq!(
                     value1,

--- a/crates/kernel/testsuite/basic/basic_suite.rs
+++ b/crates/kernel/testsuite/basic/basic_suite.rs
@@ -17,7 +17,7 @@ use moor_compiler::Program;
 use moor_db::odb::RelBoxWorldState;
 use moor_db::Database;
 use moor_kernel::tasks::sessions::NoopClientSession;
-use moor_kernel::tasks::vm_test_utils::call_verb;
+use moor_kernel::tasks::vm_test_utils::{call_verb, ExecResult};
 use moor_kernel::textdump::textdump_load;
 use moor_values::model::CommitResult;
 use moor_values::model::Named;
@@ -73,7 +73,7 @@ fn compile_verbs(db: Arc<dyn WorldStateSource>, verbs: &[(&str, &Program)]) {
     assert_eq!(tx.commit().unwrap(), CommitResult::Success);
 }
 
-fn eval(db: Arc<dyn WorldStateSource>, expression: &str) -> Var {
+fn eval(db: Arc<dyn WorldStateSource>, expression: &str) -> ExecResult {
     let binary = compile(format!("return {expression};").as_str()).unwrap();
     compile_verbs(db.clone(), &[("test", &binary)]);
     let mut state = db.new_world_state().unwrap();

--- a/crates/kernel/testsuite/basic/basic_suite.rs
+++ b/crates/kernel/testsuite/basic/basic_suite.rs
@@ -25,10 +25,10 @@ use moor_values::model::VerbArgsSpec;
 use moor_values::model::WorldStateSource;
 use moor_values::model::{BinaryType, VerbFlag};
 use moor_values::var::Objid;
-use moor_values::var::Var;
 use moor_values::{AsByteBuffer, SYSTEM_OBJECT};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use uuid::Uuid;
 
 fn testsuite_dir() -> PathBuf {
     let manifest_dir = env!("CARGO_MANIFEST_DIR");
@@ -75,12 +75,13 @@ fn compile_verbs(db: Arc<dyn WorldStateSource>, verbs: &[(&str, &Program)]) {
 
 fn eval(db: Arc<dyn WorldStateSource>, expression: &str) -> ExecResult {
     let binary = compile(format!("return {expression};").as_str()).unwrap();
-    compile_verbs(db.clone(), &[("test", &binary)]);
+    let verb_uuid = Uuid::new_v4().to_string();
+    compile_verbs(db.clone(), &[(&verb_uuid, &binary)]);
     let mut state = db.new_world_state().unwrap();
     let result = call_verb(
         state.as_mut(),
         Arc::new(NoopClientSession::new()),
-        "test",
+        &verb_uuid,
         vec![],
     );
     state.commit().unwrap();
@@ -114,9 +115,14 @@ fn run_basic_test(test_dir: &str) {
     let db = Arc::new(db);
     load_textdump(db.clone());
     for (line_num, (input, expected_output)) in zipped.enumerate() {
-        let evaluated = eval(db.clone(), input);
-        let output = eval(db.clone(), expected_output);
-        assert_eq!(evaluated, output, "{test_dir}: line {line_num}: {input}")
+        let evaluated_output = eval(db.clone(), input);
+        let expected_ouput = eval(db.clone(), expected_output);
+        assert_eq!(
+            evaluated_output,
+            expected_ouput,
+            "{test_dir}: line {}: {input}",
+            line_num + 1
+        )
     }
 }
 

--- a/crates/values/src/model/mod.rs
+++ b/crates/values/src/model/mod.rs
@@ -22,7 +22,7 @@ pub use crate::model::objects::{ObjAttr, ObjAttrs, ObjFlag};
 pub use crate::model::objset::{ObjSet, ObjSetIter};
 pub use crate::model::permissions::Perms;
 pub use crate::model::propdef::{PropDef, PropDefs};
-pub use crate::model::props::{PropAttr, PropAttrs, PropFlag};
+pub use crate::model::props::{PropAttr, PropAttrs, PropFlag, PropPerms};
 pub use crate::model::r#match::{ArgSpec, PrepSpec, Preposition, VerbArgsSpec, PREP_LIST};
 pub use crate::model::verb_info::VerbInfo;
 pub use crate::model::verbdef::{VerbDef, VerbDefs};
@@ -129,6 +129,7 @@ impl From<WorldStateError> for Error {
 }
 
 pub fn world_state_err(err: WorldStateError) -> Error {
+    eprintln!("WorldStateError: {:?}", err);
     err.into()
 }
 

--- a/crates/values/src/model/permissions.rs
+++ b/crates/values/src/model/permissions.rs
@@ -15,7 +15,7 @@
 use crate::model::objects::ObjFlag;
 use crate::model::props::PropFlag;
 use crate::model::verbs::VerbFlag;
-use crate::model::WorldStateError;
+use crate::model::{PropPerms, WorldStateError};
 use crate::util::BitEnum;
 use crate::var::Objid;
 
@@ -36,17 +36,16 @@ impl Perms {
 
     pub fn check_property_allows(
         &self,
-        property_owner: Objid,
-        property_flags: BitEnum<PropFlag>,
+        property_permissions: &PropPerms,
         allows: PropFlag,
     ) -> Result<(), WorldStateError> {
-        if self.who == property_owner {
+        if self.who == property_permissions.owner() {
             return Ok(());
         }
         if self.flags.contains(ObjFlag::Wizard) {
             return Ok(());
         }
-        if !property_flags.contains(allows) {
+        if !property_permissions.flags().contains(allows) {
             return Err(WorldStateError::PropertyPermissionDenied);
         }
         Ok(())

--- a/crates/values/src/model/props.rs
+++ b/crates/values/src/model/props.rs
@@ -61,3 +61,39 @@ impl Default for PropAttrs {
         Self::new()
     }
 }
+
+#[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
+pub struct PropPerms {
+    owner: Objid,
+    flags: BitEnum<PropFlag>,
+}
+
+impl PropPerms {
+    #[must_use]
+    pub fn new(owner: Objid, flags: BitEnum<PropFlag>) -> Self {
+        Self { owner, flags }
+    }
+    #[must_use]
+    pub fn owner(&self) -> Objid {
+        self.owner
+    }
+
+    #[must_use]
+    pub fn flags(&self) -> BitEnum<PropFlag> {
+        self.flags
+    }
+
+    pub fn with_owner(self, owner: Objid) -> Self {
+        Self {
+            owner,
+            flags: self.flags,
+        }
+    }
+
+    pub fn with_flags(self, flags: BitEnum<PropFlag>) -> Self {
+        Self {
+            owner: self.owner,
+            flags,
+        }
+    }
+}

--- a/crates/values/src/model/world_state.rs
+++ b/crates/values/src/model/world_state.rs
@@ -22,8 +22,8 @@ use crate::model::r#match::{PrepSpec, VerbArgsSpec};
 use crate::model::verb_info::VerbInfo;
 use crate::model::verbdef::{VerbDef, VerbDefs};
 use crate::model::verbs::{BinaryType, VerbAttrs, VerbFlag};
-use crate::model::CommitResult;
 use crate::model::WorldStateError;
+use crate::model::{CommitResult, PropPerms};
 use crate::util::BitEnum;
 use crate::var::Objid;
 use crate::var::Var;
@@ -113,12 +113,13 @@ pub trait WorldState {
     ) -> Result<Var, WorldStateError>;
 
     /// Get information about a property, without walking the inheritance tree.
+    /// Returns the PropDef as well as the owner of the property.
     fn get_property_info(
         &self,
         perms: Objid,
         obj: Objid,
         pname: &str,
-    ) -> Result<PropDef, WorldStateError>;
+    ) -> Result<(PropDef, PropPerms), WorldStateError>;
 
     fn set_property_info(
         &mut self,


### PR DESCRIPTION
Rework and fix how property definitions and values are handled
    
At some point values and properties got mixed up in how transitive
propagation and resolution was happening. PropDefs were being copied
down the inheritance hierarchy, but not values. Which is opposite of
how LambdaMOO has it.
    
This meant that bf_properties was returning the set of all properties
defined by parents instead of just the locally defined properties,
which was wrong.
    
This is a fairly major rework that rewrites things so that:
    

-  PropDefs exist only on the root of the chain where the property is  defined.
-  Values propagate down the tree.
-  Flags and owners are moved off PropDefs, and are separately defined,   and again propagated down the tree
-  Clearness remains defined by absence of a property value on a given  point in the inheritance chain.

    
I could have broken this into more commits, but it kind of grew and
grew and grew...
