### PR TITLE
Put "relbox" behind a `feature`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,20 @@ members = [
     "crates/web-host",
     "crates/console-host",
 ]
+default-members = [
+    "crates/values",
+    "crates/compiler",
+    "crates/kernel",
+    "crates/db",
+    "crates/db-wiredtiger",
+    "crates/rpc-common",
+    "crates/rpc-sync-client",
+    "crates/rpc-async-client",
+    "crates/daemon",
+    "crates/telnet-host",
+    "crates/web-host",
+    "crates/console-host",
+]
 
 [workspace.package]
 edition = "2021"

--- a/crates/daemon/Cargo.toml
+++ b/crates/daemon/Cargo.toml
@@ -12,9 +12,10 @@ keywords.workspace = true
 readme.workspace = true
 
 [dependencies]
-relbox = { path = "../relbox" }
+relbox = { path = "../relbox", optional = true }
+moor-db-relbox = { path = "../db-relbox", optional = true }
+
 moor-db = { path = "../db" }
-moor-db-relbox = { path = "../db-relbox" }
 moor-kernel = { path = "../kernel" }
 moor-values = { path = "../values" }
 rpc-common = { path = "../rpc-common" }
@@ -46,3 +47,6 @@ ed25519-dalek.workspace = true
 pem.workspace = true
 rand.workspace = true
 rusty_paseto.workspace = true
+
+[features]
+relbox = ["dep:moor-db-relbox", "dep:relbox", "moor-db/relbox"]

--- a/crates/daemon/src/main.rs
+++ b/crates/daemon/src/main.rs
@@ -22,7 +22,6 @@ use ed25519_dalek::SigningKey;
 use eyre::Report;
 
 use moor_db::DatabaseFlavour;
-use moor_db_relbox::RelBoxDatabaseBuilder;
 use pem::Pem;
 use rand::rngs::OsRng;
 use rusty_paseto::core::Key;
@@ -35,7 +34,12 @@ use moor_kernel::textdump::textdump_load;
 
 use crate::rpc_server::zmq_loop;
 
+#[cfg(feature = "relbox")]
+use moor_db_relbox::RelBoxDatabaseBuilder;
+
 mod connections;
+
+#[cfg(feature = "relbox")]
 mod connections_rb;
 mod connections_wt;
 mod rpc_server;
@@ -231,6 +235,7 @@ fn main() -> Result<(), Report> {
             info!(path = ?args.db, "Opened database");
             (db_source, freshly_made)
         }
