### PR TITLE
Run `kernel` test suite against both storage backends

### DIFF
--- a/crates/db-relbox/src/rb_worldstate.rs
+++ b/crates/db-relbox/src/rb_worldstate.rs
@@ -1262,7 +1262,7 @@ mod tests {
             .unwrap();
         assert_eq!(oid, Objid(0));
         assert!(tx.object_valid(oid).unwrap());
-        assert_eq!(tx.get_object_owner(oid).unwrap(), NOTHING);
+        assert_eq!(tx.get_object_owner(oid).unwrap(), oid);
         assert_eq!(tx.get_object_parent(oid).unwrap(), NOTHING);
         assert_eq!(tx.get_object_location(oid).unwrap(), NOTHING);
         assert_eq!(tx.get_object_name(oid).unwrap(), "test");
@@ -1271,7 +1271,7 @@ mod tests {
         // Verify existence in a new transaction.
         let tx = RelBoxTransaction::new(db);
         assert!(tx.object_valid(oid).unwrap());
-        assert_eq!(tx.get_object_owner(oid).unwrap(), NOTHING);
+        assert_eq!(tx.get_object_owner(oid).unwrap(), oid);
     }
 
     #[test]

--- a/crates/db-wildtiger/src/worldstate/wt_worldstate.rs
+++ b/crates/db-wildtiger/src/worldstate/wt_worldstate.rs
@@ -277,13 +277,13 @@ impl WorldStateTransaction for WtWorldStateTransaction {
             }
         };
 
-        let owner = attrs.owner().unwrap_or(NOTHING);
+        let owner = attrs.owner().unwrap_or(id);
         self.tx
             .upsert(WtWorldStateTable::ObjectOwner, id, owner)
             .expect("Unable to insert initial owner");
 
         // Set initial name
-        let name = attrs.name().unwrap_or_else(|| format!("Object {}", id));
+        let name = attrs.name().unwrap_or_default();
         self.tx
             .upsert(WtWorldStateTable::ObjectName, id, name)
             .expect("Unable to insert initial name");
@@ -1304,7 +1304,7 @@ mod tests {
             .unwrap();
         assert_eq!(oid, Objid(0));
         assert!(tx.object_valid(oid).unwrap());
-        assert_eq!(tx.get_object_owner(oid).unwrap(), NOTHING);
+        assert_eq!(tx.get_object_owner(oid).unwrap(), oid);
         assert_eq!(tx.get_object_parent(oid).unwrap(), NOTHING);
         assert_eq!(tx.get_object_location(oid).unwrap(), NOTHING);
         assert_eq!(tx.get_object_name(oid).unwrap(), "test");
@@ -1313,7 +1313,7 @@ mod tests {
         // Verify existence in a new transaction.
         let tx = WtWorldStateTransaction::new(ws.db.clone());
         assert!(tx.object_valid(oid).unwrap());
-        assert_eq!(tx.get_object_owner(oid).unwrap(), NOTHING);
+        assert_eq!(tx.get_object_owner(oid).unwrap(), oid);
     }
 
     #[test]

--- a/crates/kernel/testsuite/regression_suite.rs
+++ b/crates/kernel/testsuite/regression_suite.rs
@@ -13,11 +13,19 @@
 //
 
 mod common;
-use common::{create_db, AssertRunAsVerb};
+use common::{create_relbox_db, create_wiretiger_db, AssertRunAsVerb};
 
 #[test]
-fn test_testhelper_verb_redefinition() {
-    let db = create_db();
+fn test_testhelper_verb_redefinition_relbox() {
+    let db = create_relbox_db();
+    db.assert_run_as_verb("return 42;", Ok(42.into()));
+    db.assert_run_as_verb("return create(#2).name;", Ok("".into()));
+    db.assert_run_as_verb("return 200;", Ok(200.into()));
+}
+
+#[test]
+fn test_testhelper_verb_redefinition_wiretiger() {
+    let db = create_wiretiger_db();
     db.assert_run_as_verb("return 42;", Ok(42.into()));
     db.assert_run_as_verb("return create(#2).name;", Ok("".into()));
     db.assert_run_as_verb("return 200;", Ok(200.into()));


### PR DESCRIPTION
Also fix smol bugs caught by the test suite while we're at it; they're the same small ones we saw on `relbox` too.