### PR TITLE
Fix deadlock from `bf_read`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1704,7 +1704,6 @@ dependencies = [
  "criterion",
  "crossbeam-channel",
  "crypt-sys",
- "dashmap",
  "decorum",
  "eyre",
  "iana-time-zone",

--- a/crates/kernel/Cargo.toml
+++ b/crates/kernel/Cargo.toml
@@ -50,7 +50,6 @@ moor-values = { path = "../values" }
 ## General usefulness
 chrono.workspace = true
 crossbeam-channel.workspace = true
-dashmap.workspace = true
 decorum.workspace = true
 lazy_static.workspace = true
 libc.workspace = true

--- a/crates/kernel/src/tasks/task.rs
+++ b/crates/kernel/src/tasks/task.rs
@@ -520,11 +520,7 @@ impl Task {
             }
             TaskControlMsg::ResumeReceiveInput(state_source, input) => {
                 // We're back.
-                debug!(
-                    task_id = self.task_id,
-                    ?input,
-                    "Resuming task, with new transaction and input"
-                );
+                trace!(task_id = self.task_id, ?input, "Resuming task, with input");
                 assert!(!self.vm_host.is_running());
                 self.world_state = state_source
                     .new_world_state()

--- a/crates/kernel/src/tasks/vm_host.rs
+++ b/crates/kernel/src/tasks/vm_host.rs
@@ -33,7 +33,7 @@ use moor_values::var::Var;
 use moor_values::AsByteBuffer;
 use std::sync::Arc;
 use std::time::{Duration, SystemTime};
-use tracing::{error, trace, warn};
+use tracing::{debug, error, trace, warn};
 
 /// Return values from exec_interpreter back to the Task scheduler loop
 pub enum VMHostResponse {
@@ -360,12 +360,13 @@ impl VmHost {
 
     /// Resume what you were doing after suspension.
     pub fn resume_execution(&mut self, value: Var) {
-        // coming back from suspend, we need a return value to feed back to `bf_suspend`
+        // coming back from any suspend, we need a return value to feed back to `bf_suspend` or
+        // `bf_read()`
         self.vm_exec_state.top_mut().frame.push(value);
         self.vm_exec_state.start_time = Some(SystemTime::now());
         self.vm_exec_state.tick_count = 0;
         self.running = true;
-        trace!(task_id = self.vm_exec_state.task_id, "Resuming VMHost");
+        debug!(task_id = self.vm_exec_state.task_id, "Resuming VMHost");
     }
 
     pub fn is_running(&self) -> bool {


### PR DESCRIPTION
Didn't fully diagnose why, but the scheduler `dashmap` tasks map was deadlocking when returning from a read.

Switching back to a mutex'd hashmap fixes the problem.