### PR TITLE
Remove task "subscriptions" and switch from `kanal` to crossbeam (again)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1078,6 +1078,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "generator"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "186014d53bc231d0090ef8d6f03e0920c54d85a5ed22f4f2f74315ec56cf83fb"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "log",
+ "rustversion",
+ "windows",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1280,7 +1294,7 @@ dependencies = [
  "iana-time-zone-haiku",
  "js-sys",
  "wasm-bindgen",
- "windows-core",
+ "windows-core 0.52.0",
 ]
 
 [[package]]
@@ -1515,6 +1529,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 
 [[package]]
+name = "loom"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "419e0dc8046cb947daa77eb95ae174acfbddb7673b4151f56d1eed8e93fbfaca"
+dependencies = [
+ "cfg-if",
+ "generator",
+ "pin-utils",
+ "scoped-tls",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "matchers"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1688,6 +1716,7 @@ dependencies = [
  "moor-db",
  "moor-db-relbox",
  "moor-values",
+ "oneshot",
  "onig",
  "paste",
  "pretty_assertions",
@@ -1872,6 +1901,15 @@ name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+
+[[package]]
+name = "oneshot"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071d1cf3298ad8e543dca18217d198cb6a3884443d204757b9624b935ef09fa0"
+dependencies = [
+ "loom",
+]
 
 [[package]]
 name = "onig"
@@ -2486,6 +2524,12 @@ checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
 ]
+
+[[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "scopeguard"
@@ -3461,10 +3505,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.54.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9252e5725dbed82865af151df558e754e4a3c2c30818359eb17465f1346a1b49"
+dependencies = [
+ "windows-core 0.54.0",
+ "windows-targets 0.52.5",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+dependencies = [
+ "windows-targets 0.52.5",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.54.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12661b9c89351d684a50a8a643ce5f608e20243b9fb84687800163429f161d65"
+dependencies = [
+ "windows-result",
+ "windows-targets 0.52.5",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "749f0da9cc72d82e600d8d2e44cadd0b9eedb9038f71a1c58556ac1c5791813b"
 dependencies = [
  "windows-targets 0.52.5",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1459,16 +1459,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "kanal"
-version = "0.1.0-pre8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05d55519627edaf7fd0f29981f6dc03fb52df3f5b257130eb8d0bf2801ea1d7"
-dependencies = [
- "futures-core",
- "lock_api",
-]
-
-[[package]]
 name = "kernel32-sys"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1702,13 +1692,13 @@ dependencies = [
  "chrono",
  "chrono-tz",
  "criterion",
+ "crossbeam-channel",
  "crypt-sys",
  "dashmap",
  "decorum",
  "eyre",
  "iana-time-zone",
  "inventory",
- "kanal",
  "lazy_static",
  "libc",
  "md5",
@@ -2349,13 +2339,13 @@ dependencies = [
  "atomic-wait",
  "binary-layout",
  "criterion",
+ "crossbeam-channel",
  "crossbeam-queue",
  "dashmap",
  "hi_sparse_bitset",
  "human_bytes",
  "im",
  "io-uring",
- "kanal",
  "libc",
  "moor-values",
  "okaywal",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,6 +80,7 @@ inventory = "0.3.15"
 itertools = "0.13.0"
 kanal = "0.1.0-pre8"
 lazy_static = "1.4.0"
+oneshot = { version = "0.1", default-features = false, features = ["std"] }
 num-traits = "0.2.19"
 owo-colors = "3.5"
 rustyline = "14.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,6 +71,7 @@ bytes = "1.6"
 chrono = "0.4"
 cmake = "0.1"
 criterion = { version = "0.5", features = ["async_tokio"] }
+crossbeam-channel = "0.5"
 dashmap = "5.5"
 decorum = "0.3"                                             # For ordering & comparing our floats
 enum-primitive-derive = "0.3"
@@ -78,7 +79,6 @@ fast-counter = "1.0"
 human_bytes = "0.4"
 inventory = "0.3.15"
 itertools = "0.13.0"
-kanal = "0.1.0-pre8"
 lazy_static = "1.4.0"
 oneshot = { version = "0.1", default-features = false, features = ["std"] }
 num-traits = "0.2.19"

--- a/crates/daemon/src/rpc_server.rs
+++ b/crates/daemon/src/rpc_server.rs
@@ -12,9 +12,10 @@
 // this program. If not, see <https://www.gnu.org/licenses/>.
 //
 
+//! The core of the server logic for the RPC daemon
+
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
-/// The core of the server logic for the RPC daemon
 use std::sync::{Arc, Mutex};
 use std::time::SystemTime;
 
@@ -33,7 +34,7 @@ use zmq::{Socket, SocketType};
 use moor_kernel::tasks::scheduler::{Scheduler, SchedulerError, TaskWaiterResult};
 use moor_kernel::tasks::sessions::SessionError::DeliveryError;
 use moor_kernel::tasks::sessions::{Session, SessionError};
-use moor_kernel::tasks::TaskId;
+use moor_kernel::tasks::TaskHandle;
 use moor_values::model::NarrativeEvent;
 use moor_values::model::WorldStateSource;
 use moor_values::util::parse_into_words;
@@ -459,7 +460,7 @@ impl RpcServer {
         let Ok(session) = self.clone().new_session(client_id, connection) else {
             return Err(RpcRequestError::CreateSessionFailed);
         };
-        let task_id = match self.clone().scheduler.submit_verb_task(
+        let task_handle = match self.clone().scheduler.submit_verb_task(
             connection,
             SYSTEM_OBJECT,
             "do_login_command".to_string(),
@@ -475,14 +476,7 @@ impl RpcServer {
                 return Err(RpcRequestError::InternalError(e.to_string()));
             }
         };
-        let receiver = match self.clone().scheduler.subscribe_to_task(task_id) {
-            Ok(r) => r,
-            Err(e) => {
-                error!(error = ?e, "Error subscribing to login task");
-
-                return Err(RpcRequestError::LoginTaskFailed);
-            }
-        };
+        let receiver = task_handle.1;
         let player = match receiver.recv() {
             Ok(TaskWaiterResult::Success(v)) => {
                 // If v is an objid, we have a successful login and we need to rewrite this
@@ -592,7 +586,7 @@ impl RpcServer {
         // TODO: fold this functionality into Task.
 
         let arguments = parse_into_words(command.as_str());
-        if let Ok(task_id) = self.clone().scheduler.submit_verb_task(
+        if let Ok(task_handle) = self.clone().scheduler.submit_verb_task(
             connection,
             SYSTEM_OBJECT,
             "do_command".to_string(),
@@ -601,7 +595,8 @@ impl RpcServer {
             SYSTEM_OBJECT,
             session.clone(),
         ) {
-            if let Ok(value) = self.clone().watch_command_task(task_id) {
+            let task_id = task_handle.task_id();
+            if let Ok(value) = self.clone().watch_command_task(task_handle) {
                 if value != v_bool(false) {
                     return Ok(RpcResponse::CommandSubmitted(task_id));
                 }
@@ -616,7 +611,7 @@ impl RpcServer {
             ?connection,
             "Invoking submit_command_task"
         );
-        let task_id =
+        let task_handle =
             match self
                 .clone()
                 .scheduler
@@ -632,7 +627,7 @@ impl RpcServer {
                 }
             };
 
-        Ok(RpcResponse::CommandSubmitted(task_id))
+        Ok(RpcResponse::CommandSubmitted(task_handle.task_id()))
     }
 
     fn respond_input(
@@ -663,17 +658,15 @@ impl RpcServer {
         Ok(RpcResponse::InputThanks)
     }
 
-    fn watch_command_task(self: Arc<Self>, task_id: TaskId) -> Result<Var, RpcRequestError> {
-        debug!(task_id, "Subscribed to command task results");
-        let receiver = match self.clone().scheduler.subscribe_to_task(task_id) {
-            Ok(r) => r,
-            Err(e) => {
-                error!(error = ?e, "Error subscribing to command task");
-                return Err(RpcRequestError::InternalError(e.to_string()));
-            }
-        };
-
-        match receiver.recv() {
+    fn watch_command_task(
+        self: Arc<Self>,
+        task_handle: TaskHandle,
+    ) -> Result<Var, RpcRequestError> {
+        debug!(
+            task_id = task_handle.task_id(),
+            "Subscribed to command task results"
+        );
+        match task_handle.1.recv() {
             Ok(TaskWaiterResult::Success(value)) => Ok(value),
             Ok(TaskWaiterResult::Error(SchedulerError::CommandExecutionError(e))) => {
                 Err(RpcRequestError::CommandError(e))
@@ -695,7 +688,7 @@ impl RpcServer {
         };
 
         let command_components = parse_into_words(command.as_str());
-        let task_id = match self.clone().scheduler.submit_out_of_band_task(
+        let task_handle = match self.clone().scheduler.submit_out_of_band_task(
             connection,
             command_components,
             command,
@@ -712,7 +705,7 @@ impl RpcServer {
         // let the session run to completion on its own and output back to the client.
         // Maybe we should be returning a value from this for the future, but the way clients are
         // written right now, there's little point.
-        Ok(RpcResponse::CommandSubmitted(task_id))
+        Ok(RpcResponse::CommandSubmitted(task_handle.task_id()))
     }
 
     fn eval(
@@ -725,7 +718,7 @@ impl RpcServer {
             return Err(RpcRequestError::CreateSessionFailed);
         };
 
-        let task_id = match self
+        let task_handle = match self
             .clone()
             .scheduler
             .submit_eval_task(connection, connection, expression, session)
@@ -736,16 +729,7 @@ impl RpcServer {
                 return Err(RpcRequestError::InternalError(e.to_string()));
             }
         };
-
-        let receiver = match self.clone().scheduler.subscribe_to_task(task_id) {
-            Ok(r) => r,
-            Err(e) => {
-                error!(error = ?e, "Error subscribing to command task");
-                return Err(RpcRequestError::InternalError(e.to_string()));
-            }
-        };
-
-        match receiver.recv() {
+        match task_handle.1.recv() {
             Ok(TaskWaiterResult::Success(v)) => Ok(RpcResponse::EvalResult(v)),
             Ok(TaskWaiterResult::Error(SchedulerError::CommandExecutionError(e))) => {
                 Err(RpcRequestError::CommandError(e))

--- a/crates/daemon/src/rpc_server.rs
+++ b/crates/daemon/src/rpc_server.rs
@@ -476,7 +476,7 @@ impl RpcServer {
                 return Err(RpcRequestError::InternalError(e.to_string()));
             }
         };
-        let receiver = task_handle.receiver();
+        let receiver = task_handle.into_receiver();
         let player = match receiver.recv() {
             Ok(TaskWaiterResult::Success(v)) => {
                 // If v is an objid, we have a successful login and we need to rewrite this
@@ -669,7 +669,7 @@ impl RpcServer {
             task_id = task_handle.task_id(),
             "Subscribed to command task results"
         );
-        match task_handle.receiver().recv() {
+        match task_handle.into_receiver().recv() {
             Ok(TaskWaiterResult::Success(value)) => Ok(value),
             Ok(TaskWaiterResult::Error(SchedulerError::CommandExecutionError(e))) => {
                 Err(RpcRequestError::CommandError(e))
@@ -732,7 +732,7 @@ impl RpcServer {
                 return Err(RpcRequestError::InternalError(e.to_string()));
             }
         };
-        match task_handle.receiver().recv() {
+        match task_handle.into_receiver().recv() {
             Ok(TaskWaiterResult::Success(v)) => Ok(RpcResponse::EvalResult(v)),
             Ok(TaskWaiterResult::Error(SchedulerError::CommandExecutionError(e))) => {
                 Err(RpcRequestError::CommandError(e))

--- a/crates/db-wildtiger/src/wtrel/db.rs
+++ b/crates/db-wildtiger/src/wtrel/db.rs
@@ -16,7 +16,7 @@ use std::path::Path;
 use std::sync::atomic::AtomicI64;
 use std::sync::Arc;
 
-use tracing::{debug, info};
+use tracing::debug;
 
 use crate::bindings::{
     Connection, CursorConfig, Datum, Error, Isolation, LogConfig, OpenConfig, SessionConfig,

--- a/crates/db-wildtiger/src/wtrel/db.rs
+++ b/crates/db-wildtiger/src/wtrel/db.rs
@@ -93,7 +93,6 @@ where
         let session = self.connection.open_session(session_config).unwrap();
         let tx_config = TransactionConfig::new();
         session.begin_transaction(Some(tx_config)).unwrap();
-        info!("Starting transaction...");
         WiredTigerRelTransaction::new(session, self.sequences.clone())
     }
 

--- a/crates/db-wildtiger/src/wtrel/relation.rs
+++ b/crates/db-wildtiger/src/wtrel/relation.rs
@@ -1,3 +1,17 @@
+// Copyright (C) 2024 Ryan Daum <ryan.daum@gmail.com>
+//
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free Software
+// Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program. If not, see <https://www.gnu.org/licenses/>.
+//
+
 use crate::bindings::DataSource::Table;
 use crate::bindings::FormatType::RawByte;
 use crate::bindings::{CreateConfig, DataSource, FormatType, Session};

--- a/crates/kernel/Cargo.toml
+++ b/crates/kernel/Cargo.toml
@@ -51,6 +51,7 @@ decorum.workspace = true
 kanal.workspace = true
 lazy_static.workspace = true
 libc.workspace = true
+oneshot.workspace = true
 strum.workspace = true
 text_io.workspace = true
 uuid.workspace = true

--- a/crates/kernel/Cargo.toml
+++ b/crates/kernel/Cargo.toml
@@ -46,9 +46,9 @@ moor-values = { path = "../values" }
 
 ## General usefulness
 chrono.workspace = true
+crossbeam-channel.workspace = true
 dashmap.workspace = true
 decorum.workspace = true
-kanal.workspace = true
 lazy_static.workspace = true
 libc.workspace = true
 oneshot.workspace = true

--- a/crates/kernel/benches/vm_benches.rs
+++ b/crates/kernel/benches/vm_benches.rs
@@ -52,7 +52,7 @@ pub fn prepare_call_verb(
     args: Vec<Var>,
     max_ticks: usize,
 ) -> VmHost {
-    let (scs_tx, _scs_rx) = kanal::unbounded();
+    let (scs_tx, _scs_rx) = crossbeam_channel::unbounded();
     let mut vm_host = VmHost::new(
         0,
         20,

--- a/crates/kernel/src/builtins/bf_server.rs
+++ b/crates/kernel/src/builtins/bf_server.rs
@@ -417,7 +417,7 @@ fn bf_queued_tasks(bf_args: &mut BfCallState<'_>) -> Result<BfRet, Error> {
     }
 
     // Ask the scheduler (through its mailbox) to describe all the queued tasks.
-    let (send, receive) = kanal::oneshot();
+    let (send, receive) = oneshot::channel();
     debug!("sending DescribeOtherTasks to scheduler");
     bf_args
         .scheduler_sender
@@ -480,7 +480,7 @@ fn bf_kill_task(bf_args: &mut BfCallState<'_>) -> Result<BfRet, Error> {
         return Ok(VmInstr(ExecutionResult::Complete(v_none())));
     }
 
-    let (send, receive) = kanal::oneshot();
+    let (send, receive) = oneshot::channel();
     bf_args
         .scheduler_sender
         .send((
@@ -524,7 +524,7 @@ fn bf_resume(bf_args: &mut BfCallState<'_>) -> Result<BfRet, Error> {
         return Err(E_INVARG);
     }
 
-    let (send, receive) = kanal::oneshot();
+    let (send, receive) = oneshot::channel();
     bf_args
         .scheduler_sender
         .send((

--- a/crates/kernel/src/builtins/mod.rs
+++ b/crates/kernel/src/builtins/mod.rs
@@ -23,7 +23,7 @@ mod bf_verbs;
 
 use std::sync::Arc;
 
-use kanal::Sender;
+use crossbeam_channel::Sender;
 
 use moor_values::model::Perms;
 use moor_values::model::WorldState;

--- a/crates/kernel/src/tasks/mod.rs
+++ b/crates/kernel/src/tasks/mod.rs
@@ -30,12 +30,16 @@ pub mod vm_host;
 
 pub type TaskId = usize;
 
-pub struct TaskHandle(pub TaskId, pub oneshot::Receiver<TaskWaiterResult>);
+pub struct TaskHandle(TaskId, oneshot::Receiver<TaskWaiterResult>);
 impl TaskHandle {
     pub fn task_id(&self) -> TaskId {
         self.0
     }
+    pub fn receiver(self) -> oneshot::Receiver<TaskWaiterResult> {
+        self.1
+    }
 }
+
 pub(crate) type PhantomUnsync = PhantomData<Cell<()>>;
 pub(crate) type PhantomUnsend = PhantomData<MutexGuard<'static, ()>>;
 
@@ -196,7 +200,7 @@ pub mod scheduler_test_utils {
             .recv_timeout(Duration::from_secs(1))
             .inspect_err(|e| {
                 eprintln!(
-                    "subscriber.recv() failed for task {}: {e}",
+                    "subscriber.recv_timeout() failed for task {}: {e}",
                     task_handle.task_id(),
                 )
             })

--- a/crates/kernel/src/tasks/mod.rs
+++ b/crates/kernel/src/tasks/mod.rs
@@ -82,7 +82,7 @@ pub mod vm_test_utils {
     where
         F: FnOnce(&mut dyn WorldState, &mut VmHost),
     {
-        let (scs_tx, _scs_rx) = kanal::unbounded();
+        let (scs_tx, _scs_rx) = crossbeam_channel::unbounded();
         let mut vm_host = VmHost::new(
             0,
             20,
@@ -92,7 +92,7 @@ pub mod vm_test_utils {
             scs_tx,
         );
 
-        let (sched_send, _) = kanal::unbounded();
+        let (sched_send, _) = crossbeam_channel::unbounded();
         let _vm_exec_params = VmExecParams {
             scheduler_sender: sched_send.clone(),
             max_stack_depth: 50,

--- a/crates/kernel/src/tasks/mod.rs
+++ b/crates/kernel/src/tasks/mod.rs
@@ -176,6 +176,7 @@ pub mod scheduler_test_utils {
     use moor_values::model::CommandError;
     use moor_values::var::{Error::E_VERBNF, Objid, Var};
     use std::sync::Arc;
+    use std::time::Duration;
 
     use super::scheduler::{Scheduler, SchedulerError, TaskWaiterResult};
     use super::TaskHandle;
@@ -192,8 +193,13 @@ pub mod scheduler_test_utils {
         let task_handle = fun()?;
         match task_handle
             .1
-            .recv()
-            .inspect_err(|e| eprintln!("subscriber.recv() failed: {e}"))
+            .recv_timeout(Duration::from_secs(1))
+            .inspect_err(|e| {
+                eprintln!(
+                    "subscriber.recv() failed for task {}: {e}",
+                    task_handle.task_id(),
+                )
+            })
             .unwrap()
         {
             // Some errors can be represented as a MOO `Var`; translate those to a `Var`, so that

--- a/crates/kernel/src/tasks/mod.rs
+++ b/crates/kernel/src/tasks/mod.rs
@@ -30,12 +30,15 @@ pub mod vm_host;
 
 pub type TaskId = usize;
 
+/// Just a handle to a task, with a receiver for the result.
 pub struct TaskHandle(TaskId, oneshot::Receiver<TaskWaiterResult>);
 impl TaskHandle {
     pub fn task_id(&self) -> TaskId {
         self.0
     }
-    pub fn receiver(self) -> oneshot::Receiver<TaskWaiterResult> {
+
+    /// Dissolve the handle into a receiver for the result.
+    pub fn into_receiver(self) -> oneshot::Receiver<TaskWaiterResult> {
         self.1
     }
 }

--- a/crates/kernel/src/tasks/task.rs
+++ b/crates/kernel/src/tasks/task.rs
@@ -352,7 +352,7 @@ impl Task {
                 // send a message back asking it to fork the task and return the new task id on a
                 // reply channel.
                 // We will then take the new task id and send it back to the caller.
-                let (send, reply) = kanal::oneshot();
+                let (send, reply) = oneshot::channel();
                 let task_id_var = fork_request.task_id;
                 self.scheduler_control_sender
                     .send((

--- a/crates/kernel/src/tasks/task_messages.rs
+++ b/crates/kernel/src/tasks/task_messages.rs
@@ -18,7 +18,6 @@ use crate::vm::vm_unwind::UncaughtException;
 use crate::vm::Fork;
 use std::sync::Arc;
 
-use kanal::OneshotSender;
 use moor_compiler::Program;
 
 use moor_values::model::{CommandError, NarrativeEvent};
@@ -68,7 +67,7 @@ pub enum TaskControlMsg {
     ///   Causes deadlock if the task _requesting_ the description is the task being
     ///   described, so I need to rethink this. Right now this is prevented by the
     ///   runtime, but it's not a good design.
-    Describe(OneshotSender<TaskDescription>),
+    Describe(oneshot::Sender<TaskDescription>),
     /// The scheduler is telling the task to abort itself.
     Abort,
 }
@@ -88,7 +87,7 @@ pub enum SchedulerControlMsg {
     /// An exception was thrown while executing the verb.
     TaskException(UncaughtException),
     /// The task is requesting that it be forked.
-    TaskRequestFork(Fork, OneshotSender<TaskId>),
+    TaskRequestFork(Fork, oneshot::Sender<TaskId>),
     /// The task is letting us know it was cancelled.
     TaskAbortCancelled,
     /// The task is letting us know that it has reached its abort limits.
@@ -98,19 +97,19 @@ pub enum SchedulerControlMsg {
     /// Tell the scheduler we're suspending until we get input from the client.
     TaskRequestInput,
     /// Task is requesting a list of all other tasks known to the scheduler.
-    DescribeOtherTasks(OneshotSender<Vec<TaskDescription>>),
+    DescribeOtherTasks(oneshot::Sender<Vec<TaskDescription>>),
     /// Task is requesting that the scheduler abort another task.
     KillTask {
         victim_task_id: TaskId,
         sender_permissions: Perms,
-        result_sender: OneshotSender<Var>,
+        result_sender: oneshot::Sender<Var>,
     },
     /// Task is requesting that the scheduler resume another task.
     ResumeTask {
         queued_task_id: TaskId,
         sender_permissions: Perms,
         return_value: Var,
-        result_sender: OneshotSender<Var>,
+        result_sender: oneshot::Sender<Var>,
     },
     /// Task is requesting that the scheduler boot a player.
     BootPlayer {

--- a/crates/kernel/src/tasks/vm_host.rs
+++ b/crates/kernel/src/tasks/vm_host.rs
@@ -21,7 +21,7 @@ use crate::tasks::{PhantomUnsend, PhantomUnsync, TaskId, VerbCall};
 use crate::vm::{ExecutionResult, Fork, VerbExecutionRequest, VM};
 use crate::vm::{FinallyReason, VMExecState};
 use crate::vm::{UncaughtException, VmExecParams};
-use kanal::Sender;
+use crossbeam_channel::Sender;
 use moor_compiler::Program;
 use moor_compiler::{compile, Name};
 use moor_values::model::VerbInfo;

--- a/crates/kernel/src/vm/vm_execute.rs
+++ b/crates/kernel/src/vm/vm_execute.rs
@@ -12,7 +12,7 @@
 // this program. If not, see <https://www.gnu.org/licenses/>.
 //
 
-use kanal::Sender;
+use crossbeam_channel::Sender;
 use std::sync::Arc;
 use std::time::Duration;
 

--- a/crates/relbox/Cargo.toml
+++ b/crates/relbox/Cargo.toml
@@ -38,11 +38,11 @@ tracing.workspace = true
 # For the DB layer.
 atomic-wait.workspace = true
 binary-layout.workspace = true
+crossbeam-channel.workspace = true
 crossbeam-queue.workspace = true
 dashmap.workspace = true
 hi_sparse_bitset.workspace = true
 im.workspace = true
 io-uring.workspace = true
-kanal.workspace = true
 libc.workspace = true
 okaywal.workspace = true

--- a/crates/relbox/src/index/mod.rs
+++ b/crates/relbox/src/index/mod.rs
@@ -82,7 +82,7 @@ impl IndexType {
     }
 }
 
-pub trait Index {
+pub trait Index: Send {
     /// Return the index type for the index.
     fn index_type(&self) -> IndexType;
     /// Check for potential duplicates which could cause ambiguous updates for update operations.

--- a/crates/relbox/src/paging/backing.rs
+++ b/crates/relbox/src/paging/backing.rs
@@ -16,7 +16,7 @@
 //! Used for write-ahead type storage at commit-time, and backed by whatever preferred physical
 //! storage mechanism is desired.
 
-use kanal::Sender;
+use crossbeam_channel::Sender;
 use std::thread::yield_now;
 
 use crate::tx::WorkingSet;

--- a/crates/relbox/src/tx/transaction.rs
+++ b/crates/relbox/src/tx/transaction.rs
@@ -20,7 +20,7 @@ use std::thread::yield_now;
 use thiserror::Error;
 
 use moor_values::util::{BitArray, Bitset64};
-use moor_values::util::{PhantomUnsend, PhantomUnsync, SliceRef};
+use moor_values::util::{PhantomUnsync, SliceRef};
 
 use crate::base_relation::BaseRelation;
 use crate::paging::TupleBox;
@@ -39,8 +39,6 @@ pub struct Transaction {
     /// to the transaction, and represents the set of values that will be committed to the base
     /// relations at commit time.
     pub(crate) working_set: RefCell<Option<WorkingSet>>,
-
-    unsend: PhantomUnsend,
     unsync: PhantomUnsync,
 }
 
@@ -68,7 +66,6 @@ impl Transaction {
         Self {
             db,
             working_set: RefCell::new(Some(ws)),
-            unsend: Default::default(),
             unsync: Default::default(),
         }
     }
@@ -249,8 +246,6 @@ pub struct CommitSet<'a> {
     // Holds a lock on the base relations, which we'll swap out with the new relations at successful commit
     write_guard: RwLockWriteGuard<'a, Vec<BaseRelation>>,
 
-    // I can't/shouldn't be moved around between threads...
-    unsend: PhantomUnsend,
     unsync: PhantomUnsync,
 }
 
@@ -260,7 +255,6 @@ impl<'a> CommitSet<'a> {
             ts,
             relations: Box::new(BitArray::new()),
             write_guard,
-            unsend: Default::default(),
             unsync: Default::default(),
         }
     }

--- a/crates/relbox/src/tx/transaction.rs
+++ b/crates/relbox/src/tx/transaction.rs
@@ -20,7 +20,7 @@ use std::thread::yield_now;
 use thiserror::Error;
 
 use moor_values::util::{BitArray, Bitset64};
-use moor_values::util::{PhantomUnsync, SliceRef};
+use moor_values::util::{PhantomUnsend, PhantomUnsync, SliceRef};
 
 use crate::base_relation::BaseRelation;
 use crate::paging::TupleBox;
@@ -39,6 +39,8 @@ pub struct Transaction {
     /// to the transaction, and represents the set of values that will be committed to the base
     /// relations at commit time.
     pub(crate) working_set: RefCell<Option<WorkingSet>>,
+
+    unsend: PhantomUnsend,
     unsync: PhantomUnsync,
 }
 
@@ -66,6 +68,7 @@ impl Transaction {
         Self {
             db,
             working_set: RefCell::new(Some(ws)),
+            unsend: Default::default(),
             unsync: Default::default(),
         }
     }

--- a/crates/relbox/src/tx/working_set.rs
+++ b/crates/relbox/src/tx/working_set.rs
@@ -17,7 +17,7 @@ use std::sync::Arc;
 use tracing::{error, warn};
 
 use moor_values::util::{BitArray, Bitset64};
-use moor_values::util::{PhantomUnsend, PhantomUnsync, SliceRef};
+use moor_values::util::{PhantomUnsync, SliceRef};
 
 use crate::index::{pick_tx_index, Index};
 use crate::paging::TupleBox;
@@ -36,7 +36,6 @@ pub struct WorkingSet {
     pub(crate) tuplebox: Arc<TupleBox>,
     pub(crate) relations: Box<BitArray<TxBaseRelation, 64, Bitset64<1>>>,
 
-    unsend: PhantomUnsend,
     unsync: PhantomUnsync,
 }
 
@@ -48,7 +47,6 @@ impl WorkingSet {
             tuplebox: slotbox,
             schema: schema.to_vec(),
             relations,
-            unsend: Default::default(),
             unsync: Default::default(),
         }
     }
@@ -78,7 +76,6 @@ impl WorkingSet {
             tx_tuple_events: HashMap::new(),
             domain_index,
             codomain_index,
-            unsend: Default::default(),
             unsync: Default::default(),
         };
 
@@ -590,7 +587,6 @@ pub(crate) struct TxBaseRelation {
     domain_index: Box<dyn Index>,
     codomain_index: Option<Box<dyn Index>>,
 
-    unsend: PhantomUnsend,
     unsync: PhantomUnsync,
 }
 


### PR DESCRIPTION
Three related things:

  * Eliminates the use of `subscribe_to_task` because this was a) overengineered and b) leading to race conditions if the task completed before the subscription attempt
  * Switch to `oneshot` crate from kanal from the kanal::oneshot usage and thereby be able to use its `recv_timeout` function and then make tests use that so they can't hang forevers.
  * Rip out remaining use of `kanal` as this crate seems mainly abandoned and crossbeam is already in the dependency hierarchy. I'm not in love with crossbeam, but it will do, and it's reliable and maintained. (Over time I will be deprecating a lot of the channel usage in the scheduler anyways).