+        #[cfg(feature = "relbox")]
         DatabaseFlavour::RelBox => {
             let db_source_builder = RelBoxDatabaseBuilder::new()
                 .with_path(args.db.clone())

--- a/crates/daemon/src/rpc_server.rs
+++ b/crates/daemon/src/rpc_server.rs
@@ -51,9 +51,11 @@ use rpc_common::{
 };
 
 use crate::connections::ConnectionsDB;
-use crate::connections_rb::ConnectionsRb;
 use crate::connections_wt::ConnectionsWT;
 use crate::rpc_session::RpcSession;
+
+#[cfg(feature = "relbox")]
+use crate::connections_rb::ConnectionsRb;
 
 pub struct RpcServer {
     keypair: Key<64>,
@@ -93,6 +95,7 @@ impl RpcServer {
             .expect("Unable to bind ZMQ PUB socket");
         let connections: Arc<dyn ConnectionsDB + Send + Sync> = match db_flavor {
             DatabaseFlavour::WiredTiger => Arc::new(ConnectionsWT::new(Some(connections_db_path))),
+            #[cfg(feature = "relbox")]
             DatabaseFlavour::RelBox => Arc::new(ConnectionsRb::new(Some(connections_db_path))),
         };
         info!(

--- a/crates/db-wiredtiger/build.rs
+++ b/crates/db-wiredtiger/build.rs
@@ -37,6 +37,8 @@ fn main() {
     println!("cargo:include={}/include", include_dir.display());
     println!("cargo:rustc-link-search=native={}", build.display());
     println!("cargo:rustc-link-lib=static=wiredtiger");
+    println!("cargo:rerun-if-changed=wrapper.h");
+    println!("cargo:rerun-if-changed=build.rs");
 
     // Link to the generated wiredtiger library
     println!("cargo:rustc-link-lib=wiredtiger");

--- a/crates/db-wiredtiger/src/bindings/cursor.rs
+++ b/crates/db-wiredtiger/src/bindings/cursor.rs
@@ -372,6 +372,7 @@ mod tests {
 
         {
             let session = connection
+                .clone()
                 .open_session(session_config::SessionConfig::new())
                 .unwrap();
 
@@ -416,6 +417,7 @@ mod tests {
 
         // Now do so in a new session.
         let session = connection
+            .clone()
             .open_session(session_config::SessionConfig::new())
             .unwrap();
         session.begin_transaction(None).unwrap();
@@ -444,6 +446,7 @@ mod tests {
         let entity = DataSource::Table("test_table".to_string());
 
         let session = connection
+            .clone()
             .open_session(session_config::SessionConfig::new())
             .unwrap();
 
@@ -463,6 +466,7 @@ mod tests {
         session.commit().unwrap();
 
         let session = connection
+            .clone()
             .open_session(session_config::SessionConfig::new())
             .unwrap();
         session.begin_transaction(None).unwrap();
@@ -507,6 +511,7 @@ mod tests {
         // Now insert them in a transaction
         {
             let session = connection
+                .clone()
                 .open_session(session_config::SessionConfig::new())
                 .unwrap();
             session.begin_transaction(None).unwrap();
@@ -528,6 +533,7 @@ mod tests {
 
         // Now iterate over them
         let session = connection
+            .clone()
             .open_session(session_config::SessionConfig::new())
             .unwrap();
         session.begin_transaction(None).unwrap();

--- a/crates/db-wiredtiger/src/lib.rs
+++ b/crates/db-wiredtiger/src/lib.rs
@@ -17,8 +17,8 @@ use std::sync::Arc;
 pub use crate::wtrel::relation::WiredTigerRelation;
 use moor_db::Database;
 
-pub use crate::worldstate::wt_worldstate::WiredTigerWorldState;
-pub use crate::wtrel::db::WiredTigerRelDb;
+pub use crate::worldstate::wt_worldstate::WiredTigerDB;
+pub use crate::wtrel::rel_db::WiredTigerRelDb;
 pub use crate::wtrel::rel_transaction::WiredTigerRelTransaction;
 
 #[allow(dead_code, unused_imports)]
@@ -43,7 +43,7 @@ impl WiredTigerDatabaseBuilder {
     /// Returns a new database instance. The second value in the result tuple is true if the
     /// database was newly created, and false if it was already present.
     pub fn open_db(&self) -> Result<(Arc<dyn Database + Send + Sync>, bool), String> {
-        let (db, fresh) = WiredTigerWorldState::open(self.path.as_ref());
+        let (db, fresh) = WiredTigerDB::open(self.path.as_ref());
         Ok((Arc::new(db), fresh))
     }
 }

--- a/crates/db-wiredtiger/src/wtrel/mod.rs
+++ b/crates/db-wiredtiger/src/wtrel/mod.rs
@@ -22,7 +22,7 @@ use moor_values::AsByteBuffer;
 use crate::bindings::FormatType::RawByte;
 use crate::bindings::{Datum, Pack, Session, Unpack};
 
-pub mod db;
+pub mod rel_db;
 pub mod rel_transaction;
 pub mod relation;
 

--- a/crates/db-wiredtiger/src/wtrel/rel_transaction.rs
+++ b/crates/db-wiredtiger/src/wtrel/rel_transaction.rs
@@ -22,7 +22,7 @@ use moor_values::AsByteBuffer;
 
 use crate::bindings::FormatType::RawByte;
 use crate::bindings::{CursorConfig, Datum, Error, Pack, Session};
-use crate::wtrel::db::MAX_NUM_SEQUENCES;
+use crate::wtrel::rel_db::MAX_NUM_SEQUENCES;
 use crate::wtrel::relation::WiredTigerRelation;
 use crate::wtrel::{from_datum, to_datum};
 
@@ -588,7 +588,7 @@ mod tests {
     use moor_values::var::Objid;
     use TestRelation::{CompositeToOne, OneToOne, OneToOneSecondaryIndexed, Sequences};
 
-    use crate::wtrel::db::WiredTigerRelDb;
+    use crate::wtrel::rel_db::WiredTigerRelDb;
 
     use crate::wtrel::relation::WiredTigerRelation;
 

--- a/crates/db/Cargo.toml
+++ b/crates/db/Cargo.toml
@@ -26,3 +26,5 @@ strum.workspace = true
 tracing.workspace = true
 uuid.workspace = true
 
+[features]
+relbox = []

--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -47,6 +47,7 @@ pub enum DatabaseFlavour {
     WiredTiger,
     /// In-house in-memory MVCC transactional store based on copy-on-write hashes and trees and
     /// custom buffer pool management. Consider experimental.
+    #[cfg(feature = "relbox")]
     RelBox,
 }
 
@@ -54,6 +55,7 @@ impl From<&str> for DatabaseFlavour {
     fn from(s: &str) -> Self {
         match s {
             "wiredtiger" => DatabaseFlavour::WiredTiger,
+            #[cfg(feature = "relbox")]
             "relbox" => DatabaseFlavour::RelBox,
             _ => panic!("Unknown database flavour: {}", s),
         }

--- a/crates/kernel/Cargo.toml
+++ b/crates/kernel/Cargo.toml
@@ -10,9 +10,9 @@ rust-version.workspace = true
 categories.workspace = true
 keywords.workspace = true
 readme.workspace = true
+resolver = "2"
 
 [dev-dependencies]
-moor-db-relbox = { path = "../db-relbox" }
 moor-db-wiredtiger = { path = "../db-wiredtiger" }
 
 criterion.workspace = true
@@ -47,6 +47,9 @@ moor-compiler = { path = "../compiler" }
 moor-db = { path = "../db" }
 moor-values = { path = "../values" }
 
+## Should be dev-dependencies, but cargo won't allow optional dev-deps
+moor-db-relbox = { path = "../db-relbox", optional = true }
+
 ## General usefulness
 chrono.workspace = true
 crossbeam-channel.workspace = true
@@ -77,3 +80,6 @@ tracing.workspace = true
 
 # For the DB layer.
 bincode.workspace = true
+
+[features]
+relbox = ["dep:moor-db-relbox"]

--- a/crates/kernel/src/vm/vm_test.rs
+++ b/crates/kernel/src/vm/vm_test.rs
@@ -39,7 +39,7 @@ mod tests {
     use moor_compiler::Op;
     use moor_compiler::Op::*;
     use moor_compiler::Program;
-    use moor_db_wiredtiger::WiredTigerWorldState;
+    use moor_db_wiredtiger::WiredTigerDB;
     use test_case::test_case;
 
     fn mk_program(main_vector: Vec<Op>, literals: Vec<Var>, var_names: Names) -> Program {
@@ -54,8 +54,8 @@ mod tests {
     }
 
     // Create an in memory db with a single object (#0) containing a single provided verb.
-    fn test_db_with_verbs(verbs: &[(&str, &Program)]) -> WiredTigerWorldState {
-        let (state, _) = WiredTigerWorldState::open(None);
+    fn test_db_with_verbs(verbs: &[(&str, &Program)]) -> WiredTigerDB {
+        let (state, _) = WiredTigerDB::open(None);
         let mut tx = state.new_world_state().unwrap();
         let sysobj = tx
             .create_object(SYSTEM_OBJECT, NOTHING, SYSTEM_OBJECT, BitEnum::all())
@@ -97,7 +97,7 @@ mod tests {
         state
     }
 
-    fn test_db_with_verb(verb_name: &str, program: &Program) -> WiredTigerWorldState {
+    fn test_db_with_verb(verb_name: &str, program: &Program) -> WiredTigerDB {
         test_db_with_verbs(&[(verb_name, program)])
     }
 
@@ -368,9 +368,8 @@ mod tests {
 
     fn world_with_test_program(program: &str) -> Box<dyn WorldState> {
         let binary = compile(program).unwrap();
-        test_db_with_verb("test", &binary)
-            .new_world_state()
-            .unwrap()
+        let db = test_db_with_verb("test", &binary);
+        db.new_world_state().unwrap()
     }
 
     #[test]

--- a/crates/kernel/src/vm/vm_test.rs
+++ b/crates/kernel/src/vm/vm_test.rs
@@ -39,7 +39,7 @@ mod tests {
     use moor_compiler::Op;
     use moor_compiler::Op::*;
     use moor_compiler::Program;
-    use moor_db_relbox::RelBoxWorldState;
+    use moor_db_wiredtiger::WiredTigerWorldState;
     use test_case::test_case;
 
     fn mk_program(main_vector: Vec<Op>, literals: Vec<Var>, var_names: Names) -> Program {
@@ -54,8 +54,8 @@ mod tests {
     }
 
     // Create an in memory db with a single object (#0) containing a single provided verb.
-    fn test_db_with_verbs(verbs: &[(&str, &Program)]) -> RelBoxWorldState {
-        let (state, _) = RelBoxWorldState::open(None, 1 << 30);
+    fn test_db_with_verbs(verbs: &[(&str, &Program)]) -> WiredTigerWorldState {
+        let (state, _) = WiredTigerWorldState::open(None);
         let mut tx = state.new_world_state().unwrap();
         let sysobj = tx
             .create_object(SYSTEM_OBJECT, NOTHING, SYSTEM_OBJECT, BitEnum::all())
@@ -97,7 +97,7 @@ mod tests {
         state
     }
 
-    fn test_db_with_verb(verb_name: &str, program: &Program) -> RelBoxWorldState {
+    fn test_db_with_verb(verb_name: &str, program: &Program) -> WiredTigerWorldState {
         test_db_with_verbs(&[(verb_name, program)])
     }
 

--- a/crates/kernel/tests/textdump.rs
+++ b/crates/kernel/tests/textdump.rs
@@ -17,7 +17,7 @@ mod test {
     use moor_compiler::Program;
     use moor_db::loader::LoaderInterface;
     use moor_db::Database;
-    use moor_db_wiredtiger::WiredTigerWorldState;
+    use moor_db_wiredtiger::WiredTigerDB;
     use moor_kernel::textdump::{make_textdump, read_textdump, textdump_load, TextdumpReader};
     use moor_values::model::VerbArgsSpec;
     use moor_values::model::VerbFlag;
@@ -46,7 +46,7 @@ mod test {
         assert_eq!(tx.commit().unwrap(), CommitResult::Success);
     }
 
-    fn write_textdump(db: Arc<WiredTigerWorldState>, version: &str) -> String {
+    fn write_textdump(db: Arc<WiredTigerDB>, version: &str) -> String {
         let mut tx = db.clone().loader_client().unwrap();
         let mut output = Vec::new();
         let textdump = make_textdump(tx.as_ref(), Some(version));
@@ -174,7 +174,7 @@ mod test {
         let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         let minimal_db = manifest_dir.join("tests/Minimal.db");
 
-        let (db, _) = WiredTigerWorldState::open(None);
+        let (db, _) = WiredTigerDB::open(None);
         let db = Arc::new(db);
         let mut tx = db.clone().loader_client().unwrap();
         textdump_load(tx.as_mut(), minimal_db).unwrap();
@@ -213,7 +213,7 @@ mod test {
         let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         let minimal_db = manifest_dir.join("tests/Minimal.db");
 
-        let (db, _) = WiredTigerWorldState::open(None);
+        let (db, _) = WiredTigerDB::open(None);
         let db = Arc::new(db);
         load_textdump_file(
             db.clone().loader_client().unwrap().as_mut(),
@@ -237,7 +237,7 @@ mod test {
         let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         let minimal_db = manifest_dir.join("../../JHCore-DEV-2.db");
 
-        let (db1, _) = WiredTigerWorldState::open(None);
+        let (db1, _) = WiredTigerDB::open(None);
         let db1 = Arc::new(db1);
         load_textdump_file(
             db1.clone().loader_client().unwrap().as_mut(),
@@ -254,7 +254,7 @@ mod test {
         let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         let minimal_db = manifest_dir.join("../../JHCore-DEV-2.db");
 
-        let (db1, _) = WiredTigerWorldState::open(None);
+        let (db1, _) = WiredTigerDB::open(None);
         let db1 = Arc::new(db1);
         load_textdump_file(
             db1.clone().loader_client().unwrap().as_mut(),
@@ -264,7 +264,7 @@ mod test {
         let textdump = write_textdump(db1.clone(), "** LambdaMOO Database, Format Version 4 **");
 
         // Now load that same core back in to a new DB, and hope we don't blow up anywhere.
-        let (db2, _) = WiredTigerWorldState::open(None);
+        let (db2, _) = WiredTigerDB::open(None);
         let db2 = Arc::new(db2);
         let buffered_string_reader = std::io::BufReader::new(textdump.as_bytes());
         let mut lc = db2.clone().loader_client().unwrap();

--- a/crates/kernel/tests/textdump.rs
+++ b/crates/kernel/tests/textdump.rs
@@ -17,7 +17,6 @@ mod test {
     use moor_compiler::Program;
     use moor_db::loader::LoaderInterface;
     use moor_db::Database;
-    use moor_db_relbox::RelBoxWorldState;
     use moor_db_wiredtiger::WiredTigerWorldState;
     use moor_kernel::textdump::{make_textdump, read_textdump, textdump_load, TextdumpReader};
     use moor_values::model::VerbArgsSpec;
@@ -265,7 +264,7 @@ mod test {
         let textdump = write_textdump(db1.clone(), "** LambdaMOO Database, Format Version 4 **");
 
         // Now load that same core back in to a new DB, and hope we don't blow up anywhere.
-        let (db2, _) = RelBoxWorldState::open(None, 1 << 34);
+        let (db2, _) = WiredTigerWorldState::open(None);
         let db2 = Arc::new(db2);
         let buffered_string_reader = std::io::BufReader::new(textdump.as_bytes());
         let mut lc = db2.clone().loader_client().unwrap();

--- a/crates/kernel/testsuite/common/mod.rs
+++ b/crates/kernel/testsuite/common/mod.rs
@@ -15,7 +15,7 @@
 use moor_compiler::compile;
 use moor_compiler::Program;
 use moor_db::Database;
-use moor_db_relbox::RelBoxWorldState;
+
 use moor_db_wiredtiger::WiredTigerWorldState;
 use moor_kernel::tasks::sessions::NoopClientSession;
 use moor_kernel::tasks::sessions::Session;
@@ -33,6 +33,9 @@ use pretty_assertions::assert_eq;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use uuid::Uuid;
+
+#[cfg(feature = "relbox")]
+use moor_db_relbox::RelBoxWorldState;
 
 #[allow(dead_code)]
 pub const WIZARD: Objid = Objid(3);
@@ -53,6 +56,7 @@ pub fn load_textdump(db: Arc<dyn Database>) {
     assert_eq!(tx.commit().unwrap(), CommitResult::Success);
 }
 
+#[cfg(feature = "relbox")]
 pub fn create_relbox_db() -> Arc<dyn Database + Send + Sync> {
     let (db, _) = RelBoxWorldState::open(None, 1 << 30);
     let db = Arc::new(db);

--- a/crates/kernel/testsuite/common/mod.rs
+++ b/crates/kernel/testsuite/common/mod.rs
@@ -16,7 +16,7 @@ use moor_compiler::compile;
 use moor_compiler::Program;
 use moor_db::Database;
 
-use moor_db_wiredtiger::WiredTigerWorldState;
+use moor_db_wiredtiger::WiredTigerDB;
 use moor_kernel::tasks::sessions::NoopClientSession;
 use moor_kernel::tasks::sessions::Session;
 use moor_kernel::tasks::vm_test_utils;
@@ -65,7 +65,7 @@ pub fn create_relbox_db() -> Arc<dyn Database + Send + Sync> {
 }
 
 pub fn create_wiredtiger_db() -> Arc<dyn Database + Send + Sync> {
-    let (db, _) = WiredTigerWorldState::open(None);
+    let (db, _) = WiredTigerDB::open(None);
     let db = Arc::new(db);
     load_textdump(db.clone());
     db

--- a/crates/kernel/testsuite/regression_suite.rs
+++ b/crates/kernel/testsuite/regression_suite.rs
@@ -13,8 +13,12 @@
 //
 
 mod common;
-use common::{create_relbox_db, create_wiredtiger_db, AssertRunAsVerb};
+use common::{create_wiredtiger_db, AssertRunAsVerb};
 
+#[cfg(feature = "relbox")]
+use crate::common::create_relbox_db;
+
+#[cfg(feature = "relbox")]
 #[test]
 fn test_testhelper_verb_redefinition_relbox() {
     let db = create_relbox_db();


### PR DESCRIPTION
Makes it so by default moor is built without my in-house experimental/unfinished in-memory "relbox" database backend.