### PR TITLE
Halp: scheduler-based tests + `huh`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,7 +93,7 @@ yoke-derive = "0.7.3"
 chrono-tz = "0.9.0"
 crypt-sys = "0.1.0"
 iana-time-zone = "0.1.60"
-md5 = "0.7"                                          # For MOO's "string_hash"
+md5 = "0.7"                                            # For MOO's "string_hash"
 onig = { version = "6.4.0", default-features = false }
 rand = "0.8"
 
@@ -111,13 +111,13 @@ paste = "1.0"
 
 # For the DB & values layer.
 crossbeam-queue = "0.3"
-bincode = "2.0.0-rc.3"     # For serializing/deserializing values
+bincode = "2.0.0-rc.3"   # For serializing/deserializing values
 hi_sparse_bitset = "0.6" # For buffer pool allocator in the DB
 im = "15.1"              # Immutable data structures
 io-uring = "0.6"
 libc = "0.2"
 okaywal = "0.3"
-text_io = "0.1"         # Used for reading text dumps.
+text_io = "0.1"          # Used for reading text dumps.
 
 # Dev dependencies
 tempfile = "3.10"

--- a/crates/compiler/src/lib.rs
+++ b/crates/compiler/src/lib.rs
@@ -64,7 +64,7 @@ pub enum GlobalName {
     iobjstr,
 }
 
-#[derive(Debug, Error, Clone, Decode, Encode)]
+#[derive(Debug, Error, Clone, Decode, Encode, PartialEq)]
 pub enum CompileError {
     #[error("Failure to parse string: {0}")]
     StringLexError(String),

--- a/crates/kernel/src/tasks/mod.rs
+++ b/crates/kernel/src/tasks/mod.rs
@@ -162,3 +162,73 @@ pub mod vm_test_utils {
         })
     }
 }
+
+pub mod scheduler_test_utils {
+    use crate::config::Config;
+    use crate::tasks::sessions::Session;
+    use crate::vm::UncaughtException;
+    use moor_db::Database;
+    use moor_values::model::{CommandError, WorldStateSource};
+    use moor_values::var::{Error::E_VERBNF, Objid, Var};
+    use std::sync::Arc;
+
+    use super::scheduler::{Scheduler, SchedulerError, TaskWaiterResult};
+    use super::TaskId;
+    use crate::tasks::scheduler_test_utils::SchedulerError::{
+        CommandExecutionError, TaskAbortedException,
+    };
+
+    pub type ExecResult = Result<Var, UncaughtException>;
+
+    fn execute<F>(database: Arc<dyn Database + Send + Sync>, fun: F) -> Result<Var, SchedulerError>
+    where
+        F: FnOnce(Arc<dyn WorldStateSource>, Arc<Scheduler>) -> Result<TaskId, SchedulerError>,
+    {
+        let scheduler = Arc::new(Scheduler::new(database.clone(), Config::default()));
+        let task_id = fun(database.world_state_source().unwrap(), scheduler.clone())?;
+        let subscriber = scheduler.subscribe_to_task(task_id).unwrap();
+
+        let loop_scheduler = scheduler.clone();
+        let scheduler_loop_jh = std::thread::Builder::new()
+            .name("moor-scheduler".to_string())
+            .spawn(move || loop_scheduler.run())
+            .unwrap();
+
+        let result = match subscriber.recv().unwrap() {
+            TaskWaiterResult::Error(TaskAbortedException(UncaughtException { code, .. })) => {
+                Ok(code.into())
+            }
+            TaskWaiterResult::Error(CommandExecutionError(CommandError::NoCommandMatch)) => {
+                Ok(E_VERBNF.into())
+            }
+            TaskWaiterResult::Error(err) => Err(err),
+            TaskWaiterResult::Success(var) => Ok(var),
+        };
+        scheduler.stop().unwrap();
+        scheduler_loop_jh.join().unwrap();
+
+        result
+    }
+
+    pub fn call_command(
+        database: Arc<dyn Database + Send + Sync>,
+        session: Arc<dyn Session>,
+        player: Objid,
+        command: &str,
+    ) -> Result<Var, SchedulerError> {
+        execute(database, |_world_state, scheduler: Arc<Scheduler>| {
+            scheduler.submit_command_task(player, command, session)
+        })
+    }
+
+    pub fn call_eval(
+        database: Arc<dyn Database + Send + Sync>,
+        session: Arc<dyn Session>,
+        player: Objid,
+        code: String,
+    ) -> Result<Var, SchedulerError> {
+        execute(database, |_world_state, scheduler: Arc<Scheduler>| {
+            scheduler.submit_eval_task(player, player, code, session)
+        })
+    }
+}

