### PR TITLE
The great `E_INVARG` purge of '24

### DIFF
--- a/crates/kernel/src/builtins/bf_list_sets.rs
+++ b/crates/kernel/src/builtins/bf_list_sets.rs
@@ -18,7 +18,7 @@ use std::sync::Arc;
 use onig::{Region, SearchOptions, SyntaxOperator};
 
 use moor_compiler::offset_for_builtin;
-use moor_values::var::Error::{E_INVARG, E_TYPE};
+use moor_values::var::Error::{E_ARGS, E_INVARG, E_TYPE};
 use moor_values::var::Variant;
 use moor_values::var::{v_empty_list, v_int, v_list, v_string};
 use moor_values::var::{v_listv, Error};
@@ -31,7 +31,7 @@ use crate::vm::VM;
 
 fn bf_is_member(bf_args: &mut BfCallState<'_>) -> Result<BfRet, Error> {
     if bf_args.args.len() != 2 {
-        return Err(E_INVARG);
+        return Err(E_ARGS);
     }
     let (value, list) = (&bf_args.args[0], &bf_args.args[1]);
     let Variant::List(list) = list.variant() else {
@@ -47,7 +47,7 @@ bf_declare!(is_member, bf_is_member);
 
 fn bf_listinsert(bf_args: &mut BfCallState<'_>) -> Result<BfRet, Error> {
     if bf_args.args.len() < 2 || bf_args.args.len() > 3 {
-        return Err(E_INVARG);
+        return Err(E_ARGS);
     }
     let len = bf_args.args.len();
     let value = bf_args.args[1].clone();
@@ -74,7 +74,7 @@ bf_declare!(listinsert, bf_listinsert);
 
 fn bf_listappend(bf_args: &mut BfCallState<'_>) -> Result<BfRet, Error> {
     if bf_args.args.len() < 2 || bf_args.args.len() > 3 {
-        return Err(E_INVARG);
+        return Err(E_ARGS);
     }
     let value = bf_args.args[1].clone();
     let list = &mut bf_args.args[0];
@@ -96,7 +96,7 @@ bf_declare!(listappend, bf_listappend);
 
 fn bf_listdelete(bf_args: &mut BfCallState<'_>) -> Result<BfRet, Error> {
     if bf_args.args.len() != 2 {
-        return Err(E_INVARG);
+        return Err(E_ARGS);
     }
     let index = bf_args.args[1].clone();
     let list = bf_args.args[0].variant_mut();
@@ -113,7 +113,7 @@ bf_declare!(listdelete, bf_listdelete);
 
 fn bf_listset(bf_args: &mut BfCallState<'_>) -> Result<BfRet, Error> {
     if bf_args.args.len() != 3 {
-        return Err(E_INVARG);
+        return Err(E_ARGS);
     }
     let index = bf_args.args[2].clone();
     let value = bf_args.args[1].clone();
@@ -131,7 +131,7 @@ bf_declare!(listset, bf_listset);
 
 fn bf_setadd(bf_args: &mut BfCallState<'_>) -> Result<BfRet, Error> {
     if bf_args.args.len() != 2 {
-        return Err(E_INVARG);
+        return Err(E_ARGS);
     }
     let value = bf_args.args[1].clone();
     let list = &mut bf_args.args[0];
@@ -147,7 +147,7 @@ bf_declare!(setadd, bf_setadd);
 
 fn bf_setremove(bf_args: &mut BfCallState<'_>) -> Result<BfRet, Error> {
     if bf_args.args.len() != 2 {
-        return Err(E_INVARG);
+        return Err(E_ARGS);
     }
     let value = bf_args.args[1].clone();
     let list = bf_args.args[0].variant_mut();
@@ -266,7 +266,7 @@ fn perform_regex_match(
 /// Common code for both match and rmatch.
 fn do_re_match(bf_args: &mut BfCallState<'_>, reverse: bool) -> Result<BfRet, Error> {
     if bf_args.args.len() < 2 || bf_args.args.len() > 3 {
-        return Err(E_INVARG);
+        return Err(E_ARGS);
     }
     let (subject, pattern) = match (bf_args.args[0].variant(), bf_args.args[1].variant()) {
         (Variant::Str(subject), Variant::Str(pattern)) => (subject, pattern),
@@ -378,7 +378,7 @@ fn substitute(template: &str, subs: &[(isize, isize)], source: &str) -> Result<S
 
 fn bf_substitute(bf_args: &mut BfCallState<'_>) -> Result<BfRet, Error> {
     if bf_args.args.len() != 2 {
-        return Err(E_INVARG);
+        return Err(E_ARGS);
     }
     let (template, subs) = match (bf_args.args[0].variant(), bf_args.args[1].variant()) {
         (Variant::Str(template), Variant::List(subs)) => (template, subs),
@@ -388,7 +388,7 @@ fn bf_substitute(bf_args: &mut BfCallState<'_>) -> Result<BfRet, Error> {
     // Subs is of form {<start>, <end>, <replacements>, <subject>}
     // "replacement" and subject are what we're interested in.
     if subs.len() != 4 {
-        return Err(E_INVARG);
+        return Err(E_ARGS);
     }
 
     let (Variant::List(subs), Variant::Str(source)) = (subs[2].variant(), subs[3].variant()) else {

--- a/crates/kernel/src/builtins/bf_num.rs
+++ b/crates/kernel/src/builtins/bf_num.rs
@@ -18,7 +18,7 @@ use decorum::R64;
 use rand::Rng;
 
 use moor_values::var::Error;
-use moor_values::var::Error::{E_INVARG, E_TYPE};
+use moor_values::var::Error::{E_ARGS, E_INVARG, E_TYPE};
 use moor_values::var::Variant;
 use moor_values::var::{v_float, v_int, v_str};
 
@@ -30,7 +30,7 @@ use moor_compiler::offset_for_builtin;
 
 fn bf_abs(bf_args: &mut BfCallState<'_>) -> Result<BfRet, Error> {
     if bf_args.args.len() != 1 {
-        return Err(E_INVARG);
+        return Err(E_ARGS);
     }
 
     match bf_args.args[0].variant() {
@@ -43,7 +43,7 @@ bf_declare!(abs, bf_abs);
 
 fn bf_min(bf_args: &mut BfCallState<'_>) -> Result<BfRet, Error> {
     if bf_args.args.len() != 2 {
-        return Err(E_INVARG);
+        return Err(E_ARGS);
     }
 
     match (bf_args.args[0].variant(), bf_args.args[1].variant()) {
@@ -59,7 +59,7 @@ bf_declare!(min, bf_min);
 
 fn bf_max(bf_args: &mut BfCallState<'_>) -> Result<BfRet, Error> {
     if bf_args.args.len() != 2 {
-        return Err(E_INVARG);
+        return Err(E_ARGS);
     }
 
     match (bf_args.args[0].variant(), bf_args.args[1].variant()) {
@@ -75,7 +75,7 @@ bf_declare!(max, bf_max);
 
 fn bf_random(bf_args: &mut BfCallState<'_>) -> Result<BfRet, Error> {
     if bf_args.args.len() > 1 {
-        return Err(E_INVARG);
+        return Err(E_ARGS);
     }
 
     let mut rng = rand::thread_rng();
@@ -89,7 +89,7 @@ bf_declare!(random, bf_random);
 
 fn bf_floatstr(bf_args: &mut BfCallState<'_>) -> Result<BfRet, Error> {
     if bf_args.args.len() < 2 || bf_args.args.len() > 3 {
-        return Err(E_INVARG);
+        return Err(E_ARGS);
     }
 
     let x = match bf_args.args[0].variant() {
@@ -118,7 +118,7 @@ bf_declare!(floatstr, bf_floatstr);
 
 fn bf_sin(bf_args: &mut BfCallState<'_>) -> Result<BfRet, Error> {
     if bf_args.args.len() != 1 {
-        return Err(E_INVARG);
+        return Err(E_ARGS);
     }
 
     let x = match bf_args.args[0].variant() {
@@ -132,7 +132,7 @@ bf_declare!(sin, bf_sin);
 
 fn bf_cos(bf_args: &mut BfCallState<'_>) -> Result<BfRet, Error> {
     if bf_args.args.len() != 1 {
-        return Err(E_INVARG);
+        return Err(E_ARGS);
     }
 
     let x = match bf_args.args[0].variant() {
@@ -146,7 +146,7 @@ bf_declare!(cos, bf_cos);
 
 fn bf_tan(bf_args: &mut BfCallState<'_>) -> Result<BfRet, Error> {
     if bf_args.args.len() != 1 {
-        return Err(E_INVARG);
+        return Err(E_ARGS);
     }
 
     let x = match bf_args.args[0].variant() {
@@ -160,7 +160,7 @@ bf_declare!(tan, bf_tan);
 
 fn bf_sqrt(bf_args: &mut BfCallState<'_>) -> Result<BfRet, Error> {
     if bf_args.args.len() != 1 {
-        return Err(E_INVARG);
+        return Err(E_ARGS);
     }
 
     let x = match bf_args.args[0].variant() {
@@ -178,7 +178,7 @@ bf_declare!(sqrt, bf_sqrt);
 
 fn bf_asin(bf_args: &mut BfCallState<'_>) -> Result<BfRet, Error> {
     if bf_args.args.len() != 1 {
-        return Err(E_INVARG);
+        return Err(E_ARGS);
     }
 
     let x = match bf_args.args[0].variant() {
@@ -196,7 +196,7 @@ bf_declare!(asin, bf_asin);
 
 fn bf_acos(bf_args: &mut BfCallState<'_>) -> Result<BfRet, Error> {
     if bf_args.args.len() != 1 {
-        return Err(E_INVARG);
+        return Err(E_ARGS);
     }
 
     let x = match bf_args.args[0].variant() {
@@ -214,7 +214,7 @@ bf_declare!(acos, bf_acos);
 
 fn bf_atan(bf_args: &mut BfCallState<'_>) -> Result<BfRet, Error> {
     if bf_args.args.is_empty() || bf_args.args.len() > 2 {
-        return Err(E_INVARG);
+        return Err(E_ARGS);
     }
 
     let y = match bf_args.args[0].variant() {
@@ -233,7 +233,7 @@ bf_declare!(atan, bf_atan);
 
 fn bf_sinh(bf_args: &mut BfCallState<'_>) -> Result<BfRet, Error> {
     if bf_args.args.len() != 1 {
-        return Err(E_INVARG);
+        return Err(E_ARGS);
     }
 
     let x = match bf_args.args[0].variant() {
@@ -247,7 +247,7 @@ bf_declare!(sinh, bf_sinh);
 
 fn bf_cosh(bf_args: &mut BfCallState<'_>) -> Result<BfRet, Error> {
     if bf_args.args.len() != 1 {
-        return Err(E_INVARG);
+        return Err(E_ARGS);
     }
 
     let x = match bf_args.args[0].variant() {
@@ -261,7 +261,7 @@ bf_declare!(cosh, bf_cosh);
 
 fn bf_tanh(bf_args: &mut BfCallState<'_>) -> Result<BfRet, Error> {
     if bf_args.args.len() != 1 {
-        return Err(E_INVARG);
+        return Err(E_ARGS);
     }
 
     let x = match bf_args.args[0].variant() {
@@ -275,7 +275,7 @@ bf_declare!(tanh, bf_tanh);
 
 fn bf_exp(bf_args: &mut BfCallState<'_>) -> Result<BfRet, Error> {
     if bf_args.args.len() != 1 {
-        return Err(E_INVARG);
+        return Err(E_ARGS);
     }
 
     let x = match bf_args.args[0].variant() {
@@ -289,7 +289,7 @@ bf_declare!(exp, bf_exp);
 
 fn bf_log(bf_args: &mut BfCallState<'_>) -> Result<BfRet, Error> {
     if bf_args.args.len() != 1 {
-        return Err(E_INVARG);
+        return Err(E_ARGS);
     }
 
     let x = match bf_args.args[0].variant() {
@@ -307,7 +307,7 @@ bf_declare!(log, bf_log);
 
 fn bf_log10(bf_args: &mut BfCallState<'_>) -> Result<BfRet, Error> {
     if bf_args.args.len() != 1 {
-        return Err(E_INVARG);
+        return Err(E_ARGS);
     }
 
     let x = match bf_args.args[0].variant() {
@@ -325,7 +325,7 @@ bf_declare!(log10, bf_log10);
 
 fn bf_ceil(bf_args: &mut BfCallState<'_>) -> Result<BfRet, Error> {
     if bf_args.args.len() != 1 {
-        return Err(E_INVARG);
+        return Err(E_ARGS);
     }
 
     let x = match bf_args.args[0].variant() {
@@ -339,7 +339,7 @@ bf_declare!(ceil, bf_ceil);
 
 fn bf_floor(bf_args: &mut BfCallState<'_>) -> Result<BfRet, Error> {
     if bf_args.args.len() != 1 {
-        return Err(E_INVARG);
+        return Err(E_ARGS);
     }
 
     let x = match bf_args.args[0].variant() {
@@ -353,7 +353,7 @@ bf_declare!(floor, bf_floor);
 
 fn bf_trunc(bf_args: &mut BfCallState<'_>) -> Result<BfRet, Error> {
     if bf_args.args.len() != 1 {
-        return Err(E_INVARG);
+        return Err(E_ARGS);
     }
 
     let x = match bf_args.args[0].variant() {

--- a/crates/kernel/src/builtins/bf_objects.rs
+++ b/crates/kernel/src/builtins/bf_objects.rs
@@ -40,7 +40,7 @@ Returns a non-zero integer (i.e., a true value) if object is a valid object (one
 */
 fn bf_valid(bf_args: &mut BfCallState<'_>) -> Result<BfRet, Error> {
     if bf_args.args.len() != 1 {
-        return Err(E_INVARG);
+        return Err(E_ARGS);
     }
     let Variant::Obj(obj) = bf_args.args[0].variant() else {
         return Err(E_TYPE);
@@ -52,7 +52,7 @@ bf_declare!(valid, bf_valid);
 
 fn bf_parent(bf_args: &mut BfCallState<'_>) -> Result<BfRet, Error> {
     if bf_args.args.len() != 1 {
-        return Err(E_INVARG);
+        return Err(E_ARGS);
     }
     let Variant::Obj(obj) = bf_args.args[0].variant() else {
         return Err(E_TYPE);
@@ -70,7 +70,7 @@ bf_declare!(parent, bf_parent);
 
 fn bf_chparent(bf_args: &mut BfCallState<'_>) -> Result<BfRet, Error> {
     if bf_args.args.len() != 2 {
-        return Err(E_INVARG);
+        return Err(E_ARGS);
     }
     let Variant::Obj(obj) = bf_args.args[0].variant() else {
         return Err(E_TYPE);
@@ -88,7 +88,7 @@ bf_declare!(chparent, bf_chparent);
 
 fn bf_children(bf_args: &mut BfCallState<'_>) -> Result<BfRet, Error> {
     if bf_args.args.len() != 1 {
-        return Err(E_INVARG);
+        return Err(E_ARGS);
     }
     let Variant::Obj(obj) = bf_args.args[0].variant() else {
         return Err(E_TYPE);
@@ -190,7 +190,7 @@ const BF_RECYCLE_TRAMPOLINE_CALL_EXITFUNC: usize = 0;
 const BF_RECYCLE_TRAMPOLINE_DONE_MOVE: usize = 1;
 fn bf_recycle(bf_args: &mut BfCallState<'_>) -> Result<BfRet, Error> {
     if bf_args.args.len() != 1 {
-        return Err(E_INVARG);
+        return Err(E_ARGS);
     }
     let Variant::Obj(obj) = bf_args.args[0].variant() else {
         return Err(E_TYPE);
@@ -336,7 +336,7 @@ bf_declare!(recycle, bf_recycle);
 
 fn bf_max_object(bf_args: &mut BfCallState<'_>) -> Result<BfRet, Error> {
     if !bf_args.args.is_empty() {
-        return Err(E_INVARG);
+        return Err(E_ARGS);
     }
     let max_obj = bf_args
         .world_state
@@ -353,7 +353,7 @@ const BF_MOVE_TRAMPOLINE_DONE: usize = 3;
 
 fn bf_move(bf_args: &mut BfCallState<'_>) -> Result<BfRet, Error> {
     if bf_args.args.len() != 2 {
-        return Err(E_INVARG);
+        return Err(E_ARGS);
     }
     let Variant::Obj(what) = bf_args.args[0].variant() else {
         return Err(E_TYPE);
@@ -565,7 +565,7 @@ bf_declare!(move, bf_move);
 
 fn bf_verbs(bf_args: &mut BfCallState<'_>) -> Result<BfRet, Error> {
     if bf_args.args.len() != 1 {
-        return Err(E_INVARG);
+        return Err(E_ARGS);
     }
     let Variant::Obj(obj) = bf_args.args[0].variant() else {
         return Err(E_TYPE);
@@ -588,7 +588,7 @@ Returns a list of the names of the properties defined directly on the given obje
  */
 fn bf_properties(bf_args: &mut BfCallState<'_>) -> Result<BfRet, Error> {
     if bf_args.args.len() != 1 {
-        return Err(E_INVARG);
+        return Err(E_ARGS);
     }
     let Variant::Obj(obj) = bf_args.args[0].variant() else {
         return Err(E_TYPE);
@@ -604,7 +604,7 @@ bf_declare!(properties, bf_properties);
 
 fn bf_set_player_flag(bf_args: &mut BfCallState<'_>) -> Result<BfRet, Error> {
     if bf_args.args.len() != 2 {
-        return Err(E_INVARG);
+        return Err(E_ARGS);
     }
 
     let (Variant::Obj(obj), Variant::Int(f)) =
@@ -650,7 +650,7 @@ bf_declare!(set_player_flag, bf_set_player_flag);
 
 fn bf_players(bf_args: &mut BfCallState<'_>) -> Result<BfRet, Error> {
     if !bf_args.args.is_empty() {
-        return Err(E_INVARG);
+        return Err(E_ARGS);
     }
     let players = bf_args.world_state.players().map_err(world_state_err)?;
 

--- a/crates/kernel/src/builtins/bf_properties.rs
+++ b/crates/kernel/src/builtins/bf_properties.rs
@@ -17,7 +17,7 @@ use std::sync::Arc;
 use moor_values::model::world_state_err;
 use moor_values::model::{PropAttrs, PropFlag};
 use moor_values::util::BitEnum;
-use moor_values::var::Error::{E_INVARG, E_TYPE};
+use moor_values::var::Error::{E_ARGS, E_INVARG, E_TYPE};
 use moor_values::var::Variant;
 use moor_values::var::{v_bool, v_list, v_none, v_objid, v_string, Var};
 use moor_values::var::{v_empty_list, Error};
@@ -32,7 +32,7 @@ use moor_compiler::offset_for_builtin;
 //  {<owner>, <perms> }
 fn bf_property_info(bf_args: &mut BfCallState<'_>) -> Result<BfRet, Error> {
     if bf_args.args.len() != 2 {
-        return Err(E_INVARG);
+        return Err(E_ARGS);
     }
     let Variant::Obj(obj) = bf_args.args[0].variant() else {
         return Err(E_TYPE);
@@ -70,7 +70,7 @@ enum InfoParseResult {
 
 fn info_to_prop_attrs(info: &[Var]) -> InfoParseResult {
     if info.len() < 2 || info.len() > 3 {
-        return InfoParseResult::Fail(E_INVARG);
+        return InfoParseResult::Fail(E_ARGS);
     }
     let Variant::Obj(owner) = info[0].variant() else {
         return InfoParseResult::Fail(E_TYPE);
@@ -108,7 +108,7 @@ fn info_to_prop_attrs(info: &[Var]) -> InfoParseResult {
 
 fn bf_set_property_info(bf_args: &mut BfCallState<'_>) -> Result<BfRet, Error> {
     if bf_args.args.len() != 3 {
-        return Err(E_INVARG);
+        return Err(E_ARGS);
     }
     let Variant::Obj(obj) = bf_args.args[0].variant() else {
         return Err(E_TYPE);
@@ -137,7 +137,7 @@ bf_declare!(set_property_info, bf_set_property_info);
 
 fn bf_is_clear_property(bf_args: &mut BfCallState<'_>) -> Result<BfRet, Error> {
     if bf_args.args.len() != 2 {
-        return Err(E_INVARG);
+        return Err(E_ARGS);
     }
     let Variant::Obj(obj) = bf_args.args[0].variant() else {
         return Err(E_TYPE);
@@ -155,7 +155,7 @@ bf_declare!(is_clear_property, bf_is_clear_property);
 
 fn bf_clear_property(bf_args: &mut BfCallState<'_>) -> Result<BfRet, Error> {
     if bf_args.args.len() != 2 {
-        return Err(E_INVARG);
+        return Err(E_ARGS);
     }
     let Variant::Obj(obj) = bf_args.args[0].variant() else {
         return Err(E_TYPE);
@@ -174,7 +174,7 @@ bf_declare!(set_clear_property, bf_clear_property);
 // add_property (obj <object>, str <prop-name>, <value>, list <info>) => none
 fn bf_add_property(bf_args: &mut BfCallState<'_>) -> Result<BfRet, Error> {
     if bf_args.args.len() != 4 {
-        return Err(E_INVARG);
+        return Err(E_ARGS);
     }
 
     let (Variant::Obj(location), Variant::Str(name), value, Variant::List(info)) = (
@@ -211,7 +211,7 @@ bf_declare!(add_property, bf_add_property);
 
 fn bf_delete_property(bf_args: &mut BfCallState<'_>) -> Result<BfRet, Error> {
     if bf_args.args.len() != 2 {
-        return Err(E_INVARG);
+        return Err(E_ARGS);
     }
     let Variant::Obj(obj) = bf_args.args[0].variant() else {
         return Err(E_TYPE);

--- a/crates/kernel/src/builtins/bf_server.rs
+++ b/crates/kernel/src/builtins/bf_server.rs
@@ -49,7 +49,7 @@ bf_declare!(noop, bf_noop);
 
 fn bf_notify(bf_args: &mut BfCallState<'_>) -> Result<BfRet, Error> {
     if bf_args.args.len() != 2 {
-        return Err(E_INVARG);
+        return Err(E_ARGS);
     }
     let player = bf_args.args[0].variant();
     let Variant::Obj(player) = player else {
@@ -87,7 +87,7 @@ bf_declare!(notify, bf_notify);
 
 fn bf_connected_players(bf_args: &mut BfCallState<'_>) -> Result<BfRet, Error> {
     if !bf_args.args.is_empty() {
-        return Err(E_INVARG);
+        return Err(E_ARGS);
     }
 
     Ok(Ret(v_listv(
@@ -104,7 +104,7 @@ bf_declare!(connected_players, bf_connected_players);
 
 fn bf_is_player(bf_args: &mut BfCallState<'_>) -> Result<BfRet, Error> {
     if bf_args.args.len() != 1 {
-        return Err(E_INVARG);
+        return Err(E_ARGS);
     }
     let player = bf_args.args[0].variant();
     let Variant::Obj(player) = player else {
@@ -122,7 +122,7 @@ bf_declare!(is_player, bf_is_player);
 
 fn bf_caller_perms(bf_args: &mut BfCallState<'_>) -> Result<BfRet, Error> {
     if !bf_args.args.is_empty() {
-        return Err(E_INVARG);
+        return Err(E_ARGS);
     }
 
     Ok(Ret(v_objid(bf_args.caller_perms())))
@@ -131,7 +131,7 @@ bf_declare!(caller_perms, bf_caller_perms);
 
 fn bf_set_task_perms(bf_args: &mut BfCallState<'_>) -> Result<BfRet, Error> {
     if bf_args.args.len() != 1 {
-        return Err(E_INVARG);
+        return Err(E_ARGS);
     }
     let Variant::Obj(perms_for) = bf_args.args[0].variant().clone() else {
         return Err(E_TYPE);
@@ -150,7 +150,7 @@ bf_declare!(set_task_perms, bf_set_task_perms);
 
 fn bf_callers(bf_args: &mut BfCallState<'_>) -> Result<BfRet, Error> {
     if !bf_args.args.is_empty() {
-        return Err(E_INVARG);
+        return Err(E_ARGS);
     }
 
     // We have to exempt ourselves from the callers list.
@@ -182,7 +182,7 @@ bf_declare!(callers, bf_callers);
 
 fn bf_task_id(bf_args: &mut BfCallState<'_>) -> Result<BfRet, Error> {
     if !bf_args.args.is_empty() {
-        return Err(E_INVARG);
+        return Err(E_ARGS);
     }
 
     Ok(Ret(v_int(bf_args.exec_state.task_id as i64)))
@@ -191,7 +191,7 @@ bf_declare!(task_id, bf_task_id);
 
 fn bf_idle_seconds(bf_args: &mut BfCallState<'_>) -> Result<BfRet, Error> {
     if bf_args.args.len() != 1 {
-        return Err(E_INVARG);
+        return Err(E_ARGS);
     }
     let Variant::Obj(who) = bf_args.args[0].variant() else {
         return Err(E_TYPE);
@@ -206,7 +206,7 @@ bf_declare!(idle_seconds, bf_idle_seconds);
 
 fn bf_connected_seconds(bf_args: &mut BfCallState<'_>) -> Result<BfRet, Error> {
     if bf_args.args.len() != 1 {
-        return Err(E_INVARG);
+        return Err(E_ARGS);
     }
     let Variant::Obj(who) = bf_args.args[0].variant() else {
         return Err(E_TYPE);
@@ -228,7 +228,7 @@ Returns a network-specific string identifying the connection being used by the g
  */
 fn bf_connection_name(bf_args: &mut BfCallState<'_>) -> Result<BfRet, Error> {
     if bf_args.args.len() != 1 {
-        return Err(E_INVARG);
+        return Err(E_ARGS);
     }
 
     let Variant::Obj(player) = bf_args.args[0].variant() else {
@@ -256,7 +256,7 @@ bf_declare!(connection_name, bf_connection_name);
 
 fn bf_shutdown(bf_args: &mut BfCallState<'_>) -> Result<BfRet, Error> {
     if bf_args.args.len() > 1 {
-        return Err(E_INVARG);
+        return Err(E_ARGS);
     }
     let msg = if bf_args.args.is_empty() {
         None
@@ -286,7 +286,7 @@ bf_declare!(shutdown, bf_shutdown);
 
 fn bf_time(bf_args: &mut BfCallState<'_>) -> Result<BfRet, Error> {
     if !bf_args.args.is_empty() {
-        return Err(E_INVARG);
+        return Err(E_ARGS);
     }
     Ok(Ret(v_int(
         SystemTime::now()
@@ -299,7 +299,7 @@ bf_declare!(time, bf_time);
 
 fn bf_ctime(bf_args: &mut BfCallState<'_>) -> Result<BfRet, Error> {
     if bf_args.args.len() > 1 {
-        return Err(E_INVARG);
+        return Err(E_ARGS);
     }
     let time = if bf_args.args.is_empty() {
         SystemTime::now()
@@ -335,7 +335,7 @@ fn bf_raise(bf_args: &mut BfCallState<'_>) -> Result<BfRet, Error> {
     // and <value>, which defaults to zero, are made available to any `try'-`except' statements that catch the error.  If the error is not caught, then <message> will
     // appear on the first line of the traceback printed to the user.
     if bf_args.args.is_empty() || bf_args.args.len() > 3 {
-        return Err(E_INVARG);
+        return Err(E_ARGS);
     }
 
     let Variant::Err(err) = bf_args.args[0].variant() else {
@@ -351,7 +351,7 @@ bf_declare!(raise, bf_raise);
 
 fn bf_server_version(bf_args: &mut BfCallState<'_>) -> Result<BfRet, Error> {
     if !bf_args.args.is_empty() {
-        return Err(E_INVARG);
+        return Err(E_ARGS);
     }
     // TODO: Support server version flag passed down the pipe, rather than hardcoded
     //   This is a placeholder for now, should be set by the server on startup. But right now
@@ -367,7 +367,7 @@ fn bf_suspend(bf_args: &mut BfCallState<'_>) -> Result<BfRet, Error> {
     // Suspends the current task for <seconds> seconds.  If <seconds> is not specified, the task is suspended indefinitely.  The task may be resumed early by
     // calling `resume' on it.
     if bf_args.args.len() > 1 {
-        return Err(E_INVARG);
+        return Err(E_ARGS);
     }
 
     let seconds = if bf_args.args.is_empty() {
@@ -385,7 +385,7 @@ bf_declare!(suspend, bf_suspend);
 
 fn bf_read(bf_args: &mut BfCallState<'_>) -> Result<BfRet, Error> {
     if bf_args.args.len() > 1 {
-        return Err(E_INVARG);
+        return Err(E_ARGS);
     }
 
     // We don't actually support reading from arbitrary connections that aren't the current player,
@@ -413,7 +413,7 @@ bf_declare!(read, bf_read);
 
 fn bf_queued_tasks(bf_args: &mut BfCallState<'_>) -> Result<BfRet, Error> {
     if !bf_args.args.is_empty() {
-        return Err(E_INVARG);
+        return Err(E_ARGS);
     }
 
     // Ask the scheduler (through its mailbox) to describe all the queued tasks.
@@ -464,7 +464,7 @@ fn bf_kill_task(bf_args: &mut BfCallState<'_>) -> Result<BfRet, Error> {
     //
     // Kills the task with the given <task-id>.  The task must be queued or suspended, and the current task must be the owner of the task being killed.
     if bf_args.args.len() != 1 {
-        return Err(E_INVARG);
+        return Err(E_ARGS);
     }
 
     let Variant::Int(victim_task_id) = bf_args.args[0].variant() else {
@@ -503,7 +503,7 @@ bf_declare!(kill_task, bf_kill_task);
 
 fn bf_resume(bf_args: &mut BfCallState<'_>) -> Result<BfRet, Error> {
     if bf_args.args.len() < 2 {
-        return Err(E_INVARG);
+        return Err(E_ARGS);
     }
 
     let Variant::Int(resume_task_id) = bf_args.args[0].variant() else {
@@ -551,7 +551,7 @@ fn bf_ticks_left(bf_args: &mut BfCallState<'_>) -> Result<BfRet, Error> {
     //
     // Returns the number of ticks left in the current time slice.
     if !bf_args.args.is_empty() {
-        return Err(E_INVARG);
+        return Err(E_ARGS);
     }
 
     let ticks_left = bf_args.exec_state.tick_slice - bf_args.exec_state.tick_count;
@@ -565,7 +565,7 @@ fn bf_seconds_left(bf_args: &mut BfCallState<'_>) -> Result<BfRet, Error> {
     //
     // Returns the number of seconds left in the current time slice.
     if !bf_args.args.is_empty() {
-        return Err(E_INVARG);
+        return Err(E_ARGS);
     }
 
     let seconds_left = match bf_args.exec_state.time_left() {
@@ -582,7 +582,7 @@ fn bf_boot_player(bf_args: &mut BfCallState<'_>) -> Result<BfRet, Error> {
     //
     // Disconnects the player with the given object number.
     if bf_args.args.len() != 1 {
-        return Err(E_INVARG);
+        return Err(E_ARGS);
     }
 
     let Variant::Obj(player) = bf_args.args[0].variant() else {
@@ -614,7 +614,7 @@ fn bf_call_function(bf_args: &mut BfCallState<'_>) -> Result<BfRet, Error> {
     //
     // Calls the given function with the given arguments and returns the result.
     if bf_args.args.is_empty() {
-        return Err(E_INVARG);
+        return Err(E_ARGS);
     }
 
     let Variant::Str(func_name) = bf_args.args[0].variant() else {
@@ -649,7 +649,7 @@ is not a wizard, then `E_PERM' is raised.  If <is-error> is provided and true, t
 */
 fn bf_server_log(bf_args: &mut BfCallState<'_>) -> Result<BfRet, Error> {
     if bf_args.args.is_empty() || bf_args.args.len() > 2 {
-        return Err(E_INVARG);
+        return Err(E_ARGS);
     }
 
     let Variant::Str(message) = bf_args.args[0].variant() else {
@@ -721,7 +721,7 @@ fn bf_function_info_to_list(bf: &Builtin) -> Var {
 
 fn bf_function_info(bf_args: &mut BfCallState<'_>) -> Result<BfRet, Error> {
     if bf_args.args.len() > 1 {
-        return Err(E_INVARG);
+        return Err(E_ARGS);
     }
 
     if bf_args.args.len() == 1 {
@@ -749,7 +749,7 @@ bf_declare!(function_info, bf_function_info);
 
 fn bf_listeners(bf_args: &mut BfCallState<'_>) -> Result<BfRet, Error> {
     if !bf_args.args.is_empty() {
-        return Err(E_INVARG);
+        return Err(E_ARGS);
     }
 
     // TODO: Return something better from bf_listeners, rather than hardcoded value
@@ -829,7 +829,7 @@ bf_declare!(dump_database, bf_dump_database);
 
 fn bf_memory_usage(bf_args: &mut BfCallState<'_>) -> Result<BfRet, Error> {
     if !bf_args.args.is_empty() {
-        return Err(E_INVARG);
+        return Err(E_ARGS);
     }
 
     // Must be wizard.
@@ -886,7 +886,7 @@ fn db_disk_size(bf_args: &mut BfCallState<'_>) -> Result<BfRet, Error> {
     //
     // Returns the number of bytes currently occupied by the database on disk.
     if !bf_args.args.is_empty() {
-        return Err(E_INVARG);
+        return Err(E_ARGS);
     }
 
     // Must be wizard.

--- a/crates/kernel/src/builtins/bf_strings.rs
+++ b/crates/kernel/src/builtins/bf_strings.rs
@@ -19,7 +19,7 @@ use rand::distributions::Alphanumeric;
 use rand::Rng;
 
 use moor_values::var::Error;
-use moor_values::var::Error::{E_INVARG, E_TYPE};
+use moor_values::var::Error::{E_ARGS, E_INVARG, E_TYPE};
 use moor_values::var::Variant;
 use moor_values::var::{v_int, v_str, v_string};
 
@@ -63,7 +63,7 @@ fn bf_strsub(bf_args: &mut BfCallState<'_>) -> Result<BfRet, Error> {
         };
         *case_matters == 1
     } else {
-        return Err(E_INVARG);
+        return Err(E_ARGS);
     };
     let (subject, what, with) = (
         bf_args.args[0].variant(),
@@ -112,7 +112,7 @@ fn bf_index(bf_args: &mut BfCallState<'_>) -> Result<BfRet, Error> {
         };
         *case_matters == 1
     } else {
-        return Err(E_INVARG);
+        return Err(E_ARGS);
     };
 
     let (subject, what) = (bf_args.args[0].variant(), bf_args.args[1].variant());
@@ -136,7 +136,7 @@ fn bf_rindex(bf_args: &mut BfCallState<'_>) -> Result<BfRet, Error> {
         };
         *case_matters == 1
     } else {
-        return Err(E_INVARG);
+        return Err(E_ARGS);
     };
 
     let (subject, what) = (bf_args.args[0].variant(), bf_args.args[1].variant());
@@ -153,7 +153,7 @@ bf_declare!(rindex, bf_rindex);
 
 fn bf_strcmp(bf_args: &mut BfCallState<'_>) -> Result<BfRet, Error> {
     if bf_args.args.len() != 2 {
-        return Err(E_INVARG);
+        return Err(E_ARGS);
     }
     let (str1, str2) = (bf_args.args[0].variant(), bf_args.args[1].variant());
     match (str1, str2) {
@@ -176,7 +176,7 @@ encryption "salt" in the algorithm. If salt is not provided, a random pair of ch
 */
 fn bf_crypt(bf_args: &mut BfCallState<'_>) -> Result<BfRet, Error> {
     if bf_args.args.is_empty() || bf_args.args.len() > 2 {
-        return Err(E_INVARG);
+        return Err(E_ARGS);
     }
 
     let salt = if bf_args.args.len() == 1 {
@@ -210,7 +210,7 @@ bf_declare!(crypt, bf_crypt);
 
 fn bf_string_hash(bf_args: &mut BfCallState<'_>) -> Result<BfRet, Error> {
     if bf_args.args.len() != 1 {
-        return Err(E_INVARG);
+        return Err(E_ARGS);
     }
     match bf_args.args[0].variant() {
         Variant::Str(s) => {

--- a/crates/kernel/src/builtins/bf_values.rs
+++ b/crates/kernel/src/builtins/bf_values.rs
@@ -17,7 +17,7 @@ use std::hash::{Hash, Hasher};
 use std::sync::Arc;
 
 use moor_values::var::Error;
-use moor_values::var::Error::{E_INVARG, E_TYPE};
+use moor_values::var::Error::{E_ARGS, E_INVARG, E_TYPE};
 use moor_values::var::Variant;
 use moor_values::var::{v_bool, v_float, v_int, v_obj, v_str};
 use moor_values::AsByteBuffer;
@@ -53,7 +53,7 @@ bf_declare!(tostr, bf_tostr);
 
 fn bf_toliteral(bf_args: &mut BfCallState<'_>) -> Result<BfRet, Error> {
     if bf_args.args.len() != 1 {
-        return Err(E_INVARG);
+        return Err(E_ARGS);
     }
     let literal = bf_args.args[0].to_literal();
     Ok(Ret(v_str(literal.as_str())))
@@ -62,7 +62,7 @@ bf_declare!(toliteral, bf_toliteral);
 
 fn bf_toint(bf_args: &mut BfCallState<'_>) -> Result<BfRet, Error> {
     if bf_args.args.len() != 1 {
-        return Err(E_INVARG);
+        return Err(E_ARGS);
     }
     match bf_args.args[0].variant() {
         Variant::Int(i) => Ok(Ret(v_int(*i))),
@@ -83,7 +83,7 @@ bf_declare!(toint, bf_toint);
 
 fn bf_toobj(bf_args: &mut BfCallState<'_>) -> Result<BfRet, Error> {
     if bf_args.args.len() != 1 {
-        return Err(E_INVARG);
+        return Err(E_ARGS);
     }
     match bf_args.args[0].variant() {
         Variant::Int(i) => Ok(Ret(v_obj(*i))),
@@ -109,7 +109,7 @@ bf_declare!(toobj, bf_toobj);
 
 fn bf_tofloat(bf_args: &mut BfCallState<'_>) -> Result<BfRet, Error> {
     if bf_args.args.len() != 1 {
-        return Err(E_INVARG);
+        return Err(E_ARGS);
     }
     match bf_args.args[0].variant() {
         Variant::Int(i) => Ok(Ret(v_float(*i as f64))),
@@ -129,7 +129,7 @@ bf_declare!(tofloat, bf_tofloat);
 
 fn bf_equal(bf_args: &mut BfCallState<'_>) -> Result<BfRet, Error> {
     if bf_args.args.len() != 2 {
-        return Err(E_INVARG);
+        return Err(E_ARGS);
     }
     let result = match (bf_args.args[0].variant(), bf_args.args[1].variant()) {
         (Variant::Str(s1), Variant::Str(s2)) => s1.as_str() == s2.as_str().to_lowercase(),
@@ -141,7 +141,7 @@ bf_declare!(equal, bf_equal);
 
 fn bf_value_bytes(bf_args: &mut BfCallState<'_>) -> Result<BfRet, Error> {
     if bf_args.args.len() != 1 {
-        return Err(E_INVARG);
+        return Err(E_ARGS);
     }
     let count = bf_args.args[0].size_bytes();
     Ok(Ret(v_int(count as i64)))
@@ -150,7 +150,7 @@ bf_declare!(value_bytes, bf_value_bytes);
 
 fn bf_value_hash(bf_args: &mut BfCallState<'_>) -> Result<BfRet, Error> {
     if bf_args.args.len() != 1 {
-        return Err(E_INVARG);
+        return Err(E_ARGS);
     }
     let mut s = DefaultHasher::new();
     bf_args.args[0].hash(&mut s);
@@ -160,7 +160,7 @@ bf_declare!(value_hash, bf_value_hash);
 
 fn bf_length(bf_args: &mut BfCallState<'_>) -> Result<BfRet, Error> {
     if bf_args.args.len() != 1 {
-        return Err(E_INVARG);
+        return Err(E_ARGS);
     }
 
     match bf_args.args[0].variant() {
@@ -173,7 +173,7 @@ bf_declare!(length, bf_length);
 
 fn bf_object_bytes(bf_args: &mut BfCallState<'_>) -> Result<BfRet, Error> {
     if bf_args.args.len() != 1 {
-        return Err(E_INVARG);
+        return Err(E_ARGS);
     }
     let Variant::Obj(o) = bf_args.args[0].variant() else {
         return Err(E_INVARG);

--- a/crates/kernel/src/builtins/bf_verbs.rs
+++ b/crates/kernel/src/builtins/bf_verbs.rs
@@ -25,7 +25,7 @@ use moor_values::model::{world_state_err, WorldStateError};
 use moor_values::model::{ArgSpec, VerbArgsSpec};
 use moor_values::model::{BinaryType, VerbAttrs, VerbFlag};
 use moor_values::util::BitEnum;
-use moor_values::var::Error::{E_INVARG, E_INVIND, E_PERM, E_TYPE, E_VERBNF};
+use moor_values::var::Error::{E_ARGS, E_INVARG, E_INVIND, E_PERM, E_TYPE, E_VERBNF};
 use moor_values::var::List;
 use moor_values::var::Objid;
 use moor_values::var::Variant;
@@ -47,7 +47,7 @@ use moor_compiler::Program;
 // verb_info (obj <object>, str <verb-desc>) ->  {<owner>, <perms>, <names>}
 fn bf_verb_info(bf_args: &mut BfCallState<'_>) -> Result<BfRet, Error> {
     if bf_args.args.len() != 2 {
-        return Err(E_INVARG);
+        return Err(E_ARGS);
     }
     let Variant::Obj(obj) = bf_args.args[0].variant() else {
         return Err(E_TYPE);
@@ -139,7 +139,7 @@ fn get_verbdef(
 
 fn parse_verb_info(info: &List) -> Result<VerbAttrs, Error> {
     if info.len() != 3 {
-        return Err(E_INVARG);
+        return Err(E_ARGS);
     }
     match (info[0].variant(), info[1].variant(), info[2].variant()) {
         (Variant::Obj(owner), Variant::Str(perms_str), Variant::Str(names)) => {
@@ -178,7 +178,7 @@ fn parse_verb_info(info: &List) -> Result<VerbAttrs, Error> {
 // set_verb_info (obj <object>, str <verb-desc>, list <info>) => none
 fn bf_set_verb_info(bf_args: &mut BfCallState<'_>) -> Result<BfRet, Error> {
     if bf_args.args.len() != 3 {
-        return Err(E_INVARG);
+        return Err(E_ARGS);
     }
     let Variant::Obj(obj) = bf_args.args[0].variant() else {
         return Err(E_TYPE);
@@ -227,7 +227,7 @@ bf_declare!(set_verb_info, bf_set_verb_info);
 
 fn bf_verb_args(bf_args: &mut BfCallState<'_>) -> Result<BfRet, Error> {
     if bf_args.args.len() != 2 {
-        return Err(E_INVARG);
+        return Err(E_ARGS);
     }
     let Variant::Obj(obj) = bf_args.args[0].variant() else {
         return Err(E_TYPE);
@@ -254,7 +254,7 @@ bf_declare!(verb_args, bf_verb_args);
 
 fn parse_verb_args(verbinfo: &List) -> Result<VerbArgsSpec, Error> {
     if verbinfo.len() != 3 {
-        return Err(E_INVARG);
+        return Err(E_ARGS);
     }
     match (
         verbinfo[0].variant(),
@@ -278,7 +278,7 @@ fn parse_verb_args(verbinfo: &List) -> Result<VerbArgsSpec, Error> {
 // set_verb_args (obj <object>, str <verb-desc>, list <args>) => none
 fn bf_set_verb_args(bf_args: &mut BfCallState<'_>) -> Result<BfRet, Error> {
     if bf_args.args.len() != 3 {
-        return Err(E_INVARG);
+        return Err(E_ARGS);
     }
     let Variant::Obj(obj) = bf_args.args[0].variant() else {
         return Err(E_TYPE);
@@ -336,7 +336,7 @@ bf_declare!(set_verb_args, bf_set_verb_args);
 fn bf_verb_code(bf_args: &mut BfCallState<'_>) -> Result<BfRet, Error> {
     //verb_code (obj object, str verb-desc [, fully-paren [, indent]]) => list
     if bf_args.args.len() < 2 || bf_args.args.len() > 4 {
-        return Err(E_INVARG);
+        return Err(E_ARGS);
     }
     let Variant::Obj(obj) = bf_args.args[0].variant() else {
         return Err(E_TYPE);
@@ -413,7 +413,7 @@ bf_declare!(verb_code, bf_verb_code);
 fn bf_set_verb_code(bf_args: &mut BfCallState<'_>) -> Result<BfRet, Error> {
     //set_verb_code (obj object, str verb-desc, list code) => none
     if bf_args.args.len() != 3 {
-        return Err(E_INVARG);
+        return Err(E_ARGS);
     }
     let Variant::Obj(obj) = bf_args.args[0].variant() else {
         return Err(E_TYPE);
@@ -490,7 +490,7 @@ bf_declare!(set_verb_code, bf_set_verb_code);
 // Function: none add_verb (obj object, list info, list args)
 fn bf_add_verb(bf_args: &mut BfCallState<'_>) -> Result<BfRet, Error> {
     if bf_args.args.len() != 3 {
-        return Err(E_INVARG);
+        return Err(E_ARGS);
     }
     let Variant::Obj(obj) = bf_args.args[0].variant() else {
         return Err(E_TYPE);
@@ -538,7 +538,7 @@ bf_declare!(add_verb, bf_add_verb);
 //Function: none delete_verb (obj object, str verb-desc)
 fn bf_delete_verb(bf_args: &mut BfCallState<'_>) -> Result<BfRet, Error> {
     if bf_args.args.len() != 2 {
-        return Err(E_INVARG);
+        return Err(E_ARGS);
     }
     let Variant::Obj(obj) = bf_args.args[0].variant() else {
         return Err(E_TYPE);
@@ -578,7 +578,7 @@ bf_declare!(delete_verb, bf_delete_verb);
 // the output of `disassemble()' interesting to peruse as a way to gain a deeper appreciation of how the server works.
 fn bf_disassemble(bf_args: &mut BfCallState<'_>) -> Result<BfRet, Error> {
     if bf_args.args.len() != 2 {
-        return Err(E_INVARG);
+        return Err(E_ARGS);
     }
     let Variant::Obj(obj) = bf_args.args[0].variant() else {
         return Err(E_TYPE);


### PR DESCRIPTION
```
E_ARGS      Incorrect number of arguments
E_INVARG    Invalid argument
```

We're raising `E_INVARG` where we should instead raise `E_ARGS`. I've been fixing these as they're caught by test cases, but 1. I'm not sure they'll *all* be covered by tests ever, and 2. let's just get through them all in one go.

_If this PR changes any `E_INVARG` that is *not* about "wrong number of arguments", then that is a mistake_