### PR TITLE
fix: task tick slicing logic

### DIFF
--- a/crates/kernel/src/builtins/bf_server.rs
+++ b/crates/kernel/src/builtins/bf_server.rs
@@ -566,7 +566,10 @@ fn bf_ticks_left(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
         return Err(BfErr::Code(E_ARGS));
     }
 
-    let ticks_left = bf_args.exec_state.tick_slice - bf_args.exec_state.tick_count;
+    let ticks_left = bf_args
+        .exec_state
+        .max_ticks
+        .saturating_sub(bf_args.exec_state.tick_count);
 
     Ok(Ret(v_int(ticks_left as i64)))
 }

--- a/crates/kernel/src/tasks/vm_host.rs
+++ b/crates/kernel/src/tasks/vm_host.rs
@@ -87,7 +87,7 @@ impl VmHost {
         scheduler_control_sender: Sender<(TaskId, SchedulerControlMsg)>,
     ) -> Self {
         let vm = VM::new();
-        let vm_exec_state = VMExecState::new(task_id);
+        let vm_exec_state = VMExecState::new(task_id, max_ticks);
 
         // Created in an initial suspended state.
         Self {

--- a/crates/kernel/src/vm/exec_state.rs
+++ b/crates/kernel/src/vm/exec_state.rs
@@ -32,6 +32,8 @@ pub struct VMExecState {
     pub(crate) stack: Vec<Activation>,
     /// The tick slice for the current execution.
     pub(crate) tick_slice: usize,
+    /// The total number of ticks that the task is allowed to run.
+    pub(crate) max_ticks: usize,
     /// The number of ticks that have been executed so far.
     pub(crate) tick_count: usize,
     /// The time at which the task was started.
@@ -44,12 +46,13 @@ pub struct VMExecState {
 }
 
 impl VMExecState {
-    pub fn new(task_id: TaskId) -> Self {
+    pub fn new(task_id: TaskId, max_ticks: usize) -> Self {
         Self {
             task_id,
             stack: vec![],
             tick_count: 0,
             start_time: None,
+            max_ticks,
             tick_slice: 0,
             maximum_time: None,
             unsend: Default::default(),


### PR DESCRIPTION
The logic to aportion and then account for used ticks in the execution loop was broken. This is what was breaking long running tasks like e.g. "help intro."

At some point in some refactor I must have confused the idea of `tick_slice` with `max_ticks` and the counting of the used ticks for the task as a whole was being mixed up with the ticks for the current pass through the execution loop. And so tasks were running forever not being killed for hitting max count, but also treated further down as if they had no ticks.