### PR TITLE
test(moot): `huh` using `Scheduler` in tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1700,6 +1700,7 @@ dependencies = [
  "text_io",
  "thiserror",
  "tracing",
+ "tracing-subscriber",
  "tracing-test",
  "unindent",
  "uuid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,7 +93,7 @@ yoke-derive = "0.7.3"
 chrono-tz = "0.9.0"
 crypt-sys = "0.1.0"
 iana-time-zone = "0.1.60"
-md5 = "0.7"                                          # For MOO's "string_hash"
+md5 = "0.7"                                            # For MOO's "string_hash"
 onig = { version = "6.4.0", default-features = false }
 rand = "0.8"
 
@@ -111,13 +111,13 @@ paste = "1.0"
 
 # For the DB & values layer.
 crossbeam-queue = "0.3"
-bincode = "2.0.0-rc.3"     # For serializing/deserializing values
+bincode = "2.0.0-rc.3"   # For serializing/deserializing values
 hi_sparse_bitset = "0.6" # For buffer pool allocator in the DB
 im = "15.1"              # Immutable data structures
 io-uring = "0.6"
 libc = "0.2"
 okaywal = "0.3"
-text_io = "0.1"         # Used for reading text dumps.
+text_io = "0.1"          # Used for reading text dumps.
 
 # Dev dependencies
 tempfile = "3.10"

--- a/crates/compiler/src/lib.rs
+++ b/crates/compiler/src/lib.rs
@@ -64,7 +64,7 @@ pub enum GlobalName {
     iobjstr,
 }
 
-#[derive(Debug, Error, Clone, Decode, Encode)]
+#[derive(Debug, Error, Clone, Decode, Encode, PartialEq)]
 pub enum CompileError {
     #[error("Failure to parse string: {0}")]
     StringLexError(String),

--- a/crates/kernel/Cargo.toml
+++ b/crates/kernel/Cargo.toml
@@ -12,16 +12,18 @@ rust-version.workspace = true
 moor-db-relbox = { path = "../db-relbox" }
 wtdb = { path = "../db-wildtiger" }
 
-eyre.workspace = true
 criterion.workspace = true
+eyre.workspace = true
 inventory.workspace = true
 pretty_assertions.workspace = true
 tempfile.workspace = true
 test-case.workspace = true
+test_each_file.workspace = true
 text-diff.workspace = true
 tracing-test.workspace = true
+tracing.workspace = true
+tracing-subscriber.workspace = true
 unindent.workspace = true
-test_each_file.workspace = true
 
 [[test]]
 name = "regression-suite"

--- a/crates/kernel/src/tasks/mod.rs
+++ b/crates/kernel/src/tasks/mod.rs
@@ -190,6 +190,8 @@ pub mod scheduler_test_utils {
             .inspect_err(|e| eprintln!("subscriber.recv() failed: {e}"))
             .unwrap()
         {
+            // Some errors can be represented as a MOO `Var`; translate those to a `Var`, so that
+            // `moot` tests can match against them.
             TaskWaiterResult::Error(TaskAbortedException(UncaughtException { code, .. })) => {
                 Ok(code.into())
             }

--- a/crates/kernel/src/tasks/mod.rs
+++ b/crates/kernel/src/tasks/mod.rs
@@ -185,13 +185,7 @@ pub mod scheduler_test_utils {
         let task_id = fun()?;
         let subscriber = scheduler.subscribe_to_task(task_id).unwrap();
 
-        let loop_scheduler = scheduler.clone();
-        let scheduler_loop_jh = std::thread::Builder::new()
-            .name("moor-scheduler".to_string())
-            .spawn(move || loop_scheduler.run())
-            .unwrap();
-
-        let result = match subscriber
+        match subscriber
             .recv()
             .inspect_err(|e| eprintln!("subscriber.recv() failed: {e}"))
             .unwrap()
@@ -204,13 +198,7 @@ pub mod scheduler_test_utils {
             }
             TaskWaiterResult::Error(err) => Err(err),
             TaskWaiterResult::Success(var) => Ok(var),
-        };
-        scheduler
-            .submit_shutdown(task_id, Some("Test is done".to_string()))
-            .unwrap();
-        scheduler_loop_jh.join().unwrap();
-
-        result
+        }
     }
 
     pub fn call_command(

--- a/crates/kernel/testsuite/moot/huh.moot
+++ b/crates/kernel/testsuite/moot/huh.moot
@@ -1,0 +1,21 @@
+// :huh verb on player doesn't work
+@wizard
+; move(player, $nothing);
+@programmer
+; add_verb(player, {player, "xd", "huh"}, {"this", "none", "this"});
+; set_verb_code(player, "huh", {"return \"test huh\";"});
+% zip
+E_VERBNF
+
+// :huh verb on location works
+@wizard
+; $object = create($nothing);
+; add_verb($object, {player, "xd", "accept"}, {"this", "none", "this"});
+; set_verb_code($object, "accept", {"return 1;"});
+; add_verb($object, {player, "xd", "huh"}, {"this", "none", "this"});
+; set_verb_code($object, "huh", {
+>   "return \"test2 huh\";"
+> });
+; move(player, $object);
+% zip
+"test2 huh"

--- a/crates/kernel/testsuite/moot_suite.rs
+++ b/crates/kernel/testsuite/moot_suite.rs
@@ -7,19 +7,35 @@ use std::{
     fs::File,
     io::{BufRead, BufReader},
     path::Path,
-    sync::Arc,
+    sync::{Arc, Once},
 };
 
-use common::{create_relbox_db, create_wiretiger_db, NONPROGRAMMER, PROGRAMMER};
+use common::{create_relbox_db, create_wiretiger_db, testsuite_dir, NONPROGRAMMER, PROGRAMMER};
 use eyre::Context;
-use moor_kernel::tasks::sessions::{NoopClientSession, Session};
-use moor_values::{
-    model::WorldStateSource,
-    var::{v_none, Objid},
+use moor_db::Database;
+use moor_kernel::tasks::{
+    scheduler_test_utils,
+    sessions::{NoopClientSession, Session},
 };
+use moor_values::var::{v_none, Objid};
 use pretty_assertions::assert_eq;
 
 use crate::common::WIZARD;
+
+#[derive(Clone, Copy, Debug)]
+enum CommandKind {
+    Eval,
+    Command,
+}
+impl From<char> for CommandKind {
+    fn from(c: char) -> Self {
+        match c {
+            ';' => CommandKind::Eval,
+            '%' => CommandKind::Command,
+            _ => panic!("Unknown command kind: {}", c),
+        }
+    }
+}
 
 enum MootState {
     Ready {
@@ -31,12 +47,14 @@ enum MootState {
         player: Objid,
         line_no: usize,
         command: String,
+        command_kind: CommandKind,
     },
     ReadingExpectation {
         session: Arc<dyn Session>,
         player: Objid,
         line_no: usize,
         command: String,
+        command_kind: CommandKind,
         expectation: String,
     },
 }
@@ -50,7 +68,7 @@ impl MootState {
         self,
         new_line_no: usize,
         line: &str,
-        db: Arc<dyn WorldStateSource>,
+        db: Arc<dyn Database + Send + Sync>,
     ) -> eyre::Result<Self> {
         let line = line.trim_end_matches('\n');
         match self {
@@ -58,12 +76,13 @@ impl MootState {
                 ref session,
                 player,
             } => {
-                if let Some(rest) = line.strip_prefix(';') {
+                if line.starts_with([';', '%']) {
                     Ok(MootState::ReadingCommand {
                         session: session.clone(),
                         player,
                         line_no: new_line_no,
-                        command: rest.trim_start().to_string(),
+                        command: line[1..].trim_start().to_string(),
+                        command_kind: line.chars().next().unwrap().into(),
                     })
                 } else if let Some(new_player) = line.strip_prefix('@') {
                     Ok(MootState::new(session.clone(), Self::player(new_player)?))
@@ -71,7 +90,7 @@ impl MootState {
                     Ok(self)
                 } else {
                     Err(eyre::eyre!(
-                        "Expected a command (starting `;`), a comment (starting `//`), a player switch (starting `@`), or an empty line"
+                        "Expected a command (starting `;`), a comment (starting `//`), a player switch (starting `@`), a command (starting `%`), or an empty line"
                     ))
                 }
             }
@@ -80,6 +99,7 @@ impl MootState {
                 player,
                 line_no,
                 mut command,
+                command_kind,
             } => {
                 if let Some(rest) = line.strip_prefix('>') {
                     command.push_str(rest);
@@ -88,10 +108,12 @@ impl MootState {
                         player,
                         line_no,
                         command,
+                        command_kind,
                     })
                 } else if let Some(new_player) = line.strip_prefix('@') {
                     Self::execute_test(
                         &command,
+                        command_kind,
                         None,
                         line_no,
                         db.clone(),
@@ -99,9 +121,10 @@ impl MootState {
                         player,
                     )?;
                     Ok(MootState::new(session, Self::player(new_player)?))
-                } else if line.starts_with(';') || line.is_empty() {
+                } else if line.starts_with([';', '%']) || line.is_empty() {
                     Self::execute_test(
                         &command,
+                        command_kind,
                         None,
                         line_no,
                         db.clone(),
@@ -115,6 +138,7 @@ impl MootState {
                         player,
                         line_no,
                         command,
+                        command_kind,
                         expectation: line.to_string(),
                     })
                 }
@@ -124,11 +148,13 @@ impl MootState {
                 player,
                 line_no,
                 command,
+                command_kind,
                 mut expectation,
             } => {
-                if line.is_empty() || line.starts_with("//") || line.starts_with(';') {
+                if line.is_empty() || line.starts_with("//") || line.starts_with([';', '%']) {
                     Self::execute_test(
                         &command,
+                        command_kind,
                         Some(&expectation),
                         line_no,
                         db.clone(),
@@ -140,7 +166,7 @@ impl MootState {
                     Ok(MootState::new(session, player))
                 } else if let Some(new_player) = line.strip_prefix('@') {
                     Ok(MootState::new(session, Self::player(new_player)?))
-                } else if line.starts_with(';') {
+                } else if line.starts_with([';', '%']) {
                     MootState::new(session, player).process_line(new_line_no, line, db)
                 } else {
                     expectation.push_str(line);
@@ -149,10 +175,40 @@ impl MootState {
                         player,
                         line_no,
                         command,
+                        command_kind,
                         expectation,
                     })
                 }
             }
+        }
+    }
+
+    fn finalize(self, db: Arc<dyn Database + Send + Sync>) -> eyre::Result<()> {
+        match self {
+            MootState::Ready { .. } => Ok(()),
+            MootState::ReadingCommand {
+                session,
+                player,
+                line_no,
+                command,
+                command_kind,
+            } => Self::execute_test(&command, command_kind, None, line_no, db, session, player),
+            MootState::ReadingExpectation {
+                session,
+                player,
+                line_no,
+                command,
+                command_kind,
+                expectation,
+            } => Self::execute_test(
+                &command,
+                command_kind,
+                Some(&expectation),
+                line_no,
+                db,
+                session,
+                player,
+            ),
         }
     }
 
@@ -167,28 +223,33 @@ impl MootState {
 
     fn execute_test(
         command: &str,
+        command_kind: CommandKind,
         expectation: Option<&str>,
         line_no: usize,
-        db: Arc<dyn WorldStateSource>,
+        db: Arc<dyn Database + Send + Sync>,
         session: Arc<dyn Session>,
         player: Objid,
     ) -> eyre::Result<()> {
         let expected = if let Some(expectation) = expectation {
-            common::eval(
+            scheduler_test_utils::call_eval(
                 db.clone(),
-                WIZARD,
-                &format!("return {expectation};"),
                 session.clone(),
-            )??
+                WIZARD,
+                format!("return {expectation};"),
+            )
+            .context(format!("Failed to compile expected output: {expectation}"))?
         } else {
             v_none()
         };
 
-        let actual_exec_result = common::eval(db, player, command, session)?;
-        let actual = match actual_exec_result {
-            Ok(v) => v,
-            Err(e) => e.code.into(),
-        };
+        let actual = match command_kind {
+            CommandKind::Eval => {
+                scheduler_test_utils::call_eval(db, session, player, command.into())
+            }
+            CommandKind::Command => {
+                scheduler_test_utils::call_command(db, session, player, command)
+            }
+        }?;
         assert_eq!(actual, expected, "Line {line_no}: {command}");
         Ok(())
     }
@@ -205,7 +266,28 @@ fn test_wiretiger(path: &Path) {
     test(create_wiretiger_db(), path);
 }
 
-fn test(db: Arc<dyn WorldStateSource>, path: &Path) {
+#[allow(dead_code)]
+static LOGGING_INIT: Once = Once::new();
+#[allow(dead_code)]
+fn init_logging() {
+    LOGGING_INIT.call_once(|| {
+        let main_subscriber = tracing_subscriber::fmt()
+            .compact()
+            .with_ansi(true)
+            .with_file(true)
+            .with_line_number(true)
+            .with_thread_names(true)
+            .with_max_level(tracing::Level::TRACE)
+            .with_test_writer()
+            .finish();
+        tracing::subscriber::set_global_default(main_subscriber)
+            .expect("Unable to set configure logging");
+    });
+}
+
+fn test(db: Arc<dyn Database + Send + Sync>, path: &Path) {
+    // Uncomment to get server logs for debugging; usually too noisy
+    init_logging();
     if path.is_dir() {
         return;
     }
@@ -219,5 +301,13 @@ fn test(db: Arc<dyn WorldStateSource>, path: &Path) {
             .context(format!("line {}", line_no + 1))
             .unwrap();
     }
-    state.process_line(0, "", db).unwrap();
+    state.finalize(db).unwrap();
+}
+
+#[test]
+#[ignore = "Useful for debugging; just run a single test"]
+fn test_single() {
+    // cargo test -p moor-kernel --test moot-suite test_single -- --ignored
+    // CARGO_PROFILE_RELEASE_DEBUG=true cargo flamegraph --test moot-suite -- test_single --ignored
+    test_relbox(&testsuite_dir().join("moot/example.moot"));
 }

--- a/crates/values/src/model/mod.rs
+++ b/crates/values/src/model/mod.rs
@@ -200,8 +200,8 @@ pub enum CommandError {
     NoObjectMatch,
     #[error("Could not find verb match for command")]
     NoCommandMatch,
-    #[error("Could not start transaction due to database error: {0}")]
-    DatabaseError(WorldStateError),
+    #[error("Could not start transaction due to database error")]
+    DatabaseError(#[source] WorldStateError),
     #[error("Permission denied")]
     PermissionDenied,
 }


### PR DESCRIPTION
Port tests for `huh` from Toast. The main blocker for this was adding support to execute non-`eval` commands to `moot`. To do *that*, we now run through a `Scheduler`, instead of just a VM; the prefix for non-`eval` commands is `%` in `.moot` test files.

PR includes some non-trivial / non-obvious changes. In no particular order:
* Ad-hoc transformation of `CommandExecutionError` into `Var` (for `E_VERBNF`)
* Added `#[source]` annotations to some `thiserror` error variants
* Added `Scheduler::submit_shutdown` to send a `Shutdown` request programatically
  * Why: because just calling `scheduler.stop()` makes us wait until `.recv_timeout()` in the main loop times out, slowing tests down considerably
* Don't prune tasks that are finished (i.e. sender channel is closed) but still have subscribers
  * Why: this was causing nondeterministic test failures when the order of events was: task starts, task finishes, pruning happens, we try to read the task result (but it's been pruned already)
* Changed handling of `Shutdown` requests to... actually shut down. This is the one I'm least confident about.
* Added `tracing` setup for `moot` tests (note the `with_test_writer()` to make it play nice with testing log capture)