--- a/crates/kernel/src/tasks/scheduler.rs
+++ b/crates/kernel/src/tasks/scheduler.rs
@@ -84,7 +84,7 @@ pub enum TaskWaiterResult {
     Error(SchedulerError),
 }
 
-#[derive(Debug, Error, Clone, Decode, Encode)]
+#[derive(Debug, Error, Clone, Decode, Encode, PartialEq)]
 pub enum SchedulerError {
     #[error("Task not found: {0:?}")]
     TaskNotFound(TaskId),
@@ -94,15 +94,15 @@ pub enum SchedulerError {
     #[error("Could not start task (internal error)")]
     CouldNotStartTask,
     #[error("Eval compilation error")]
-    EvalCompilationError(CompileError),
+    EvalCompilationError(#[source] CompileError),
     #[error("Could not start command")]
-    CommandExecutionError(CommandError),
+    CommandExecutionError(#[source] CommandError),
     #[error("Task aborted due to limit: {0:?}")]
     TaskAbortedLimit(AbortLimitReason),
     #[error("Task aborted due to error.")]
     TaskAbortedError,
-    #[error("Task aborted due to exception: {0:?}")]
-    TaskAbortedException(UncaughtException),
+    #[error("Task aborted due to exception")]
+    TaskAbortedException(#[source] UncaughtException),
     #[error("Task aborted due to cancellation.")]
     TaskAbortedCancelled,
 }

--- a/crates/kernel/testsuite/moot/example.moot
+++ b/crates/kernel/testsuite/moot/example.moot
@@ -27,3 +27,16 @@ E_PERM
 @wizard
 ; return {player.programmer, player.wizard, player};
 {1, 1, #3}
+
+// Execute non-eval commands (i.e. verbs) with `%`
+// Remember to still quote the expected output for `eval()`!
+; $object = create($nothing);
+; add_verb($object, {player, "xd", "accept"}, {"this", "none", "this"});
+; set_verb_code($object, "accept", {"return 1;"});
+; add_verb($object, {player, "xd", "hi"}, {"this", "none", "this"});
+; set_verb_code($object, "hi", {
+>   "return \"hello player\";"
+> });
+; move(player, $object);
+% hi
+"hello player"

--- a/crates/kernel/testsuite/moot/example.moot
+++ b/crates/kernel/testsuite/moot/example.moot
@@ -27,16 +27,3 @@ E_PERM
 @wizard
 ; return {player.programmer, player.wizard, player};
 {1, 1, #3}
-
-// Execute non-eval commands (i.e. verbs) with `%`
-// Remember to still quote the expected output for `eval()`!
-; $object = create($nothing);
-; add_verb($object, {player, "xd", "accept"}, {"this", "none", "this"});
-; set_verb_code($object, "accept", {"return 1;"});
-; add_verb($object, {player, "xd", "hi"}, {"this", "none", "this"});
-; set_verb_code($object, "hi", {
->   "return \"hello player\";"
-> });
-; move(player, $object);
-% hi
-"hello player"

--- a/crates/kernel/testsuite/moot/huh.moot
+++ b/crates/kernel/testsuite/moot/huh.moot
@@ -1,0 +1,21 @@
+// :huh verb on player doesn't work
+@wizard
+; move(player, $nothing);
+@programmer
+; add_verb(player, {player, "xd", "huh"}, {"this", "none", "this"});
+; set_verb_code(player, "huh", {"return \"test huh\";"});
+% zip
+E_VERBNF
+
+// :huh verb on location works
+@wizard
+; $object = create($nothing);
+; add_verb($object, {player, "xd", "accept"}, {"this", "none", "this"});
+; set_verb_code($object, "accept", {"return 1;"});
+; add_verb($object, {player, "xd", "huh"}, {"this", "none", "this"});
+; set_verb_code($object, "huh", {
+>   "return \"test2 huh\";"
+> });
+; move(player, $object);
+% zip
+"test2 huh"

--- a/crates/kernel/testsuite/moot_suite.rs
+++ b/crates/kernel/testsuite/moot_suite.rs
@@ -10,7 +10,7 @@ use std::{
     sync::Arc,
 };
 
-use common::{create_relbox_db, create_wiretiger_db, NONPROGRAMMER, PROGRAMMER};
+use common::{create_relbox_db, create_wiretiger_db, testsuite_dir, NONPROGRAMMER, PROGRAMMER};
 use eyre::Context;
 use moor_db::Database;
 use moor_kernel::tasks::{
@@ -281,4 +281,13 @@ fn test(db: Arc<dyn Database + Send + Sync>, path: &Path) {
             .unwrap();
     }
     state.finalize(db).unwrap();
+}
+
+#[test]
+#[ignore = "Useful for debugging; just run a single test"]
+fn test_single() {
+    // CARGO_PROFILE_RELEASE_DEBUG=true cargo flamegraph --test moot-suite -- test_single --ignored
+    for _ in [0; 10] {
+        test_relbox(&testsuite_dir().join("moot/example.moot"));
+    }
 }

--- a/crates/kernel/testsuite/moot_suite.rs
+++ b/crates/kernel/testsuite/moot_suite.rs
@@ -12,14 +12,30 @@ use std::{
 
 use common::{create_relbox_db, create_wiretiger_db, NONPROGRAMMER, PROGRAMMER};
 use eyre::Context;
-use moor_kernel::tasks::sessions::{NoopClientSession, Session};
-use moor_values::{
-    model::WorldStateSource,
-    var::{v_none, Objid},
+use moor_db::Database;
+use moor_kernel::tasks::{
+    scheduler_test_utils,
+    sessions::{NoopClientSession, Session},
 };
+use moor_values::var::{v_none, Objid};
 use pretty_assertions::assert_eq;
 
 use crate::common::WIZARD;
+
+#[derive(Clone, Copy, Debug)]
+enum CommandKind {
+    Eval,
+    Command,
+}
+impl From<char> for CommandKind {
+    fn from(c: char) -> Self {
+        match c {
+            ';' => CommandKind::Eval,
+            '%' => CommandKind::Command,
+            _ => panic!("Unknown command kind: {}", c),
+        }
+    }
+}
 
 enum MootState {
     Ready {
@@ -31,12 +47,14 @@ enum MootState {
         player: Objid,
         line_no: usize,
         command: String,
+        command_kind: CommandKind,
     },
     ReadingExpectation {
         session: Arc<dyn Session>,
         player: Objid,
         line_no: usize,
         command: String,
+        command_kind: CommandKind,
         expectation: String,
     },
 }
@@ -50,7 +68,7 @@ impl MootState {
         self,
         new_line_no: usize,
         line: &str,
-        db: Arc<dyn WorldStateSource>,
+        db: Arc<dyn Database + Send + Sync>,
     ) -> eyre::Result<Self> {
         let line = line.trim_end_matches('\n');
         match self {
@@ -58,12 +76,13 @@ impl MootState {
                 ref session,
                 player,
             } => {
-                if let Some(rest) = line.strip_prefix(';') {
+                if line.starts_with([';', '%']) {
                     Ok(MootState::ReadingCommand {
                         session: session.clone(),
                         player,
                         line_no: new_line_no,
-                        command: rest.trim_start().to_string(),
+                        command: line[1..].trim_start().to_string(),
+                        command_kind: line.chars().next().unwrap().into(),
                     })
                 } else if let Some(new_player) = line.strip_prefix('@') {
                     Ok(MootState::new(session.clone(), Self::player(new_player)?))
@@ -71,7 +90,7 @@ impl MootState {
                     Ok(self)
                 } else {
                     Err(eyre::eyre!(
-                        "Expected a command (starting `;`), a comment (starting `//`), a player switch (starting `@`), or an empty line"
+                        "Expected a command (starting `;`), a comment (starting `//`), a player switch (starting `@`), a command (starting `%`), or an empty line"
                     ))
                 }
             }
@@ -80,6 +99,7 @@ impl MootState {
                 player,
                 line_no,
                 mut command,
+                command_kind,
             } => {
                 if let Some(rest) = line.strip_prefix('>') {
                     command.push_str(rest);
@@ -88,10 +108,12 @@ impl MootState {
                         player,
                         line_no,
                         command,
+                        command_kind,
                     })
                 } else if let Some(new_player) = line.strip_prefix('@') {
                     Self::execute_test(
                         &command,
+                        command_kind,
                         None,
                         line_no,
                         db.clone(),
@@ -99,9 +121,10 @@ impl MootState {
                         player,
                     )?;
                     Ok(MootState::new(session, Self::player(new_player)?))
-                } else if line.starts_with(';') || line.is_empty() {
+                } else if line.starts_with([';', '%']) || line.is_empty() {
                     Self::execute_test(
                         &command,
+                        command_kind,
                         None,
                         line_no,
                         db.clone(),
@@ -115,6 +138,7 @@ impl MootState {
                         player,
                         line_no,
                         command,
+                        command_kind,
                         expectation: line.to_string(),
                     })
                 }
@@ -124,11 +148,13 @@ impl MootState {
                 player,
                 line_no,
                 command,
+                command_kind,
                 mut expectation,
             } => {
-                if line.is_empty() || line.starts_with("//") || line.starts_with(';') {
+                if line.is_empty() || line.starts_with("//") || line.starts_with([';', '%']) {
                     Self::execute_test(
                         &command,
+                        command_kind,
                         Some(&expectation),
                         line_no,
                         db.clone(),
@@ -140,7 +166,7 @@ impl MootState {
                     Ok(MootState::new(session, player))
                 } else if let Some(new_player) = line.strip_prefix('@') {
                     Ok(MootState::new(session, Self::player(new_player)?))
-                } else if line.starts_with(';') {
+                } else if line.starts_with([';', '%']) {
                     MootState::new(session, player).process_line(new_line_no, line, db)
                 } else {
                     expectation.push_str(line);
@@ -149,10 +175,40 @@ impl MootState {
                         player,
                         line_no,
                         command,
+                        command_kind,
                         expectation,
                     })
                 }
             }
+        }
+    }
+
+    fn finalize(self, db: Arc<dyn Database + Send + Sync>) -> eyre::Result<()> {
+        match self {
+            MootState::Ready { .. } => Ok(()),
+            MootState::ReadingCommand {
+                session,
+                player,
+                line_no,
+                command,
+                command_kind,
+            } => Self::execute_test(&command, command_kind, None, line_no, db, session, player),
+            MootState::ReadingExpectation {
+                session,
+                player,
+                line_no,
+                command,
+                command_kind,
+                expectation,
+            } => Self::execute_test(
+                &command,
+                command_kind,
+                Some(&expectation),
+                line_no,
+                db,
+                session,
+                player,
+            ),
         }
     }
 
@@ -167,28 +223,33 @@ impl MootState {
 
     fn execute_test(
         command: &str,
+        command_kind: CommandKind,
         expectation: Option<&str>,
         line_no: usize,
-        db: Arc<dyn WorldStateSource>,
+        db: Arc<dyn Database + Send + Sync>,
         session: Arc<dyn Session>,
         player: Objid,
     ) -> eyre::Result<()> {
         let expected = if let Some(expectation) = expectation {
-            common::eval(
+            scheduler_test_utils::call_eval(
                 db.clone(),
-                WIZARD,
-                &format!("return {expectation};"),
                 session.clone(),
-            )??
+                WIZARD,
+                format!("return {expectation};"),
+            )
+            .context(format!("Failed to compile expected output: {expectation}"))?
         } else {
             v_none()
         };
 
-        let actual_exec_result = common::eval(db, player, command, session)?;
-        let actual = match actual_exec_result {
-            Ok(v) => v,
-            Err(e) => e.code.into(),
-        };
+        let actual = match command_kind {
+            CommandKind::Eval => {
+                scheduler_test_utils::call_eval(db, session, player, command.into())
+            }
+            CommandKind::Command => {
+                scheduler_test_utils::call_command(db, session, player, command)
+            }
+        }?;
         assert_eq!(actual, expected, "Line {line_no}: {command}");
         Ok(())
     }
@@ -205,7 +266,7 @@ fn test_wiretiger(path: &Path) {
     test(create_wiretiger_db(), path);
 }
 
-fn test(db: Arc<dyn WorldStateSource>, path: &Path) {
+fn test(db: Arc<dyn Database + Send + Sync>, path: &Path) {
     if path.is_dir() {
         return;
     }
@@ -219,5 +280,5 @@ fn test(db: Arc<dyn WorldStateSource>, path: &Path) {
             .context(format!("line {}", line_no + 1))
             .unwrap();
     }
-    state.process_line(0, "", db).unwrap();
+    state.finalize(db).unwrap();
 }

--- a/crates/values/src/model/mod.rs
+++ b/crates/values/src/model/mod.rs
@@ -200,8 +200,8 @@ pub enum CommandError {
     NoObjectMatch,
     #[error("Could not find verb match for command")]
     NoCommandMatch,
-    #[error("Could not start transaction due to database error: {0}")]
-    DatabaseError(WorldStateError),
+    #[error("Could not start transaction due to database error")]
+    DatabaseError(#[source] WorldStateError),
     #[error("Permission denied")]
     PermissionDenied,
 }


### PR DESCRIPTION
# *DO NOT MERGE*

## What / Why

I started by trying to port https://github.com/toddsundsted/stunt/blob/300cedcdca6b3f2b64196ebebc55158f976bcce8/test/test_huh.rb. This is the first test that needs us to execute a verb, specifically to test `huh`.

## How

Created `scheduler_test_utils` to the tune of `vm_test_utils` that executes `eval` *and also commands* via a `Scheduler`. All existing tests pass with this setup; so far, so good.

An alternative could be writing a custom driver for verb execution, but since most of the verb lookup logic lives inside `Task`, that seems problematic.

## Problems / Confusion

There are many things that are surprising / confusing:

* These tests are *significantly* slower than the ones just running a VM. Am I doing it wrong? Or is this a necessary overhead of the `Scheduler`?
* The `wt` versions of tests spew logs about transaction rollback failures. Again, unsure if I'm holding it wrong, or this is a teething problem of the new storage backend.
* On some runs of `cargo test -p moor-kernel`, a random test explodes with a `OneshotReceiveError`. What... even? Is there some timing issue? Is there some shared state I can't see that shouldn't exist?
* The new test in `example.moot` fails to find a verb on the location of the player. I guess I must be holding it wrong, but I can't see how. For ease of looking, here's the test:

```
// Execute non-eval commands (i.e. verbs) with `%`
// Remember to still quote the expected output for `eval()`!
; $object = create($nothing);
; add_verb($object, {player, "xd", "accept"}, {"this", "none", "this"});
; set_verb_code($object, "accept", {"return 1;"});
; add_verb($object, {player, "xd", "hi"}, {"this", "none", "this"});
; set_verb_code($object, "hi", {
>   "return \"hello player\";"
> });
; move(player, $object);
% hi
"hello player"
```

And the result of this is a `CommandExecutionError(CommandError::NoCommandMatch)` (which I transform in the test harness to an `E_VERBNF`).

(I'm out of time for `moot` things for today, so submitting here. I suspect I'm doing something wrong on this last one, but there's also a tiny chance I guess that this is catching some actual bug)