### PR TITLE
Remove some uses of 'bincode' serialization. Remove (most) SliceRef usages. Add a semi-zero-copy List alternative.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -818,9 +818,10 @@ checksum = "e8566979429cf69b49a5c740c60791108e86440e8be149bbea4fe54d2c32d6e2"
 
 [[package]]
 name = "daumtils"
-version = "0.1.0"
-source = "git+https://github.com/rdaum/daumtils.git#2254a06f78d8e42496ae268e73c05abd7d325f13"
+version = "0.2.0"
+source = "git+https://github.com/rdaum/daumtils.git#24026dd193c2dd7679389858222f7fb97512da61"
 dependencies = [
+ "bytes",
  "num-traits",
  "yoke",
  "yoke-derive",
@@ -1138,20 +1139,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "generator"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "186014d53bc231d0090ef8d6f03e0920c54d85a5ed22f4f2f74315ec56cf83fb"
-dependencies = [
- "cc",
- "cfg-if",
- "libc",
- "log",
- "rustversion",
- "windows",
-]
-
-[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1297,9 +1284,9 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.9.2"
+version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f3935c160d00ac752e09787e6e6bfc26494c2183cc922f1bc678a60d4733bc2"
+checksum = "d0e7a4dd27b9476dc40cb050d3632d3bba3a70ddbff012285f7f8559a1e7e545"
 
 [[package]]
 name = "httpdate"
@@ -1358,7 +1345,7 @@ dependencies = [
  "iana-time-zone-haiku",
  "js-sys",
  "wasm-bindgen",
- "windows-core 0.52.0",
+ "windows-core",
 ]
 
 [[package]]
@@ -1677,7 +1664,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c2a198fb6b0eada2a8df47933734e6d35d350665a33a3593d7164fa52c75c19"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.5",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -1709,20 +1696,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 
 [[package]]
-name = "loom"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "419e0dc8046cb947daa77eb95ae174acfbddb7673b4151f56d1eed8e93fbfaca"
-dependencies = [
- "cfg-if",
- "generator",
- "pin-utils",
- "scoped-tls",
- "tracing",
- "tracing-subscriber",
-]
-
-[[package]]
 name = "matchers"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1750,9 +1723,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.2"
+version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
+checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "mime"
@@ -1791,6 +1764,7 @@ name = "moor-compiler"
 version = "0.1.0"
 dependencies = [
  "bincode",
+ "bytes",
  "daumtils",
  "itertools 0.13.0",
  "lazy_static",
@@ -1830,6 +1804,7 @@ name = "moor-daemon"
 version = "0.1.0"
 dependencies = [
  "bincode",
+ "bytes",
  "clap",
  "clap_derive",
  "color-eyre",
@@ -1860,6 +1835,7 @@ dependencies = [
 name = "moor-db"
 version = "0.1.0"
 dependencies = [
+ "bytes",
  "daumtils",
  "moor-values",
  "strum",
@@ -1874,6 +1850,7 @@ dependencies = [
 name = "moor-db-relbox"
 version = "0.1.0"
 dependencies = [
+ "bytes",
  "daumtils",
  "moor-db",
  "moor-values",
@@ -1889,6 +1866,7 @@ name = "moor-db-wiredtiger"
 version = "0.1.0"
 dependencies = [
  "bindgen",
+ "bytes",
  "cmake",
  "daumtils",
  "libc",
@@ -1905,6 +1883,7 @@ name = "moor-kernel"
 version = "0.1.0"
 dependencies = [
  "bincode",
+ "bytes",
  "chrono",
  "chrono-tz",
  "criterion",
@@ -2112,12 +2091,9 @@ checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "oneshot"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "071d1cf3298ad8e543dca18217d198cb6a3884443d204757b9624b935ef09fa0"
-dependencies = [
- "loom",
-]
+checksum = "e296cf87e61c9cfc1a61c3c63a0f7f286ed4554e0e22be84e8a38e1d264a2a29"
 
 [[package]]
 name = "onig"
@@ -2520,9 +2496,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "469052894dcb553421e483e4209ee581a45100d31b4018de03e5a7ad86374a7e"
+checksum = "c82cf8cff14456045f55ec4241383baeff27af886adb72ffb2162f99911de0fd"
 dependencies = [
  "bitflags 2.5.0",
 ]
@@ -2573,8 +2549,8 @@ checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
 name = "relbox"
-version = "0.1.0"
-source = "git+https://github.com/rdaum/Relbox.git#a2abb1b2e8067f433f20d50ff56e8d64101cbcce"
+version = "0.2.0"
+source = "git+https://github.com/rdaum/Relbox.git#e5c534003c101da6afb3dd675442c578220aa06f"
 dependencies = [
  "atomic-wait",
  "binary-layout",
@@ -2748,12 +2724,6 @@ checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
 ]
-
-[[package]]
-name = "scoped-tls"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "scopeguard"
@@ -3745,39 +3715,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
-name = "windows"
-version = "0.54.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9252e5725dbed82865af151df558e754e4a3c2c30818359eb17465f1346a1b49"
-dependencies = [
- "windows-core 0.54.0",
- "windows-targets 0.52.5",
-]
-
-[[package]]
 name = "windows-core"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
-dependencies = [
- "windows-targets 0.52.5",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.54.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12661b9c89351d684a50a8a643ce5f608e20243b9fb84687800163429f161d65"
-dependencies = [
- "windows-result",
- "windows-targets 0.52.5",
-]
-
-[[package]]
-name = "windows-result"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
 dependencies = [
  "windows-targets 0.52.5",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -321,7 +321,16 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
 dependencies = [
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -331,6 +340,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "blowfish"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32fa6a061124e37baba002e496d203e23ba3d7b73750be82dbfbc92913048a5b"
+dependencies = [
+ "byteorder",
+ "cipher 0.2.5",
+ "opaque-debug",
 ]
 
 [[package]]
@@ -412,7 +432,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
 dependencies = [
  "cfg-if",
- "cipher",
+ "cipher 0.4.4",
  "cpufeatures",
 ]
 
@@ -477,6 +497,15 @@ checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
 dependencies = [
  "ciborium-io",
  "half",
+]
+
+[[package]]
+name = "cipher"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f8e7987cbd042a63249497f41aed09f8e65add917ea6566effbc56578d6801"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -721,15 +750,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
-name = "crypt-sys"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "329e26600e8e5587230a0b9117e021a1636567d084a26d04c30c698b2a21475f"
-dependencies = [
- "bindgen",
-]
-
-[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -737,6 +757,16 @@ checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "crypto-mac"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bff07008ec701e8028e2ceb8f83f0e4274ee62bd2dbdc4fefff2e9a91824081a"
+dependencies = [
+ "generic-array",
+ "subtle",
 ]
 
 [[package]]
@@ -748,7 +778,7 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "curve25519-dalek-derive",
- "digest",
+ "digest 0.10.7",
  "fiat-crypto",
  "platforms",
  "rustc_version",
@@ -835,11 +865,20 @@ checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
 name = "digest"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
+ "block-buffer 0.10.4",
  "crypto-common",
  "subtle",
 ]
@@ -892,7 +931,7 @@ dependencies = [
  "ed25519",
  "rand_core",
  "serde",
- "sha2",
+ "sha2 0.10.8",
  "subtle",
  "zeroize",
 ]
@@ -1201,6 +1240,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b185d6db5f0fa67e0ac9ccf2e620a99300012820c5ec701ceb244c7714bd606c"
 dependencies = [
  "wide",
+]
+
+[[package]]
+name = "hmac"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1441c6b1e930e2817404b5046f1f989899143a12bf92de603b69f4e0aee1e15"
+dependencies = [
+ "crypto-mac",
+ "digest 0.9.0",
 ]
 
 [[package]]
@@ -1689,10 +1738,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
-name = "md5"
-version = "0.7.0"
+name = "md-5"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
+checksum = "7b5a279bb9607f9f53c22d496eade00d138d1bdcccd07d74650387cf94942a15"
+dependencies = [
+ "block-buffer 0.9.0",
+ "digest 0.9.0",
+ "opaque-debug",
+]
 
 [[package]]
 name = "memchr"
@@ -1855,7 +1909,6 @@ dependencies = [
  "chrono-tz",
  "criterion",
  "crossbeam-channel",
- "crypt-sys",
  "daumtils",
  "decorum",
  "eyre",
@@ -1863,7 +1916,7 @@ dependencies = [
  "inventory",
  "lazy_static",
  "libc",
- "md5",
+ "md-5",
  "moor-compiler",
  "moor-db",
  "moor-db-relbox",
@@ -1873,6 +1926,7 @@ dependencies = [
  "onig",
  "paste",
  "pretty_assertions",
+ "pwhash",
  "rand",
  "strum",
  "tempfile",
@@ -2094,6 +2148,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
 name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2201,7 +2261,7 @@ checksum = "d7a240022f37c361ec1878d646fc5b7d7c4d28d5946e1a80ad5a7a4f4ca0bdcd"
 dependencies = [
  "once_cell",
  "pest",
- "sha2",
+ "sha2 0.10.8",
 ]
 
 [[package]]
@@ -2363,6 +2423,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22244ce15aa966053a896d1accb3a6e68469b97c7f33f284b99f0d576879fc23"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "pwhash"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "419a3ad8fa9f9d445e69d9b185a24878ae6e6f55c96e4512f4a0e28cd3bc5c56"
+dependencies = [
+ "blowfish",
+ "byteorder",
+ "hmac",
+ "md-5",
+ "rand",
+ "sha-1",
+ "sha2 0.9.9",
 ]
 
 [[package]]
@@ -2614,7 +2689,7 @@ dependencies = [
  "base64 0.22.1",
  "blake2",
  "chacha20",
- "digest",
+ "digest 0.10.7",
  "ed25519-dalek",
  "erased-serde",
  "hex",
@@ -2755,6 +2830,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha-1"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99cd6713db3cf16b6c84e06321e049a9b9f699826e16096d23bbcc44d15d51a6"
+dependencies = [
+ "block-buffer 0.9.0",
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.9.0",
+ "opaque-debug",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2762,7 +2850,20 @@ checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
+dependencies = [
+ "block-buffer 0.9.0",
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.9.0",
+ "opaque-debug",
 ]
 
 [[package]]
@@ -2773,7 +2874,7 @@ checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -2915,9 +3016,9 @@ dependencies = [
 
 [[package]]
 name = "subtle"
-version = "2.5.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
+checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1737,6 +1737,7 @@ name = "moor-compiler"
 version = "0.1.0"
 dependencies = [
  "bincode",
+ "daumtils",
  "itertools 0.13.0",
  "lazy_static",
  "moor-values",
@@ -1819,6 +1820,7 @@ dependencies = [
 name = "moor-db-relbox"
 version = "0.1.0"
 dependencies = [
+ "daumtils",
  "moor-db",
  "moor-values",
  "relbox",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,9 +110,9 @@ yoke-derive = "0.7.3"
 
 ## Required for MOO builtins.
 chrono-tz = "0.9.0"
-crypt-sys = "0.1.0"
+pwhash = { version = "1.0.0", default-features = false }
 iana-time-zone = "0.1.60"
-md5 = "0.7"                                            # For MOO's "string_hash"
+md-5 = "0.9.1"                                            # For MOO's "string_hash"
 onig = { version = "6.4.0", default-features = false }
 rand = "0.8"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,7 +90,7 @@ cmake = "0.1"
 criterion = { version = "0.5", features = ["async_tokio"] }
 crossbeam-channel = "0.5"
 dashmap = "5.5"
-daumtils = { git = "https://github.com/rdaum/daumtils.git" }
+daumtils = { git = "https://github.com/rdaum/daumtils.git", version = "0.2.0" }
 decorum = "0.3"                                             # For ordering & comparing our floats
 enum-primitive-derive = "0.3"
 fast-counter = "1.0"
@@ -136,7 +136,7 @@ io-uring = "0.6"
 libc = "0.2"
 okaywal = "0.3"
 text_io = "0.1"          # Used for reading text dumps.
-relbox = { git = "https://github.com/rdaum/Relbox.git" }
+relbox = { git = "https://github.com/rdaum/Relbox.git", version = "0.2.0" }
 
 # Dev dependencies
 tempfile = "3.10"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,6 +82,7 @@ tracing-test = "0.2"
 arc-swap = "1.7"
 atomic-wait = "1.1"
 binary-layout = "4.0"
+bincode = "2.0.0-rc.3"
 bindgen = "0.69"
 bytes = "1.6"
 chrono = "0.4"
@@ -129,7 +130,6 @@ paste = "1.0"
 
 # For the DB & values layer.
 crossbeam-queue = "0.3"
-bincode = "2.0.0-rc.3"   # For serializing/deserializing values
 hi_sparse_bitset = "0.6" # For buffer pool allocator in the DB
 im = "15.1"              # Immutable data structures
 io-uring = "0.6"

--- a/crates/compiler/Cargo.toml
+++ b/crates/compiler/Cargo.toml
@@ -24,6 +24,7 @@ moor-values = { path = "../values" }
 
 ## General usefulness
 bincode.workspace = true
+bytes.workspace = true
 daumtils.workspace = true
 itertools.workspace = true
 lazy_static.workspace = true

--- a/crates/compiler/Cargo.toml
+++ b/crates/compiler/Cargo.toml
@@ -24,6 +24,7 @@ moor-values = { path = "../values" }
 
 ## General usefulness
 bincode.workspace = true
+daumtils.workspace = true
 itertools.workspace = true
 lazy_static.workspace = true
 strum.workspace = true

--- a/crates/compiler/src/program.rs
+++ b/crates/compiler/src/program.rs
@@ -15,8 +15,10 @@
 use crate::labels::{JumpLabel, Label, Name, Names};
 use crate::opcode::Op;
 use bincode::{Decode, Encode};
+use daumtils::SliceRef;
 use lazy_static::lazy_static;
 use moor_values::var::Var;
+use moor_values::{AsByteBuffer, CountingWriter, DecodingError, EncodingError, BINCODE_CONFIG};
 use std::fmt::{Display, Formatter};
 use std::sync::Arc;
 
@@ -106,5 +108,53 @@ impl Display for Program {
         }
 
         Ok(())
+    }
+}
+
+// Byte buffer representation is just bincoded for now.
+impl AsByteBuffer for Program {
+    fn size_bytes(&self) -> usize
+    where
+        Self: Encode,
+    {
+        // For now be careful with this as we have to bincode the whole thing in order to calculate
+        // this. In the long run with a zero-copy implementation we can just return the size of the
+        // underlying bytes.
+        let mut cw = CountingWriter { count: 0 };
+        bincode::encode_into_writer(self, &mut cw, *BINCODE_CONFIG)
+            .expect("bincode to bytes for counting size");
+        cw.count
+    }
+
+    fn with_byte_buffer<R, F: FnMut(&[u8]) -> R>(&self, mut f: F) -> Result<R, EncodingError>
+    where
+        Self: Sized + Encode,
+    {
+        let v = bincode::encode_to_vec(self, *BINCODE_CONFIG)
+            .map_err(|e| EncodingError::CouldNotEncode(e.to_string()))?;
+        Ok(f(&v[..]))
+    }
+
+    fn make_copy_as_vec(&self) -> Result<Vec<u8>, EncodingError>
+    where
+        Self: Sized + Encode,
+    {
+        bincode::encode_to_vec(self, *BINCODE_CONFIG)
+            .map_err(|e| EncodingError::CouldNotEncode(e.to_string()))
+    }
+
+    fn from_sliceref(bytes: SliceRef) -> Result<Self, DecodingError>
+    where
+        Self: Sized + Decode,
+    {
+        Ok(
+            bincode::decode_from_slice(bytes.as_slice(), *BINCODE_CONFIG)
+                .map_err(|e| DecodingError::CouldNotDecode(e.to_string()))?
+                .0,
+        )
+    }
+
+    fn as_sliceref(&self) -> Result<SliceRef, EncodingError> {
+        Ok(SliceRef::from_vec(self.make_copy_as_vec()?))
     }
 }

--- a/crates/compiler/src/program.rs
+++ b/crates/compiler/src/program.rs
@@ -15,7 +15,7 @@
 use crate::labels::{JumpLabel, Label, Name, Names};
 use crate::opcode::Op;
 use bincode::{Decode, Encode};
-use daumtils::SliceRef;
+use bytes::Bytes;
 use lazy_static::lazy_static;
 use moor_values::var::Var;
 use moor_values::{AsByteBuffer, CountingWriter, DecodingError, EncodingError, BINCODE_CONFIG};
@@ -143,18 +143,16 @@ impl AsByteBuffer for Program {
             .map_err(|e| EncodingError::CouldNotEncode(e.to_string()))
     }
 
-    fn from_sliceref(bytes: SliceRef) -> Result<Self, DecodingError>
+    fn from_bytes(bytes: Bytes) -> Result<Self, DecodingError>
     where
         Self: Sized + Decode,
     {
-        Ok(
-            bincode::decode_from_slice(bytes.as_slice(), *BINCODE_CONFIG)
-                .map_err(|e| DecodingError::CouldNotDecode(e.to_string()))?
-                .0,
-        )
+        Ok(bincode::decode_from_slice(bytes.as_ref(), *BINCODE_CONFIG)
+            .map_err(|e| DecodingError::CouldNotDecode(e.to_string()))?
+            .0)
     }
 
-    fn as_sliceref(&self) -> Result<SliceRef, EncodingError> {
-        Ok(SliceRef::from_vec(self.make_copy_as_vec()?))
+    fn as_bytes(&self) -> Result<Bytes, EncodingError> {
+        Ok(Bytes::from(self.make_copy_as_vec()?))
     }
 }

--- a/crates/daemon/Cargo.toml
+++ b/crates/daemon/Cargo.toml
@@ -28,6 +28,7 @@ strum.workspace = true
 
 # General.
 bincode.workspace = true
+bytes.workspace = true
 daumtils.workspace = true
 signal-hook.workspace = true
 color-eyre.workspace = true

--- a/crates/daemon/src/connections_rb.rs
+++ b/crates/daemon/src/connections_rb.rs
@@ -394,12 +394,8 @@ impl ConnectionsDB for ConnectionsRb {
         let tx = self.tb.clone().start_tx();
         let connection = match tx
             .relation(RelationId(ConnectionRelation::ClientConnection as usize))
-            .seek_unique_by_domain(
-                client_id
-                    .as_bytes()
-                    .as_sliceref()
-                    .expect("Invalid client id"),
-            ) {
+            .seek_unique_by_domain(SliceRef::from_bytes(client_id.as_bytes()))
+        {
             Ok(connection) => {
                 Some(Objid::from_sliceref(connection.codomain()).expect("Invalid connection"))
             }
@@ -413,44 +409,19 @@ impl ConnectionsDB for ConnectionsRb {
         let tx = self.tb.clone().start_tx();
         let _ = tx
             .relation(RelationId(ConnectionRelation::ClientConnection as usize))
-            .remove_by_domain(
-                client_id
-                    .as_bytes()
-                    .as_sliceref()
-                    .expect("Invalid client id"),
-            );
+            .remove_by_domain(SliceRef::from_bytes(client_id.as_bytes()));
         let _ = tx
             .relation(RelationId(ConnectionRelation::ClientActivity as usize))
-            .remove_by_domain(
-                client_id
-                    .as_bytes()
-                    .as_sliceref()
-                    .expect("Invalid client id"),
-            );
+            .remove_by_domain(SliceRef::from_bytes(client_id.as_bytes()));
         let _ = tx
             .relation(RelationId(ConnectionRelation::ClientConnectTime as usize))
-            .remove_by_domain(
-                client_id
-                    .as_bytes()
-                    .as_sliceref()
-                    .expect("Invalid client id"),
-            );
+            .remove_by_domain(SliceRef::from_bytes(client_id.as_bytes()));
         let _ = tx
             .relation(RelationId(ConnectionRelation::ClientPingTime as usize))
-            .remove_by_domain(
-                client_id
-                    .as_bytes()
-                    .as_sliceref()
-                    .expect("Invalid client id"),
-            );
+            .remove_by_domain(SliceRef::from_bytes(client_id.as_bytes()));
         let _ = tx
             .relation(RelationId(ConnectionRelation::ClientName as usize))
-            .remove_by_domain(
-                client_id
-                    .as_bytes()
-                    .as_sliceref()
-                    .expect("Invalid client id"),
-            );
+            .remove_by_domain(SliceRef::from_bytes(client_id.as_bytes()));
 
         tx.commit()?;
         Ok(())

--- a/crates/daemon/src/connections_wt.rs
+++ b/crates/daemon/src/connections_wt.rs
@@ -27,7 +27,7 @@ use strum::{AsRefStr, Display, EnumCount, EnumIter, EnumProperty};
 use tracing::{error, warn};
 use uuid::Uuid;
 
-use daumtils::SliceRef;
+use bytes::Bytes;
 use moor_db_wiredtiger::{WiredTigerRelDb, WiredTigerRelTransaction, WiredTigerRelation};
 use moor_kernel::tasks::sessions::SessionError;
 use moor_values::model::{CommitResult, ValSet};
@@ -199,21 +199,21 @@ impl AsByteBuffer for ClientId {
         Ok(self.0.as_bytes().to_vec())
     }
 
-    fn from_sliceref(bytes: SliceRef) -> Result<Self, DecodingError>
+    fn from_bytes(bytes: Bytes) -> Result<Self, DecodingError>
     where
         Self: Sized,
     {
-        let bytes = bytes.as_slice();
+        let bytes = bytes.as_ref();
         assert_eq!(bytes.len(), 16, "Decode client id: Invalid UUID length");
         let mut uuid_bytes = [0u8; 16];
         uuid_bytes.copy_from_slice(bytes);
         Ok(ClientId(Uuid::from_bytes(uuid_bytes)))
     }
 
-    fn as_sliceref(&self) -> Result<SliceRef, EncodingError> {
+    fn as_bytes(&self) -> Result<Bytes, EncodingError> {
         let buf = self.0.as_bytes();
         assert_eq!(buf.len(), 16, "Encode client id: Invalid UUID length");
-        Ok(SliceRef::from_bytes(buf))
+        Ok(Bytes::copy_from_slice(buf))
     }
 }
 impl Display for ClientId {

--- a/crates/db-relbox/Cargo.toml
+++ b/crates/db-relbox/Cargo.toml
@@ -21,6 +21,7 @@ moor-db = { path = "../db" }
 relbox.workspace = true
 
 ## General usefulness
+daumtils.workspace = true
 strum.workspace = true
 uuid.workspace = true
 

--- a/crates/db-relbox/Cargo.toml
+++ b/crates/db-relbox/Cargo.toml
@@ -22,6 +22,7 @@ relbox.workspace = true
 
 ## General usefulness
 daumtils.workspace = true
+bytes.workspace = true
 strum.workspace = true
 uuid.workspace = true
 

--- a/crates/db-relbox/src/rb_worldstate.rs
+++ b/crates/db-relbox/src/rb_worldstate.rs
@@ -12,6 +12,7 @@
 // this program. If not, see <https://www.gnu.org/licenses/>.
 //
 
+use daumtils::SliceRef;
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -43,7 +44,9 @@ impl RelBoxWorldState {
         let fresh_db = {
             let canonical = db.copy_canonical();
             canonical[WorldStateTable::ObjectParent as usize]
-                .seek_by_domain(SYSTEM_OBJECT.as_sliceref().unwrap())
+                .seek_by_domain(SliceRef::from_byte_source(
+                    SYSTEM_OBJECT.as_bytes().unwrap(),
+                ))
                 .expect("Could not seek for freshness check on DB")
                 .is_empty()
         };

--- a/crates/db-wiredtiger/Cargo.toml
+++ b/crates/db-wiredtiger/Cargo.toml
@@ -20,6 +20,7 @@ libc.workspace = true
 moor-values = { path = "../values" }
 moor-db = { path = "../db" }
 
+bytes.workspace = true
 daumtils.workspace = true
 strum.workspace = true
 tempfile.workspace = true

--- a/crates/db-wiredtiger/src/bindings/data.rs
+++ b/crates/db-wiredtiger/src/bindings/data.rs
@@ -110,12 +110,12 @@ impl Unpack {
             .collect::<Vec<_>>()
             .join("");
         let format = CString::new(format).unwrap();
-        let data = datum.as_slice();
+        let data = datum.as_ref();
         let err = unsafe {
             wiredtiger_unpack_start(
                 session.session,
                 format.as_ptr(),
-                data.as_ptr() as _,
+                data.as_slice().as_ptr() as _,
                 data.len(),
                 &mut stream as _,
             )

--- a/crates/db-wiredtiger/src/wtrel/mod.rs
+++ b/crates/db-wiredtiger/src/wtrel/mod.rs
@@ -16,7 +16,7 @@
 
 use std::rc::Rc;
 
-use daumtils::SliceRef;
+use bytes::Bytes;
 use moor_values::AsByteBuffer;
 
 use crate::bindings::FormatType::RawByte;
@@ -26,7 +26,7 @@ pub mod rel_db;
 pub mod rel_transaction;
 pub mod relation;
 
-// TODO: find ways of avoiding copies by using SliceRef / ByteSource
+// TODO: find ways of avoiding copies by using Bytes / ByteSource
 fn to_datum<V: AsByteBuffer>(session: &Session, v: &V) -> Datum {
     v.with_byte_buffer(|bytes| {
         let mut pack = Pack::new(session, &[RawByte(None)], bytes.len());
@@ -39,5 +39,5 @@ fn to_datum<V: AsByteBuffer>(session: &Session, v: &V) -> Datum {
 fn from_datum<V: AsByteBuffer>(session: &Session, d: Rc<Datum>) -> V {
     let mut unpack = Unpack::new(session, &[RawByte(None)], d);
     let bytes = unpack.unpack_item();
-    V::from_sliceref(SliceRef::from_vec(bytes)).unwrap()
+    V::from_bytes(Bytes::from(bytes)).unwrap()
 }

--- a/crates/db-wiredtiger/src/wtrel/rel_transaction.rs
+++ b/crates/db-wiredtiger/src/wtrel/rel_transaction.rs
@@ -62,15 +62,15 @@ where
         o: &DomainA,
         u: &DomainB,
     ) -> Datum {
-        let (a, b) = (o.as_sliceref().unwrap(), u.as_sliceref().unwrap());
+        let (a, b) = (o.as_bytes().unwrap(), u.as_bytes().unwrap());
 
         let mut pack = Pack::new(
             &self.session,
             &[RawByte(Some(a.len())), RawByte(Some(b.len()))],
             a.len() + b.len(),
         );
-        pack.push_item(a.as_slice());
-        pack.push_item(b.as_slice());
+        pack.push_item(a.as_ref());
+        pack.push_item(b.as_ref());
         pack.pack()
     }
 }

--- a/crates/db/Cargo.toml
+++ b/crates/db/Cargo.toml
@@ -20,6 +20,7 @@ tracing-test.workspace = true
 moor-values = { path = "../values" }
 
 ## Error declaration/ handling
+bytes.workspace = true
 daumtils.workspace = true
 strum.workspace = true
 thiserror.workspace = true

--- a/crates/db/src/db_worldstate.rs
+++ b/crates/db/src/db_worldstate.rs
@@ -14,7 +14,7 @@
 
 use uuid::Uuid;
 
-use daumtils::SliceRef;
+use bytes::Bytes;
 use moor_values::model::HasUuid;
 use moor_values::model::ObjSet;
 use moor_values::model::Perms;
@@ -581,7 +581,7 @@ impl WorldState for DbTxWorldState {
         self.perms(perms)?
             .check_verb_allows(vh.owner(), vh.flags(), VerbFlag::Read)?;
         let binary = self.tx.get_verb_binary(vh.location(), vh.uuid())?;
-        Ok(VerbInfo::new(vh, SliceRef::from_vec(binary)))
+        Ok(VerbInfo::new(vh, Bytes::from(binary)))
     }
 
     #[tracing::instrument(skip(self))]
@@ -596,7 +596,7 @@ impl WorldState for DbTxWorldState {
             .check_verb_allows(vh.owner(), vh.flags(), VerbFlag::Read)?;
 
         let binary = self.tx.get_verb_binary(vh.location(), vh.uuid())?;
-        Ok(VerbInfo::new(vh, SliceRef::from_vec(binary)))
+        Ok(VerbInfo::new(vh, Bytes::from(binary)))
     }
 
     #[tracing::instrument(skip(self))]
@@ -648,7 +648,7 @@ impl WorldState for DbTxWorldState {
             .check_verb_allows(vh.owner(), vh.flags(), VerbFlag::Read)?;
 
         let binary = self.tx.get_verb_binary(vh.location(), vh.uuid())?;
-        Ok(Some(VerbInfo::new(vh, SliceRef::from_vec(binary))))
+        Ok(Some(VerbInfo::new(vh, Bytes::from(binary))))
     }
 
     #[tracing::instrument(skip(self))]

--- a/crates/db/src/worldstate_transaction.rs
+++ b/crates/db/src/worldstate_transaction.rs
@@ -95,7 +95,7 @@ pub trait WorldStateTransaction {
     fn get_verbs(&self, obj: Objid) -> Result<VerbDefs, WorldStateError>;
 
     /// Get the binary of the given verb.
-    // TODO: "binaries" returned from the db should be SliceRefs, not Vecs.
+    // TODO: "binaries" returned from the db should be Bytess, not Vecs.
     fn get_verb_binary(&self, obj: Objid, uuid: Uuid) -> Result<Vec<u8>, WorldStateError>;
 
     /// Find & get the verb with the given name on the given object.

--- a/crates/kernel/Cargo.toml
+++ b/crates/kernel/Cargo.toml
@@ -64,10 +64,10 @@ uuid.workspace = true
 
 ## Required for MOO builtins.
 chrono-tz.workspace = true
-crypt-sys.workspace = true
 iana-time-zone.workspace = true
-md5.workspace = true
+md-5.workspace = true
 onig.workspace = true
+pwhash.workspace = true
 rand.workspace = true
 
 ## Error declaration/ handling

--- a/crates/kernel/Cargo.toml
+++ b/crates/kernel/Cargo.toml
@@ -51,6 +51,7 @@ moor-values = { path = "../values" }
 moor-db-relbox = { path = "../db-relbox", optional = true }
 
 ## General usefulness
+bytes.workspace = true
 chrono.workspace = true
 crossbeam-channel.workspace = true
 daumtils.workspace = true

--- a/crates/kernel/benches/vm_benches.rs
+++ b/crates/kernel/benches/vm_benches.rs
@@ -32,7 +32,7 @@ use moor_values::model::VerbArgsSpec;
 use moor_values::model::{BinaryType, VerbFlag};
 use moor_values::model::{WorldState, WorldStateSource};
 use moor_values::util::BitEnum;
-use moor_values::var::Var;
+use moor_values::var::{List};
 use moor_values::{AsByteBuffer, NOTHING, SYSTEM_OBJECT};
 
 fn create_worldstate() -> WiredTigerDB {
@@ -49,7 +49,7 @@ pub fn prepare_call_verb(
     world_state: &mut dyn WorldState,
     session: Arc<dyn Session>,
     verb_name: &str,
-    args: Vec<Var>,
+    args: List,
     max_ticks: usize,
 ) -> VmHost {
     let (scs_tx, _scs_rx) = crossbeam_channel::unbounded();
@@ -101,7 +101,7 @@ fn prepare_vm_execution(
     )
     .unwrap();
     let session = Arc::new(NoopClientSession::new());
-    let vm_host = prepare_call_verb(tx.as_mut(), session, "test", vec![], max_ticks);
+    let vm_host = prepare_call_verb(tx.as_mut(), session, "test", List::new(), max_ticks);
     assert_eq!(tx.commit().unwrap(), CommitResult::Success);
     vm_host
 }

--- a/crates/kernel/src/builtins/bf_list_sets.rs
+++ b/crates/kernel/src/builtins/bf_list_sets.rs
@@ -78,7 +78,7 @@ fn bf_listappend(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
     }
     let value = bf_args.args[1].clone();
     let list = &mut bf_args.args[0];
-    let Variant::List(mut list) = list.variant_mut().clone() else {
+    let Variant::List(list) = list.variant().clone() else {
         return Err(BfErr::Code(E_TYPE));
     };
     let new_list = if bf_args.args.len() == 2 {
@@ -392,20 +392,26 @@ fn bf_substitute(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
         return Err(BfErr::Code(E_INVARG));
     }
 
-    let (Variant::List(subs), Variant::Str(source)) = (subs[2].variant(), subs[3].variant()) else {
+    let (Some(a), Some(b)) = (subs.get(2), subs.get(3)) else {
+        return Err(BfErr::Code(E_INVARG));
+    };
+    let (Variant::List(subs), Variant::Str(source)) = (a.variant(), b.variant()) else {
         return Err(BfErr::Code(E_INVARG));
     };
 
     // Turn psubs into a Vec<(isize, isize)>. Raising errors on the way if they're not
     let mut mysubs = Vec::new();
-    for sub in &subs[..] {
+    for sub in subs.iter() {
         let Variant::List(sub) = sub.variant() else {
             return Err(BfErr::Code(E_INVARG));
         };
         if sub.len() != 2 {
             return Err(BfErr::Code(E_INVARG));
         }
-        let (Variant::Int(start), Variant::Int(end)) = (sub[0].variant(), sub[1].variant()) else {
+        let (Some(start), Some(end)) = (sub.get(0), sub.get(1)) else {
+            return Err(BfErr::Code(E_INVARG));
+        };
+        let (Variant::Int(start), Variant::Int(end)) = (start.variant(), end.variant()) else {
             return Err(BfErr::Code(E_INVARG));
         };
         mysubs.push((*start as isize, *end as isize));

--- a/crates/kernel/src/builtins/bf_list_sets.rs
+++ b/crates/kernel/src/builtins/bf_list_sets.rs
@@ -78,7 +78,7 @@ fn bf_listappend(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
     }
     let value = bf_args.args[1].clone();
     let list = &mut bf_args.args[0];
-    let Variant::List(list) = list.variant().clone() else {
+    let Variant::List(mut list) = list.variant().clone() else {
         return Err(BfErr::Code(E_TYPE));
     };
     let new_list = if bf_args.args.len() == 2 {

--- a/crates/kernel/src/builtins/bf_objects.rs
+++ b/crates/kernel/src/builtins/bf_objects.rs
@@ -23,8 +23,8 @@ use moor_values::model::{ObjFlag, ValSet};
 use moor_values::util::BitEnum;
 use moor_values::var::v_listv;
 use moor_values::var::Error::{E_ARGS, E_INVARG, E_NACC, E_TYPE};
-use moor_values::var::Variant;
 use moor_values::var::{v_bool, v_int, v_none, v_objid, v_str};
+use moor_values::var::{List, Variant};
 use moor_values::NOTHING;
 
 use crate::bf_declare;
@@ -160,7 +160,7 @@ fn bf_create(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
                     location: new_obj,
                     this: new_obj,
                     player: bf_args.exec_state.top().player,
-                    args: vec![],
+                    args: List::new(),
                     argstr: "".to_string(),
                     caller: bf_args.exec_state.top().this,
                 },
@@ -248,7 +248,7 @@ fn bf_recycle(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
                                 location: *obj,
                                 this: *obj,
                                 player: bf_args.exec_state.top().player,
-                                args: vec![],
+                                args: List::new(),
                                 argstr: "".to_string(),
                                 caller: bf_args.exec_state.top().this,
                             },
@@ -311,7 +311,7 @@ fn bf_recycle(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
                             location: *head_obj,
                             this: *head_obj,
                             player: bf_args.exec_state.top().player,
-                            args: vec![v_objid(*obj)],
+                            args: List::from_slice(&[v_objid(*obj)]),
                             argstr: "".to_string(),
                             caller: bf_args.exec_state.top().this,
                         },
@@ -411,7 +411,7 @@ fn bf_move(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
                                 location: *whereto,
                                 this: *whereto,
                                 player: bf_args.exec_state.top().player,
-                                args: vec![v_objid(*what)],
+                                args: List::from_slice(&[v_objid(*what)]),
                                 argstr: "".to_string(),
                                 caller: bf_args.exec_state.top().this,
                             },
@@ -487,7 +487,7 @@ fn bf_move(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
                                 location: original_location,
                                 this: original_location,
                                 player: bf_args.exec_state.top().player,
-                                args: vec![v_objid(*what)],
+                                args: List::from_slice(&[v_objid(*what)]),
                                 argstr: "".to_string(),
                                 caller: bf_args.exec_state.top().this,
                             },
@@ -531,7 +531,7 @@ fn bf_move(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
                                 location: *whereto,
                                 this: *whereto,
                                 player: bf_args.exec_state.top().player,
-                                args: vec![v_objid(*what)],
+                                args: List::from_slice(&[v_objid(*what)]),
                                 argstr: "".to_string(),
                                 caller: bf_args.exec_state.top().this,
                             },

--- a/crates/kernel/src/builtins/bf_verbs.rs
+++ b/crates/kernel/src/builtins/bf_verbs.rs
@@ -141,7 +141,7 @@ fn parse_verb_info(info: &List) -> Result<VerbAttrs, Error> {
     if info.len() != 3 {
         return Err(E_INVARG);
     }
-    match (info[0].variant(), info[1].variant(), info[2].variant()) {
+    match (info.get(0).unwrap().variant(), info.get(1).unwrap().variant(), info.get(2).unwrap().variant()) {
         (Variant::Obj(owner), Variant::Str(perms_str), Variant::Str(names)) => {
             let mut perms = BitEnum::new();
             for c in perms_str.as_str().chars() {
@@ -265,9 +265,9 @@ fn parse_verb_args(verbinfo: &List) -> Result<VerbArgsSpec, Error> {
         return Err(E_ARGS);
     }
     match (
-        verbinfo[0].variant(),
-        verbinfo[1].variant(),
-        verbinfo[2].variant(),
+        verbinfo.get(0).unwrap().variant(),
+        verbinfo.get(1).unwrap().variant(),
+        verbinfo.get(2).unwrap().variant(),
     ) {
         (Variant::Str(dobj_str), Variant::Str(prep_str), Variant::Str(iobj_str)) => {
             let (Some(dobj), Some(prep), Some(iobj)) = (

--- a/crates/kernel/src/builtins/bf_verbs.rs
+++ b/crates/kernel/src/builtins/bf_verbs.rs
@@ -397,7 +397,7 @@ fn bf_verb_code(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
     }
 
     // Decode.
-    let program = Program::from_sliceref(verb_info.binary()).map_err(|_| {
+    let program = Program::from_bytes(verb_info.binary()).map_err(|_| {
         error!(object=?bf_args.args[0], verb=?bf_args.args[1], "verb_code: verb program could not be decoded");
         BfErr::Code(E_INVARG)
     })?;
@@ -639,7 +639,7 @@ fn bf_disassemble(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
         return Ok(Ret(v_empty_list()));
     }
 
-    let program = Program::from_sliceref(verb_info.binary()).map_err(|_| {
+    let program = Program::from_bytes(verb_info.binary()).map_err(|_| {
         error!(object=?bf_args.args[0], verb=?bf_args.args[1], "disassemble: verb program could not be decoded");
         BfErr::Code(E_INVARG)
     })?;

--- a/crates/kernel/src/tasks/mod.rs
+++ b/crates/kernel/src/tasks/mod.rs
@@ -13,8 +13,7 @@
 //
 
 use crate::tasks::scheduler::TaskResult;
-use moor_values::var::Objid;
-use moor_values::var::Var;
+use moor_values::var::{List, Objid};
 use std::cell::Cell;
 use std::marker::PhantomData;
 use std::sync::MutexGuard;
@@ -53,7 +52,7 @@ pub struct VerbCall {
     pub location: Objid,
     pub this: Objid,
     pub player: Objid,
-    pub args: Vec<Var>,
+    pub args: List,
     pub argstr: String,
     pub caller: Objid,
 }
@@ -78,7 +77,7 @@ pub mod vm_test_utils {
     use crate::vm::VmExecParams;
     use moor_compiler::Program;
     use moor_values::model::WorldState;
-    use moor_values::var::{Objid, Var};
+    use moor_values::var::{List, Objid, Var};
     use moor_values::SYSTEM_OBJECT;
     use std::sync::Arc;
     use std::time::Duration;
@@ -160,7 +159,7 @@ pub mod vm_test_utils {
                     location: SYSTEM_OBJECT,
                     this: SYSTEM_OBJECT,
                     player: SYSTEM_OBJECT,
-                    args,
+                    args: List::from_slice(&args),
                     argstr: "".to_string(),
                     caller: SYSTEM_OBJECT,
                 },

--- a/crates/kernel/src/tasks/scheduler.rs
+++ b/crates/kernel/src/tasks/scheduler.rs
@@ -37,7 +37,7 @@ use moor_values::model::{BinaryType, CommandError, HasUuid, VerbAttrs};
 use moor_values::model::{CommitResult, Perms};
 use moor_values::model::{VerbProgramError, WorldStateSource};
 use moor_values::var::Error::{E_INVARG, E_PERM};
-use moor_values::var::{v_err, v_int, v_none, v_string, Var};
+use moor_values::var::{v_err, v_int, v_none, v_string, List, Var};
 use moor_values::var::{Objid, Variant};
 use moor_values::{AsByteBuffer, SYSTEM_OBJECT};
 use SchedulerError::{
@@ -281,7 +281,7 @@ impl Scheduler {
             player,
             vloc,
             verb,
-            args,
+            args: List::from_slice(&args),
             argstr,
         };
 
@@ -309,7 +309,7 @@ impl Scheduler {
             player,
             vloc: SYSTEM_OBJECT,
             verb: "do_out_of_band_command".to_string(),
-            args,
+            args: List::from_slice(&args),
             argstr,
         };
 

--- a/crates/kernel/src/tasks/task.rs
+++ b/crates/kernel/src/tasks/task.rs
@@ -24,8 +24,8 @@ use moor_values::model::VerbInfo;
 use moor_values::model::{CommandError, CommitResult, WorldStateError};
 use moor_values::model::{WorldState, WorldStateSource};
 use moor_values::util::parse_into_words;
-use moor_values::var::Objid;
 use moor_values::var::{v_int, v_string};
+use moor_values::var::{List, Objid};
 use moor_values::NOTHING;
 
 use crate::matching::match_env::MatchEnvironmentParseMatcher;
@@ -686,7 +686,7 @@ impl Task {
             location: target,
             this: target,
             player,
-            args: parsed_command.args.clone(),
+            args: List::from_slice(&parsed_command.args),
             argstr: parsed_command.argstr.clone(),
             caller: player,
         };

--- a/crates/kernel/src/tasks/task_messages.rs
+++ b/crates/kernel/src/tasks/task_messages.rs
@@ -22,8 +22,8 @@ use moor_compiler::Program;
 
 use moor_values::model::{CommandError, NarrativeEvent};
 use moor_values::model::{Perms, WorldStateSource};
-use moor_values::var::Objid;
 use moor_values::var::Var;
+use moor_values::var::{List, Objid};
 use std::time::SystemTime;
 
 #[derive(Debug, Clone)]
@@ -36,7 +36,7 @@ pub enum TaskStart {
         player: Objid,
         vloc: Objid,
         verb: String,
-        args: Vec<Var>,
+        args: List,
         argstr: String,
     },
     /// The scheduler is telling the task to run a task that was forked from another task.

--- a/crates/kernel/src/tasks/vm_host.rs
+++ b/crates/kernel/src/tasks/vm_host.rs
@@ -28,8 +28,8 @@ use moor_compiler::{compile, Name};
 use moor_values::model::VerbInfo;
 use moor_values::model::WorldState;
 use moor_values::model::{BinaryType, ObjFlag};
-use moor_values::var::Objid;
 use moor_values::var::Var;
+use moor_values::var::{List, Objid};
 use moor_values::AsByteBuffer;
 use std::sync::Arc;
 use std::time::{Duration, SystemTime};
@@ -309,7 +309,7 @@ impl VmHost {
                     result = self.vm.call_builtin_function(
                         &mut self.vm_exec_state,
                         bf_offset,
-                        &args,
+                        List::from_slice(&args),
                         &exec_params,
                         world_state,
                         self.sessions.clone(),
@@ -418,7 +418,7 @@ impl VmHost {
     pub fn reset_time(&mut self) {
         self.vm_exec_state.start_time = Some(SystemTime::now());
     }
-    pub fn args(&self) -> Vec<Var> {
+    pub fn args(&self) -> List {
         self.vm_exec_state.top().args.clone()
     }
 }

--- a/crates/kernel/src/textdump/write.rs
+++ b/crates/kernel/src/textdump/write.rs
@@ -61,7 +61,7 @@ impl<W: io::Write> TextdumpWriter<W> {
             Variant::List(l) => {
                 writeln!(self.writer, "{}\n{}", VarType::TYPE_LIST as i64, l.len())?;
                 for v in l.iter() {
-                    self.write_var(v, false)?;
+                    self.write_var(&v, false)?;
                 }
             }
             Variant::None => {

--- a/crates/kernel/src/textdump/write_db.rs
+++ b/crates/kernel/src/textdump/write_db.rs
@@ -14,7 +14,7 @@
 
 use std::collections::BTreeMap;
 
-use daumtils::SliceRef;
+use bytes::Bytes;
 use moor_compiler::Program;
 use moor_db::loader::LoaderInterface;
 use moor_values::model::{ArgSpec, PrepSpec, ValSet, VerbArgsSpec};
@@ -179,8 +179,8 @@ pub fn make_textdump(tx: &dyn LoaderInterface, version: Option<&str>) -> Textdum
                 .get_verb_binary(*db_objid, verb.uuid())
                 .expect("Failed to get verb binary");
 
-            let program = Program::from_sliceref(SliceRef::from_vec(binary))
-                .expect("Failed to parse verb binary");
+            let program =
+                Program::from_bytes(Bytes::from(binary)).expect("Failed to parse verb binary");
             let program = if !program.main_vector.is_empty() {
                 let ast = moor_compiler::program_to_tree(&program)
                     .expect("Failed to decompile verb binary");

--- a/crates/kernel/src/vm/activation.rs
+++ b/crates/kernel/src/vm/activation.rs
@@ -13,7 +13,7 @@
 //
 
 use daumtils::{BitArray, Bitset16, SliceRef};
-use moor_values::var::v_empty_str;
+use moor_values::var::{v_empty_str, List, Variant};
 use moor_values::NOTHING;
 use uuid::Uuid;
 
@@ -23,10 +23,10 @@ use moor_values::model::VerbDef;
 use moor_values::model::VerbInfo;
 use moor_values::model::{BinaryType, VerbFlag};
 use moor_values::util::BitEnum;
+use moor_values::var::Error;
 use moor_values::var::Error::E_VARNF;
 use moor_values::var::Objid;
 use moor_values::var::{v_empty_list, v_int, v_none, v_objid, v_str, v_string, Var, VarType};
-use moor_values::var::{v_listv, Error};
 
 use crate::tasks::command_parse::ParsedCommand;
 use crate::vm::VerbExecutionRequest;
@@ -102,7 +102,7 @@ pub(crate) struct Activation {
     /// The object that is the 'player' role; that is, the active user of this task.
     pub(crate) player: Objid,
     /// The arguments to the verb or bf being called.
-    pub(crate) args: Vec<Var>,
+    pub(crate) args: List,
     /// The name of the verb that is currently being executed.
     pub(crate) verb_name: String,
     /// The extended information about the verb that is currently being executed.
@@ -282,7 +282,7 @@ impl Activation {
         );
         frame.set_gvar(
             GlobalName::args,
-            v_listv(verb_call_request.call.args.clone()),
+            Var::new(Variant::List(verb_call_request.call.args.clone())),
         );
 
         // From the command, if any...
@@ -387,14 +387,14 @@ impl Activation {
             bf_index: None,
             bf_trampoline: None,
             bf_trampoline_arg: None,
-            args: vec![],
+            args: List::new(),
             permissions,
         }
     }
     pub fn for_bf_call(
         bf_index: usize,
         bf_name: &str,
-        args: Vec<Var>,
+        args: List,
         _verb_flags: BitEnum<VerbFlag>,
         player: Objid,
     ) -> Self {

--- a/crates/kernel/src/vm/activation.rs
+++ b/crates/kernel/src/vm/activation.rs
@@ -12,7 +12,8 @@
 // this program. If not, see <https://www.gnu.org/licenses/>.
 //
 
-use daumtils::{BitArray, Bitset16, SliceRef};
+use bytes::Bytes;
+use daumtils::{BitArray, Bitset16};
 use moor_values::var::{v_empty_str, List, Variant};
 use moor_values::NOTHING;
 use uuid::Uuid;
@@ -353,7 +354,7 @@ impl Activation {
                 BinaryType::None,
                 VerbArgsSpec::this_none_this(),
             ),
-            SliceRef::empty(),
+            Bytes::new(),
         );
 
         let mut frame = Frame {
@@ -409,7 +410,7 @@ impl Activation {
                 BinaryType::None,
                 VerbArgsSpec::this_none_this(),
             ),
-            SliceRef::empty(),
+            Bytes::new(),
         );
 
         // Frame doesn't really matter.

--- a/crates/kernel/src/vm/vm_execute.rs
+++ b/crates/kernel/src/vm/vm_execute.rs
@@ -272,7 +272,7 @@ impl VM {
                     // Track iteration count for range; set id to current list element for the count,
                     // then increment the count, rewind the program counter to the top of the loop, and
                     // continue.
-                    f.set_env(id, l[count].clone());
+                    f.set_env(id, l.get(count).unwrap().clone());
                     f.poke(0, v_int((count + 1) as i64));
                 }
                 Op::ForRange { end_label, id } => {
@@ -385,7 +385,7 @@ impl VM {
                         return self.push_error(state, E_TYPE);
                     };
 
-                    let new_list = list.append(tail);
+                    let new_list = list.append(&tail);
                     f.poke(0, new_list);
                 }
                 Op::IndexSet => {
@@ -698,7 +698,7 @@ impl VM {
                     let Variant::List(args) = args.variant() else {
                         return self.push_error(state, E_TYPE);
                     };
-                    return self.prepare_pass_verb(state, world_state, &args[..]);
+                    return self.prepare_pass_verb(state, world_state, args);
                 }
                 Op::CallVerb => {
                     let (args, verb, obj) = (f.pop(), f.pop(), f.pop());
@@ -713,7 +713,7 @@ impl VM {
                         world_state,
                         *obj,
                         verb.as_str(),
-                        &args[..],
+                        args.clone(),
                     );
                 }
                 Op::Return => {
@@ -735,7 +735,7 @@ impl VM {
                     return self.call_builtin_function(
                         state,
                         id.0 as usize,
-                        &args[..],
+                        args.clone(),
                         exec_params,
                         world_state,
                         session,

--- a/crates/kernel/tests/textdump.rs
+++ b/crates/kernel/tests/textdump.rs
@@ -14,7 +14,7 @@
 
 #[cfg(test)]
 mod test {
-    use daumtils::SliceRef;
+    use bytes::Bytes;
     use moor_compiler::Program;
     use moor_db::loader::LoaderInterface;
     use moor_db::Database;
@@ -367,11 +367,11 @@ mod test {
                 let binary2 = tx2.get_verb_binary(o, v2.uuid()).unwrap();
 
                 let program1 = moor_compiler::program_to_tree(
-                    &Program::from_sliceref(SliceRef::from_vec(binary1)).unwrap(),
+                    &Program::from_bytes(Bytes::from(binary1)).unwrap(),
                 )
                 .unwrap();
                 let program2 = moor_compiler::program_to_tree(
-                    &Program::from_sliceref(SliceRef::from_vec(binary2)).unwrap(),
+                    &Program::from_bytes(Bytes::from(binary2)).unwrap(),
                 )
                 .unwrap();
 

--- a/crates/values/Cargo.toml
+++ b/crates/values/Cargo.toml
@@ -26,3 +26,8 @@ thiserror.workspace = true
 uuid.workspace = true
 yoke.workspace = true
 paste.workspace = true
+
+[features]
+# If List and String are backed by Bytes instead of Arc<Vec<Var>> and Arc<String> respectively.
+list_impl_buffer = []
+default = []

--- a/crates/values/src/encode.rs
+++ b/crates/values/src/encode.rs
@@ -14,7 +14,7 @@
 
 use bincode::enc::write::Writer;
 use bincode::error::EncodeError;
-use daumtils::SliceRef;
+use bytes::Bytes;
 use lazy_static::lazy_static;
 
 lazy_static! {
@@ -55,11 +55,11 @@ pub trait AsByteBuffer {
     fn make_copy_as_vec(&self) -> Result<Vec<u8>, EncodingError>;
     /// Create a value from the given bytes.
     /// Either takes ownership or moves.
-    fn from_sliceref(bytes: SliceRef) -> Result<Self, DecodingError>
+    fn from_bytes(bytes: Bytes) -> Result<Self, DecodingError>
     where
         Self: Sized;
-    /// As a sliceref...
-    fn as_sliceref(&self) -> Result<SliceRef, EncodingError>;
+    /// As a Bytes...
+    fn as_bytes(&self) -> Result<Bytes, EncodingError>;
 }
 
 pub struct CountingWriter {

--- a/crates/values/src/lib.rs
+++ b/crates/values/src/lib.rs
@@ -14,7 +14,10 @@
 
 extern crate core;
 
-pub use encode::{AsByteBuffer, CountingWriter, DecodingError, EncodingError, BINCODE_CONFIG};
+pub use encode::{
+    AsByteBuffer, BincodeAsByteBufferExt, CountingWriter, DecodingError, EncodingError,
+    BINCODE_CONFIG,
+};
 
 use crate::var::Objid;
 

--- a/crates/values/src/lib.rs
+++ b/crates/values/src/lib.rs
@@ -14,7 +14,7 @@
 
 extern crate core;
 
-pub use encode::{AsByteBuffer, DecodingError, EncodingError};
+pub use encode::{AsByteBuffer, CountingWriter, DecodingError, EncodingError, BINCODE_CONFIG};
 
 use crate::var::Objid;
 

--- a/crates/values/src/model/verb_info.rs
+++ b/crates/values/src/model/verb_info.rs
@@ -15,17 +15,16 @@
 use crate::encode::{DecodingError, EncodingError};
 use crate::model::verbdef::VerbDef;
 use crate::AsByteBuffer;
-use bytes::BufMut;
-use daumtils::SliceRef;
+use bytes::{BufMut, Bytes};
 use std::convert::TryInto;
 
 /// The binding of both a `VerbDef` and the binary (program) associated with it.
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct VerbInfo(SliceRef);
+pub struct VerbInfo(Bytes);
 
 impl VerbInfo {
     #[must_use]
-    pub fn new(verbdef: VerbDef, binary: SliceRef) -> Self {
+    pub fn new(verbdef: VerbDef, binary: Bytes) -> Self {
         let mut storage = Vec::new();
         // Both values we hold are variable sized, but the program is always at the end, so we can
         // just append it without a length prefix.
@@ -35,20 +34,20 @@ impl VerbInfo {
                 storage.put_slice(buffer);
             })
             .expect("Failed to encode verbdef");
-        storage.put_slice(binary.as_slice());
-        Self(SliceRef::from_bytes(&storage))
+        storage.put(binary.as_ref());
+        Self(Bytes::from(storage))
     }
 
     #[must_use]
     pub fn verbdef(&self) -> VerbDef {
-        let vd_len = u32::from_le_bytes(self.0.as_slice()[0..4].try_into().unwrap()) as usize;
-        VerbDef::from_sliceref(self.0.slice(4..4 + vd_len)).expect("Failed to decode verbdef")
+        let vd_len = u32::from_le_bytes(self.0[0..4].try_into().unwrap()) as usize;
+        VerbDef::from_bytes(self.0.slice(4..4 + vd_len)).expect("Failed to decode verbdef")
     }
 
     #[must_use]
-    pub fn binary(&self) -> SliceRef {
+    pub fn binary(&self) -> Bytes {
         // The binary is after the verbdef, which is prefixed with a u32 length.
-        let vd_len = u32::from_le_bytes(self.0.as_slice()[0..4].try_into().unwrap()) as usize;
+        let vd_len = u32::from_le_bytes(self.0[0..4].try_into().unwrap()) as usize;
         self.0.slice(4 + vd_len..)
     }
 }
@@ -59,19 +58,19 @@ impl AsByteBuffer for VerbInfo {
     }
 
     fn with_byte_buffer<R, F: FnMut(&[u8]) -> R>(&self, mut f: F) -> Result<R, EncodingError> {
-        Ok(f(self.0.as_slice()))
+        Ok(f(self.0.as_ref()))
     }
 
     fn make_copy_as_vec(&self) -> Result<Vec<u8>, EncodingError> {
-        Ok(self.0.as_slice().to_vec())
+        Ok(self.0.to_vec())
     }
 
-    fn from_sliceref(bytes: SliceRef) -> Result<Self, DecodingError> {
+    fn from_bytes(bytes: Bytes) -> Result<Self, DecodingError> {
         // TODO validate
         Ok(Self(bytes))
     }
 
-    fn as_sliceref(&self) -> Result<SliceRef, EncodingError> {
+    fn as_bytes(&self) -> Result<Bytes, EncodingError> {
         Ok(self.0.clone())
     }
 }

--- a/crates/values/src/model/verbs.rs
+++ b/crates/values/src/model/verbs.rs
@@ -116,7 +116,7 @@ impl LayoutAs<u8> for BinaryType {
     }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq, Encode, Decode)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct VerbAttrs {
     pub definer: Option<Objid>,
     pub owner: Option<Objid>,

--- a/crates/values/src/util/bitenum.rs
+++ b/crates/values/src/util/bitenum.rs
@@ -20,7 +20,7 @@ use crate::encode::{DecodingError, EncodingError};
 
 use crate::AsByteBuffer;
 use bincode::{Decode, Encode};
-use daumtils::SliceRef;
+use bytes::Bytes;
 /// A barebones minimal custom bitset enum, to replace use of `EnumSet` crate which was not rkyv'able.
 use num_traits::ToPrimitive;
 
@@ -154,11 +154,11 @@ impl<T: ToPrimitive> AsByteBuffer for BitEnum<T> {
         Ok(self.value.to_le_bytes().to_vec())
     }
 
-    fn from_sliceref(bytes: SliceRef) -> Result<Self, DecodingError>
+    fn from_bytes(bytes: Bytes) -> Result<Self, DecodingError>
     where
         Self: Sized,
     {
-        let bytes = bytes.as_slice();
+        let bytes = bytes.as_ref();
         if bytes.len() != 2 {
             return Err(DecodingError::CouldNotDecode(format!(
                 "Expected 2 bytes, got {}",
@@ -173,7 +173,7 @@ impl<T: ToPrimitive> AsByteBuffer for BitEnum<T> {
         })
     }
 
-    fn as_sliceref(&self) -> Result<SliceRef, EncodingError> {
-        Ok(SliceRef::from_vec(self.value.to_le_bytes().to_vec()))
+    fn as_bytes(&self) -> Result<Bytes, EncodingError> {
+        Ok(Bytes::from(self.value.to_le_bytes().to_vec()))
     }
 }

--- a/crates/values/src/var/error.rs
+++ b/crates/values/src/var/error.rs
@@ -12,13 +12,13 @@
 // this program. If not, see <https://www.gnu.org/licenses/>.
 //
 
-use binary_layout::LayoutAs;
 use std::fmt::{Display, Formatter};
 
-use crate::encode::{DecodingError, EncodingError};
+use binary_layout::LayoutAs;
 use bincode::{Decode, Encode};
 use strum::FromRepr;
 
+use crate::encode::{DecodingError, EncodingError};
 use crate::var::{v_none, Var};
 
 #[repr(u8)]

--- a/crates/values/src/var/list.rs
+++ b/crates/values/src/var/list.rs
@@ -16,7 +16,7 @@ use std::cmp::min;
 use std::fmt::{Display, Formatter, Result as FmtResult};
 use std::hash::{Hash, Hasher};
 
-use crate::AsByteBuffer;
+use crate::{AsByteBuffer, DecodingError, EncodingError};
 use bincode::de::{BorrowDecoder, Decoder};
 use bincode::enc::Encoder;
 use bincode::error::{DecodeError, EncodeError};
@@ -491,6 +491,31 @@ impl From<List> for Vec<Var> {
             result.push(value.get(i).unwrap());
         }
         result
+    }
+}
+
+impl AsByteBuffer for List {
+    fn size_bytes(&self) -> usize {
+        self.0.len()
+    }
+
+    fn with_byte_buffer<R, F: FnMut(&[u8]) -> R>(&self, mut f: F) -> Result<R, EncodingError> {
+        Ok(f(self.0.as_slice()))
+    }
+
+    fn make_copy_as_vec(&self) -> Result<Vec<u8>, EncodingError> {
+        Ok(self.0.as_slice().to_vec())
+    }
+
+    fn from_sliceref(bytes: SliceRef) -> Result<Self, DecodingError>
+    where
+        Self: Sized,
+    {
+        Ok(Self(bytes))
+    }
+
+    fn as_sliceref(&self) -> Result<SliceRef, EncodingError> {
+        Ok(self.0.clone())
     }
 }
 

--- a/crates/values/src/var/list.rs
+++ b/crates/values/src/var/list.rs
@@ -14,173 +14,463 @@
 
 use std::cmp::min;
 use std::fmt::{Display, Formatter, Result as FmtResult};
-use std::ops::{Index, Range, RangeFrom, RangeFull, RangeTo};
-use std::sync::Arc;
+use std::hash::{Hash, Hasher};
 
-use bincode::{Decode, Encode};
+use crate::AsByteBuffer;
+use bincode::de::{BorrowDecoder, Decoder};
+use bincode::enc::Encoder;
+use bincode::error::{DecodeError, EncodeError};
+use bincode::{BorrowDecode, Decode, Encode};
+use daumtils::SliceRef;
 
 use crate::var::variant::Variant;
 use crate::var::{v_empty_list, Var};
 
-#[derive(Clone, Debug, Encode, Decode, Eq, PartialEq, Ord, PartialOrd, Hash)]
-pub struct List {
-    // TODO: Implement our own zero-copy list type and get rid of bincoding
-    //   To support nested content, would require an offsets table at the front, etc.
-    //   Take a look at how flatbufers, capnproto, and other zero-copy serialization formats do this.
-    inner: Arc<Vec<Var>>,
+#[derive(Clone, Debug)]
+pub struct List(SliceRef);
+
+fn offsets_end_pos(buf: &[u8]) -> usize {
+    unsafe {
+        let ptr = buf.as_ptr() as *const u32;
+        *ptr as usize
+    }
+}
+
+fn offset_at(buf: &[u8], index: usize) -> usize {
+    let ptr = buf.as_ptr() as *const u32;
+    unsafe { *ptr.add(index + 1) as usize }
 }
 
 impl List {
-    #[must_use]
     pub fn new() -> Self {
-        Self {
-            inner: Arc::new(Vec::new()),
-        }
+        Self(SliceRef::from_vec(Vec::new()))
     }
 
-    #[must_use]
-    pub fn from_vec(vec: Vec<Var>) -> Self {
-        Self {
-            inner: Arc::new(vec),
+    pub fn len(&self) -> usize {
+        let l = self.0.len();
+        if l == 0 || l == 4 {
+            return 0;
         }
+
+        let slc = self.0.as_slice();
+        let offsets_end = offsets_end_pos(slc);
+        let offsets_len = offsets_end - 4;
+        // The offsets table is 4 bytes per offset.
+        offsets_len >> 2
     }
 
-    #[must_use]
-    pub fn push(&mut self, v: Var) -> Var {
-        // If there's only one copy of us, mutate that directly.
-        match Arc::get_mut(&mut self.inner) {
-            Some(vec) => {
-                vec.push(v);
-                Variant::List(self.clone()).into()
-            }
-            None => {
-                let mut new_vec = (*self.inner).clone();
-                new_vec.push(v);
-                Variant::List(Self::from_vec(new_vec)).into()
-            }
+    pub fn is_empty(&self) -> bool {
+        let l = self.0.len();
+        if l == 0 || l == 4 {
+            return true;
         }
+        false
     }
 
-    /// Take the first item from the front, and return (item, `new_list`)
-    #[must_use]
+    pub fn get(&self, index: usize) -> Option<Var> {
+        let len = self.len();
+        if index >= len {
+            return None;
+        }
+
+        let slc = self.0.as_slice();
+        let offsets_end = offsets_end_pos(slc);
+
+        // The offsets table is 4 bytes per offset.
+        let data_offset = offset_at(slc, index);
+
+        let data_section = &self.0.slice(offsets_end..);
+
+        // If this is the last item, we can just slice to the end of the data section.
+        if index == len - 1 {
+            let slice_ref = data_section.slice(data_offset..);
+            return Some(Var::from_sliceref(slice_ref).expect("could not decode var"));
+        }
+
+        // Otherwise, we need to slice from this offset to the next offset.
+        let next_offset = offset_at(slc, index + 1);
+
+        // Note that the offsets are relative to the start of the data section.
+        let data = data_section.slice(data_offset..next_offset);
+        Var::from_sliceref(data.clone()).ok()
+    }
+
+    pub fn from_slice(vec: &[Var]) -> List {
+        let mut data = Vec::new();
+
+        let mut relative_offset: u32 = 0;
+        let mut offsets = Vec::with_capacity(vec.len() * 4);
+        for v in vec.iter() {
+            offsets.extend_from_slice(&relative_offset.to_le_bytes());
+            let vsr = v.as_sliceref().unwrap();
+            let bytes = vsr.as_slice();
+            data.extend_from_slice(bytes);
+            relative_offset += bytes.len() as u32;
+        }
+
+        let mut result = Vec::with_capacity(4 + offsets.len() + data.len());
+        result.extend_from_slice(&(offsets.len() as u32 + 4).to_le_bytes());
+        result.extend_from_slice(&offsets);
+        result.extend_from_slice(&data);
+
+        Self(SliceRef::from_vec(result))
+    }
+
+    // expensive because we need to extend both buffer length and the offsets length...
+    pub fn push(&self, v: Var) -> Var {
+        let len = self.len();
+
+        let data_sr = v.as_sliceref().unwrap();
+
+        // Special case if we're empty.
+        if len == 0 {
+            let mut new_offsets = Vec::with_capacity(4);
+            let offset: u32 = 0;
+            new_offsets.extend_from_slice(&offset.to_le_bytes());
+
+            let mut result = Vec::with_capacity(4 + new_offsets.len() + data_sr.len());
+            result.extend_from_slice(&8u32.to_le_bytes());
+            result.extend_from_slice(&new_offsets);
+            result.extend_from_slice(data_sr.as_slice());
+
+            return Var::new(Variant::List(Self(SliceRef::from_vec(result))));
+        }
+
+        let slc = self.0.as_slice();
+        let offsets_end = offsets_end_pos(slc);
+
+        let existing_offset_table = &slc[4..offsets_end];
+        let existing_data = &slc[offsets_end..];
+
+        // Add the new offset to the offsets table. The new offset is end of the old data section,
+        // that is, the length of the whole buffer.
+        let mut new_offsets = Vec::with_capacity(existing_offset_table.len() + 4);
+        new_offsets.extend_from_slice(existing_offset_table);
+        let new_offset = existing_data.len() as u32;
+        new_offsets.extend_from_slice(&new_offset.to_le_bytes());
+
+        // Add the new data to the data section.
+        let mut new_data = Vec::with_capacity(existing_data.len() + data_sr.len());
+        new_data.extend_from_slice(existing_data);
+        new_data.extend_from_slice(data_sr.as_slice());
+
+        // Update offsets end
+        let new_offsets_end = new_offsets.len() as u32 + 4;
+
+        // Result is new_offsets_len + new_offsets + new_data
+        let mut result = Vec::with_capacity(4 + new_offsets.len() + new_data.len());
+        result.extend_from_slice(&new_offsets_end.to_le_bytes());
+        result.extend_from_slice(&new_offsets);
+        result.extend_from_slice(&new_data);
+
+        Var::new(Variant::List(Self(SliceRef::from_vec(result))))
+    }
+
     pub fn pop_front(&self) -> (Var, Var) {
-        if self.inner.is_empty() {
+        let len = self.len();
+        if len == 0 {
             return (v_empty_list(), v_empty_list());
         }
-        let mut new_list = (*self.inner).clone();
-        let item = new_list.remove(0);
-        (item.clone(), Variant::List(Self::from_vec(new_list)).into())
+
+        if len == 1 {
+            return (self.get(0).unwrap(), v_empty_list());
+        }
+
+        let slc = self.0.as_slice();
+        let offsets_end = offsets_end_pos(slc);
+
+        // Get the offset table
+        let offsets_table = &slc[4..offsets_end];
+
+        // Splice off the data section after the first item
+        let data_section = &self.0.slice(offsets_end..);
+        let first_offset = offset_at(slc, 0);
+        let next_offset = offset_at(slc, 1);
+        let length = next_offset - first_offset;
+        let data = data_section.slice(first_offset..next_offset);
+
+        // Now rebuild the offset table, subtracting the length of the first item
+        let mut new_offsets = Vec::with_capacity(offsets_table.len() - 4);
+        for i in 1..len {
+            let offset = offset_at(slc, i);
+            let new_offset = (offset - length) as u32;
+            new_offsets.extend_from_slice(&new_offset.to_le_bytes());
+        }
+
+        // Now reconstruct
+        let mut result = Vec::with_capacity(4 + new_offsets.len() + data.len());
+        result.extend_from_slice(&(new_offsets.len() as u32 + 4).to_le_bytes());
+        result.extend_from_slice(&new_offsets);
+        result.extend_from_slice(data_section.slice(next_offset..).as_slice());
+
+        (
+            Var::from_sliceref(data).unwrap(),
+            Var::new(Variant::List(Self(SliceRef::from_vec(result)))),
+        )
     }
 
-    #[must_use]
-    pub fn append(&mut self, other: Self) -> Var {
-        match Arc::get_mut(&mut self.inner) {
-            Some(vec) => {
-                vec.extend_from_slice(&other.inner);
-                Variant::List(self.clone()).into()
-            }
-            None => {
-                let mut new_list = (*self.inner).clone();
-                new_list.extend_from_slice(&other.inner);
-                Variant::List(Self::from_vec(new_list)).into()
-            }
+    pub fn append(&self, other: &Self) -> Var {
+        let len = self.len();
+        if len == 0 {
+            return Var::new(Variant::List(other.clone()));
         }
+
+        let other_len = other.len();
+        if other_len == 0 {
+            return Var::new(Variant::List(self.clone()));
+        }
+
+        // Find the starts of the two data sections
+        let slc = self.0.as_slice();
+        let oth_slc = other.0.as_slice();
+
+        let data_start_self = offsets_end_pos(slc);
+        let data_start_other = offsets_end_pos(oth_slc);
+
+        // Get their data sections
+        let data_self = &slc[data_start_self..];
+        let data_other = &oth_slc[data_start_other..];
+
+        // Get the two offsets tables
+        let offset_table_self = &slc[4..data_start_self];
+        let offset_table_other = &oth_slc[4..data_start_other];
+
+        let self_offset_len = offset_table_self.len();
+
+        // Construct a new offset table, leaving self intact and then adjusting other.
+        let mut new_offset_table = Vec::with_capacity(self_offset_len + offset_table_other.len());
+        new_offset_table.extend_from_slice(offset_table_self);
+        for i in 0..other_len {
+            let offset = offset_at(oth_slc, i);
+            let new_offset = (offset + data_self.len()) as u32;
+            new_offset_table.extend_from_slice(&new_offset.to_le_bytes());
+        }
+
+        let mut result =
+            Vec::with_capacity(4 + new_offset_table.len() + data_self.len() + data_other.len());
+        result.extend_from_slice(&(new_offset_table.len() as u32 + 4).to_le_bytes());
+        result.extend_from_slice(&new_offset_table);
+        result.extend_from_slice(data_self);
+        result.extend_from_slice(data_other);
+
+        Var::new(Variant::List(Self(SliceRef::from_vec(result))))
     }
 
-    #[must_use]
-    pub fn remove_at(&mut self, index: usize) -> Var {
-        match Arc::get_mut(&mut self.inner) {
-            Some(vec) => {
-                vec.remove(index);
-                Variant::List(self.clone()).into()
-            }
-            None => {
-                let mut new_list = (*self.inner).clone();
-                new_list.remove(index);
-                Variant::List(Self::from_vec(new_list)).into()
-            }
+    pub fn remove_at(&self, index: usize) -> Var {
+        let len = self.len();
+        if len == 0 {
+            return Var::new(Variant::List(self.clone()));
         }
+
+        if len == 1 {
+            return v_empty_list();
+        }
+
+        // This will involve rebuilding both the offsets and data sections.
+        let slc = self.0.as_slice();
+        let old_data_start = offsets_end_pos(slc);
+
+        let old_data = &slc[old_data_start..];
+        let old_offsets = &slc[4..old_data_start];
+
+        let remove_item_offset =
+            u32::from_le_bytes(old_offsets[index * 4..(index + 1) * 4].try_into().unwrap())
+                as usize;
+        let remove_item_length = if index == len - 1 {
+            old_data.len() - remove_item_offset
+        } else {
+            let next_offset = offset_at(slc, index + 1);
+            next_offset - remove_item_offset
+        };
+
+        let mut new_offsets = Vec::with_capacity(old_offsets.len() - 4);
+        let mut new_data = Vec::with_capacity(old_data.len() - remove_item_length);
+
+        // Iterate to generate
+        for i in 0..len {
+            if i == index {
+                continue;
+            }
+
+            let offset = offset_at(slc, i);
+            let data = if i == len - 1 {
+                &old_data[offset..]
+            } else {
+                let next_offset = offset_at(slc, i + 1);
+                &old_data[offset..next_offset]
+            };
+            let new_offset = new_data.len() as u32;
+            new_data.extend_from_slice(data);
+            new_offsets.extend_from_slice(&new_offset.to_le_bytes());
+        }
+
+        let mut result = Vec::with_capacity(4 + new_offsets.len() + new_data.len());
+        result.extend_from_slice(&(new_offsets.len() as u32 + 4).to_le_bytes());
+        result.extend_from_slice(&new_offsets);
+        result.extend_from_slice(&new_data);
+        Var::new(Variant::List(Self(SliceRef::from_vec(result))))
     }
 
     /// Remove the first found instance of the given value from the list.
     #[must_use]
-    pub fn setremove(&mut self, value: &Var) -> Var {
-        if self.inner.is_empty() {
-            return v_empty_list();
+    pub fn setremove(&self, value: &Var) -> Var {
+        let len = self.len();
+        if len == 0 {
+            return Var::new(Variant::List(self.clone()));
         }
-        match Arc::get_mut(&mut self.inner) {
-            Some(vec) => {
-                for i in 0..vec.len() {
-                    if !vec[i].eq(value) {
-                        vec.remove(i);
-                        break;
-                    }
-                }
-                Variant::List(self.clone()).into()
+
+        if len == 1 {
+            if self.get(0).unwrap().eq(value) {
+                return v_empty_list();
             }
-            None => {
-                let mut new_list = Vec::with_capacity(self.inner.len() - 1);
-                let mut found = false;
-                for v in self.inner.iter() {
-                    if !found && v.eq(value) {
-                        found = true;
-                        continue;
-                    }
-                    new_list.push(v.clone());
-                }
-                Variant::List(Self::from_vec(new_list)).into()
+            return Var::new(Variant::List(self.clone()));
+        }
+
+        // This will involve rebuilding both the offsets and data sections.
+        let slc = self.0.as_slice();
+        let old_data_start = offsets_end_pos(slc);
+
+        let old_data = &self.0.slice(old_data_start..);
+        let old_offsets = &slc[4..old_data_start];
+
+        let mut new_offsets = Vec::with_capacity(old_offsets.len() - 4);
+        let mut new_data = Vec::with_capacity(old_data.len());
+
+        // Iterate to generate
+        let mut found = false;
+        for i in 0..len {
+            let offset = offset_at(slc, i);
+            let data = if i == len - 1 {
+                old_data.slice(offset..)
+            } else {
+                let next_offset = offset_at(slc, i + 1);
+                old_data.slice(offset..next_offset)
+            };
+            let v = Var::from_sliceref(data.clone()).unwrap();
+            if !found && v.eq(value) {
+                found = true;
+                continue;
+            }
+
+            let new_offset = new_data.len() as u32;
+            new_data.extend_from_slice(data.as_slice());
+            new_offsets.extend_from_slice(&new_offset.to_le_bytes());
+        }
+
+        let mut result = Vec::with_capacity(4 + new_offsets.len() + new_data.len());
+        result.extend_from_slice(&(new_offsets.len() as u32 + 4).to_le_bytes());
+        result.extend_from_slice(&new_offsets);
+        result.extend_from_slice(&new_data);
+        Var::new(Variant::List(Self(SliceRef::from_vec(result))))
+    }
+
+    pub fn insert(&self, index: isize, value: Var) -> Var {
+        let index = if index < 0 {
+            0
+        } else {
+            min(index as usize, self.len())
+        };
+
+        // Special case if inserting at end, it's just push
+        if index == self.len() {
+            return self.push(value);
+        }
+
+        // Special case if we're empty.
+        if self.is_empty() {
+            return Var::new(Variant::List(Self::from_slice(&[value])));
+        }
+
+        // Accumulate up to the insertion point, building the new offsets and data sections.
+        // Then add the new item, and then add the rest of the items.
+        let slc = self.0.as_slice();
+        let old_data_start = offsets_end_pos(slc);
+        let old_data = &slc[old_data_start..];
+        let old_offsets = &slc[4..old_data_start];
+
+        let mut new_offsets = Vec::with_capacity(old_offsets.len() + 4);
+        let mut new_data = Vec::with_capacity(old_data.len() + value.as_sliceref().unwrap().len());
+
+        for i in 0..self.len() {
+            if i == index {
+                let new_offset = new_data.len() as u32;
+                new_offsets.extend_from_slice(&new_offset.to_le_bytes());
+                new_data.extend_from_slice(value.as_sliceref().unwrap().as_slice());
+            }
+            let offset = offset_at(slc, i);
+            let length = if i == self.len() - 1 {
+                old_data.len() - offset
+            } else {
+                let next_offset = offset_at(slc, i + 1);
+                next_offset - offset
+            };
+            let new_offset = new_data.len() as u32;
+            new_offsets.extend_from_slice(&new_offset.to_le_bytes());
+            new_data.extend_from_slice(&old_data[offset..offset + length]);
+        }
+
+        let mut result = Vec::with_capacity(4 + new_offsets.len() + new_data.len());
+        result.extend_from_slice(&(new_offsets.len() as u32 + 4).to_le_bytes());
+        result.extend_from_slice(&new_offsets);
+        result.extend_from_slice(&new_data);
+        Var::new(Variant::List(Self(SliceRef::from_vec(result))))
+    }
+
+    pub fn set(&self, index: usize, value: Var) -> Var {
+        let len = self.len();
+        if index >= len {
+            return Var::new(Variant::List(self.clone()));
+        }
+
+        // This will involve rebuilding both the offsets and data sections.
+        let slc = self.0.as_slice();
+        let old_data_start = offsets_end_pos(slc);
+
+        let old_data = &self.0.slice(old_data_start..);
+        let old_offsets = &slc[4..old_data_start];
+
+        let mut new_offsets = Vec::with_capacity(old_offsets.len());
+        let mut new_data = Vec::with_capacity(old_data.len());
+
+        // Iterate to generate
+        for i in 0..len {
+            let offset = offset_at(slc, i);
+            let data = if i == len - 1 {
+                old_data.slice(offset..)
+            } else {
+                let next_offset = offset_at(slc, i + 1);
+                old_data.slice(offset..next_offset)
+            };
+            if i == index {
+                let new_offset = new_data.len() as u32;
+                new_offsets.extend_from_slice(&new_offset.to_le_bytes());
+                new_data.extend_from_slice(value.as_sliceref().unwrap().as_slice());
+            } else {
+                let new_offset = new_data.len() as u32;
+                new_offsets.extend_from_slice(&new_offset.to_le_bytes());
+                new_data.extend_from_slice(data.as_slice());
             }
         }
+
+        let mut result = Vec::with_capacity(4 + new_offsets.len() + new_data.len());
+        result.extend_from_slice(&(new_offsets.len() as u32 + 4).to_le_bytes());
+        result.extend_from_slice(&new_offsets);
+        result.extend_from_slice(&new_data);
+        Var::new(Variant::List(Self(SliceRef::from_vec(result))))
     }
 
-    #[must_use]
-    pub fn insert(&mut self, index: isize, v: Var) -> Var {
-        match Arc::get_mut(&mut self.inner) {
-            Some(vec) => {
-                let index = if index < 0 {
-                    0
-                } else {
-                    min(index as usize, vec.len())
-                };
-                vec.insert(index, v);
-                Variant::List(self.clone()).into()
-            }
-            None => {
-                let mut new_list = Vec::with_capacity(self.inner.len() + 1);
-                let index = if index < 0 {
-                    0
-                } else {
-                    min(index as usize, self.inner.len())
-                };
-                new_list.extend_from_slice(&self.inner[..index]);
-                new_list.push(v);
-                new_list.extend_from_slice(&self.inner[index..]);
-                Variant::List(Self::from_vec(new_list)).into()
-            }
-        }
-    }
-
-    #[must_use]
-    pub fn len(&self) -> usize {
-        self.inner.len()
-    }
-
-    #[must_use]
-    pub fn is_empty(&self) -> bool {
-        self.inner.is_empty()
-    }
-
-    // "in" operator is case insensitive...
-    #[must_use]
+    // Case insensitive
     pub fn contains(&self, v: &Var) -> bool {
-        self.inner.contains(v)
+        self.iter().any(|item| item.eq(v))
     }
 
-    // but bf_is_member is not... sigh.
-    #[must_use]
+    pub fn iter(&self) -> impl Iterator<Item = Var> + '_ {
+        (0..self.len()).map(move |i| self.get(i).unwrap())
+    }
+
     pub fn contains_case_sensitive(&self, v: &Var) -> bool {
         if let Variant::Str(s) = v.variant() {
-            for item in self.inner.iter() {
+            for item in self.iter() {
                 if let Variant::Str(s2) = item.variant() {
                     if s.as_str() == s2.as_str() {
                         return true;
@@ -189,37 +479,18 @@ impl List {
             }
             return false;
         }
-        self.inner.contains(v)
-    }
-
-    #[must_use]
-    pub fn get(&self, index: usize) -> Option<&Var> {
-        self.inner.get(index)
-    }
-
-    #[must_use]
-    pub fn set(&mut self, index: usize, value: Var) -> Var {
-        match Arc::get_mut(&mut self.inner) {
-            Some(vec) => {
-                vec[index] = value;
-                Variant::List(self.clone()).into()
-            }
-            None => {
-                let mut new_vec = (*self.inner).clone();
-                new_vec[index] = value;
-                Variant::List(Self::from_vec(new_vec)).into()
-            }
-        }
-    }
-
-    pub fn iter(&self) -> impl Iterator<Item = &Var> {
-        self.inner.iter()
+        self.contains(v)
     }
 }
 
 impl From<List> for Vec<Var> {
-    fn from(val: List) -> Self {
-        val.inner[..].to_vec()
+    fn from(value: List) -> Self {
+        let len = value.len();
+        let mut result = Vec::with_capacity(len);
+        for i in 0..len {
+            result.push(value.get(i).unwrap());
+        }
+        result
     }
 }
 
@@ -229,51 +500,11 @@ impl Default for List {
     }
 }
 
-impl Index<usize> for List {
-    type Output = Var;
-
-    fn index(&self, index: usize) -> &Self::Output {
-        &self.inner[index]
-    }
-}
-
-impl Index<Range<usize>> for List {
-    type Output = [Var];
-
-    fn index(&self, index: Range<usize>) -> &Self::Output {
-        &self.inner[index]
-    }
-}
-
-impl Index<RangeFrom<usize>> for List {
-    type Output = [Var];
-
-    fn index(&self, index: RangeFrom<usize>) -> &Self::Output {
-        &self.inner[index]
-    }
-}
-
-impl Index<RangeTo<usize>> for List {
-    type Output = [Var];
-
-    fn index(&self, index: RangeTo<usize>) -> &Self::Output {
-        &self.inner[index]
-    }
-}
-
-impl Index<RangeFull> for List {
-    type Output = [Var];
-
-    fn index(&self, index: RangeFull) -> &Self::Output {
-        &self.inner[index]
-    }
-}
-
 impl Display for List {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         write!(f, "{{")?;
         let mut first = true;
-        for v in self.inner.iter() {
+        for v in self.iter() {
             if !first {
                 write!(f, ", ")?;
             }
@@ -284,22 +515,99 @@ impl Display for List {
     }
 }
 
+impl Encode for List {
+    fn encode<E: Encoder>(&self, encoder: &mut E) -> Result<(), EncodeError> {
+        self.0.as_slice().encode(encoder)
+    }
+}
+
+impl Decode for List {
+    fn decode<D: Decoder>(decoder: &mut D) -> Result<Self, DecodeError> {
+        let vec = Vec::<u8>::decode(decoder)?;
+        Ok(Self(SliceRef::from_vec(vec)))
+    }
+}
+
+impl<'de> BorrowDecode<'de> for List {
+    fn borrow_decode<D: BorrowDecoder<'de>>(decoder: &mut D) -> Result<Self, DecodeError> {
+        let vec = Vec::<u8>::borrow_decode(decoder)?;
+        Ok(Self(SliceRef::from_vec(vec)))
+    }
+}
+
+impl PartialEq for List {
+    fn eq(&self, other: &Self) -> bool {
+        if self.len() != other.len() {
+            return false;
+        }
+        for (a, b) in self.iter().zip(other.iter()) {
+            if !a.eq(&b) {
+                return false;
+            }
+        }
+        true
+    }
+}
+impl Eq for List {}
+
+impl Hash for List {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        for item in self.iter() {
+            item.hash(state);
+        }
+    }
+}
+impl PartialOrd for List {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for List {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        let len = self.len();
+        if len != other.len() {
+            return len.cmp(&other.len());
+        }
+
+        for (a, b) in self.iter().zip(other.iter()) {
+            match a.cmp(&b) {
+                std::cmp::Ordering::Equal => continue,
+                x => return x,
+            }
+        }
+        std::cmp::Ordering::Equal
+    }
+}
+
+impl From<Vec<Var>> for List {
+    fn from(value: Vec<Var>) -> Self {
+        Self::from_slice(&value)
+    }
+}
+
+impl From<&[Var]> for List {
+    fn from(value: &[Var]) -> Self {
+        Self::from_slice(value)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::var::list::List;
-    use crate::var::{v_int, v_list, v_string};
+    use crate::var::{v_int, v_list, v_string, Variant};
 
     #[test]
     pub fn weird_moo_insert_scenarios() {
         // MOO supports negative indexes, which just floor to 0...
-        let mut list = List::from_vec(vec![v_int(1), v_int(2), v_int(3)]);
+        let list = List::from_slice(&[v_int(1), v_int(2), v_int(3)]);
         assert_eq!(
             list.insert(-1, v_int(0)),
             v_list(&[v_int(0), v_int(1), v_int(2), v_int(3)])
         );
 
         // MOO supports indexes beyond length of the list, which just append to the end...
-        let mut list = List::from_vec(vec![v_int(1), v_int(2), v_int(3)]);
+        let list = List::from_slice(&[v_int(1), v_int(2), v_int(3)]);
         assert_eq!(
             list.insert(100, v_int(0)),
             v_list(&[v_int(1), v_int(2), v_int(3), v_int(0)])
@@ -308,7 +616,182 @@ mod tests {
 
     #[test]
     pub fn list_display() {
-        let list = List::from_vec(vec![v_int(1), v_string("foo".into()), v_int(3)]);
+        let list = List::from_slice(&[v_int(1), v_string("foo".into()), v_int(3)]);
         assert_eq!(format!("{list}"), "{1, \"foo\", 3}");
+    }
+
+    #[test]
+    pub fn list_make_get() {
+        let l = List::new();
+        assert_eq!(l.len(), 0);
+        assert!(l.is_empty());
+        // MOO is a bit weird here, it returns None for out of bounds.
+        assert_eq!(l.get(0), None);
+
+        let l = List::from_slice(&[v_int(1)]);
+        assert_eq!(l.len(), 1);
+        assert!(!l.is_empty());
+        assert_eq!(l.get(0), Some(v_int(1)));
+        assert_eq!(l.get(1), None);
+
+        let l = List::from_slice(&[v_int(1), v_int(2), v_int(3)]);
+        assert_eq!(l.len(), 3);
+        assert!(!l.is_empty());
+
+        assert_eq!(l.get(0), Some(v_int(1)));
+        assert_eq!(l.get(1), Some(v_int(2)));
+        assert_eq!(l.get(2), Some(v_int(3)));
+    }
+
+    #[test]
+    pub fn list_push() {
+        let l = List::new();
+        let l = l.push(v_int(1));
+        let Variant::List(l) = l.variant() else {
+            panic!()
+        };
+
+        assert_eq!(l.len(), 1);
+        let l = l.push(v_int(2));
+        let Variant::List(l) = l.variant() else {
+            panic!()
+        };
+
+        assert_eq!(l.len(), 2);
+        let l = l.push(v_int(3));
+        let Variant::List(l) = l.variant() else {
+            panic!()
+        };
+
+        assert_eq!(l.len(), 3);
+
+        assert_eq!(l.get(0), Some(v_int(1)));
+        assert_eq!(l.get(2), Some(v_int(3)));
+        assert_eq!(l.get(1), Some(v_int(2)));
+    }
+
+    #[test]
+    fn list_pop_front() {
+        let l = List::from_slice(&[v_int(1), v_int(2), v_int(3)]);
+        let (item, l) = l.pop_front();
+        let Variant::List(l) = l.variant() else {
+            panic!()
+        };
+
+        assert_eq!(item, v_int(1));
+        let (item, l) = l.pop_front();
+        let Variant::List(l) = l.variant() else {
+            panic!()
+        };
+
+        assert_eq!(item, v_int(2));
+        let (item, l) = l.pop_front();
+        let Variant::List(l) = l.variant() else {
+            panic!()
+        };
+
+        assert_eq!(item, v_int(3));
+        assert_eq!(l.len(), 0);
+    }
+
+    #[test]
+    fn test_list_append() {
+        let l1 = List::from_slice(&[v_int(1), v_int(2), v_int(3)]);
+        let l2 = List::from_slice(&[v_int(4), v_int(5), v_int(6)]);
+        let l = l1.append(&l2);
+        let Variant::List(l) = l.variant() else {
+            panic!()
+        };
+        assert_eq!(l.len(), 6);
+        assert_eq!(l.get(0), Some(v_int(1)));
+        assert_eq!(l.get(5), Some(v_int(6)));
+    }
+
+    #[test]
+    fn test_list_remove() {
+        let l = List::from_slice(&[v_int(1), v_int(2), v_int(3)]);
+
+        let l = l.remove_at(1);
+        let Variant::List(l) = l.variant() else {
+            panic!()
+        };
+        assert_eq!(l.len(), 2);
+        assert_eq!(l.get(1), Some(v_int(3)));
+        assert_eq!(l.get(0), Some(v_int(1)));
+    }
+
+    #[test]
+    fn test_list_setremove() {
+        let l = List::from_slice(&[v_int(1), v_int(2), v_int(3), v_int(2)]);
+        let l = l.setremove(&v_int(2));
+        let Variant::List(l) = l.variant() else {
+            panic!()
+        };
+        assert_eq!(l.len(), 3);
+        assert_eq!(l.get(0), Some(v_int(1)));
+        assert_eq!(l.get(1), Some(v_int(3)));
+        assert_eq!(l.get(2), Some(v_int(2)));
+
+        // setremove til empty
+        let l = List::from_slice(&[v_int(1)]);
+        let l = l.setremove(&v_int(1));
+        let Variant::List(l) = l.variant() else {
+            panic!()
+        };
+        assert_eq!(l.len(), 0);
+        assert_eq!(l.get(0), None);
+    }
+
+    #[test]
+    fn test_list_insert() {
+        let l = List::new();
+        let l = l.insert(0, v_int(4));
+        let Variant::List(l) = l.variant() else {
+            panic!()
+        };
+        assert_eq!(l.len(), 1);
+        assert_eq!(l.get(0), Some(v_int(4)));
+
+        let l = l.insert(0, v_int(3));
+        let Variant::List(l) = l.variant() else {
+            panic!()
+        };
+        assert_eq!(l.len(), 2);
+        assert_eq!(l.get(0), Some(v_int(3)));
+        assert_eq!(l.get(1), Some(v_int(4)));
+
+        let l = l.insert(-1, v_int(5));
+        let Variant::List(l) = l.variant() else {
+            panic!()
+        };
+        assert_eq!(l.len(), 3);
+        assert_eq!(l.get(0), Some(v_int(5)));
+        assert_eq!(l.get(1), Some(v_int(3)));
+        assert_eq!(l.get(2), Some(v_int(4)));
+    }
+
+    #[test]
+    fn test_list_set() {
+        let l = List::from_slice(&[v_int(1), v_int(2), v_int(3)]);
+        let l = l.set(1, v_int(4));
+        let Variant::List(l) = l.variant() else {
+            panic!()
+        };
+        assert_eq!(l.len(), 3);
+        assert_eq!(l.get(1), Some(v_int(4)));
+    }
+
+    #[test]
+    fn test_list_contains_case_insenstive() {
+        let l = List::from_slice(&[v_string("foo".into()), v_string("bar".into())]);
+        assert!(l.contains(&v_string("FOO".into())));
+        assert!(l.contains(&v_string("BAR".into())));
+    }
+
+    #[test]
+    fn test_list_contains_case_senstive() {
+        let l = List::from_slice(&[v_string("foo".into()), v_string("bar".into())]);
+        assert!(!l.contains_case_sensitive(&v_string("FOO".into())));
+        assert!(!l.contains_case_sensitive(&v_string("BAR".into())));
     }
 }

--- a/crates/values/src/var/list.rs
+++ b/crates/values/src/var/list.rs
@@ -11,448 +11,81 @@
 // You should have received a copy of the GNU General Public License along with
 // this program. If not, see <https://www.gnu.org/licenses/>.
 //
-
-use std::cmp::min;
 use std::fmt::{Display, Formatter, Result as FmtResult};
 use std::hash::{Hash, Hasher};
 
-use crate::{AsByteBuffer, DecodingError, EncodingError};
-use bincode::de::{BorrowDecoder, Decoder};
-use bincode::enc::Encoder;
-use bincode::error::{DecodeError, EncodeError};
-use bincode::{BorrowDecode, Decode, Encode};
+use bincode::{Decode, Encode};
 use bytes::Bytes;
 
+#[allow(unused_imports)]
+use crate::var::list_impl_buffer::ListImplBuffer;
+#[allow(unused_imports)]
+use crate::var::list_impl_vector::ListImplVector;
+
 use crate::var::variant::Variant;
-use crate::var::{v_empty_list, Var};
+use crate::var::Var;
+use crate::{AsByteBuffer, DecodingError, EncodingError};
 
-#[derive(Clone, Debug)]
-pub struct List(Bytes);
+#[cfg(feature = "list_impl_buffer")]
+type ListImpl = ListImplBuffer;
 
-fn offsets_end_pos(buf: &[u8]) -> usize {
-    u32::from_le_bytes(buf[0..4].try_into().unwrap()) as usize
-}
+#[cfg(not(feature = "list_impl_buffer"))]
+type ListImpl = ListImplVector;
 
-fn offset_at(buf: &[u8], index: usize) -> usize {
-    u32::from_le_bytes(buf[4 + index * 4..4 + (index + 1) * 4].try_into().unwrap()) as usize
-}
+#[derive(Clone, Debug, Encode, Decode)]
+pub struct List(ListImpl);
 
 impl List {
     pub fn new() -> Self {
-        Self(Bytes::from(Vec::new()))
+        Self(ListImpl::new())
     }
 
     pub fn len(&self) -> usize {
-        let l = self.0.len();
-        if l == 0 || l == 4 {
-            return 0;
-        }
-
-        let slc = self.0.as_ref();
-        let offsets_end = offsets_end_pos(slc);
-        let offsets_len = offsets_end - 4;
-        // The offsets table is 4 bytes per offset.
-        offsets_len >> 2
+        self.0.len()
     }
 
     pub fn is_empty(&self) -> bool {
-        let l = self.0.len();
-        if l == 0 || l == 4 {
-            return true;
-        }
-        false
+        self.0.is_empty()
     }
 
     pub fn get(&self, index: usize) -> Option<Var> {
-        let len = self.len();
-        if index >= len {
-            return None;
-        }
-
-        let slc = self.0.as_ref();
-        let offsets_end = offsets_end_pos(slc);
-
-        // The offsets table is 4 bytes per offset.
-        let data_offset = offset_at(slc, index);
-
-        let data_section = &self.0.slice(offsets_end..);
-
-        // If this is the last item, we can just slice to the end of the data section.
-        if index == len - 1 {
-            let slice_ref = data_section.slice(data_offset..);
-            return Some(Var::from_bytes(slice_ref).expect("could not decode var"));
-        }
-
-        // Otherwise, we need to slice from this offset to the next offset.
-        let next_offset = offset_at(slc, index + 1);
-
-        // Note that the offsets are relative to the start of the data section.
-        let data = data_section.slice(data_offset..next_offset);
-        Var::from_bytes(data.clone()).ok()
+        self.0.get(index)
     }
 
     pub fn from_slice(vec: &[Var]) -> List {
-        let mut data = Vec::new();
-
-        let mut relative_offset: u32 = 0;
-        let mut offsets = Vec::with_capacity(vec.len() * 4);
-        for v in vec.iter() {
-            offsets.extend_from_slice(&relative_offset.to_le_bytes());
-            let vsr = v.as_bytes().unwrap();
-            let bytes = vsr.as_ref();
-            data.extend_from_slice(bytes);
-            relative_offset += bytes.len() as u32;
-        }
-
-        let mut result = Vec::with_capacity(4 + offsets.len() + data.len());
-        result.extend_from_slice(&(offsets.len() as u32 + 4).to_le_bytes());
-        result.extend_from_slice(&offsets);
-        result.extend_from_slice(&data);
-
-        Self(Bytes::from(result))
+        Self(ListImpl::from_slice(vec))
     }
 
     // expensive because we need to extend both buffer length and the offsets length...
-    pub fn push(&self, v: Var) -> Var {
-        let len = self.len();
-
-        let data_sr = v.as_bytes().unwrap();
-
-        // Special case if we're empty.
-        if len == 0 {
-            let mut new_offsets = Vec::with_capacity(4);
-            let offset: u32 = 0;
-            new_offsets.extend_from_slice(&offset.to_le_bytes());
-
-            let mut result = Vec::with_capacity(4 + new_offsets.len() + data_sr.len());
-            result.extend_from_slice(&8u32.to_le_bytes());
-            result.extend_from_slice(&new_offsets);
-            result.extend_from_slice(data_sr.as_ref());
-
-            return Var::new(Variant::List(Self(Bytes::from(result))));
-        }
-
-        let slc = self.0.as_ref();
-        let offsets_end = offsets_end_pos(slc);
-
-        let existing_offset_table = &slc[4..offsets_end];
-        let existing_data = &slc[offsets_end..];
-
-        // Add the new offset to the offsets table. The new offset is end of the old data section,
-        // that is, the length of the whole buffer.
-        let mut new_offsets = Vec::with_capacity(existing_offset_table.len() + 4);
-        new_offsets.extend_from_slice(existing_offset_table);
-        let new_offset = existing_data.len() as u32;
-        new_offsets.extend_from_slice(&new_offset.to_le_bytes());
-
-        // Add the new data to the data section.
-        let mut new_data = Vec::with_capacity(existing_data.len() + data_sr.len());
-        new_data.extend_from_slice(existing_data);
-        new_data.extend_from_slice(data_sr.as_ref());
-
-        // Update offsets end
-        let new_offsets_end = new_offsets.len() as u32 + 4;
-
-        // Result is new_offsets_len + new_offsets + new_data
-        let mut result = Vec::with_capacity(4 + new_offsets.len() + new_data.len());
-        result.extend_from_slice(&new_offsets_end.to_le_bytes());
-        result.extend_from_slice(&new_offsets);
-        result.extend_from_slice(&new_data);
-
-        Var::new(Variant::List(Self(Bytes::from(result))))
+    pub fn push(&mut self, v: Var) -> Var {
+        Var::new(Variant::List(Self(self.0.push(v))))
     }
 
     pub fn pop_front(&self) -> (Var, Var) {
-        let len = self.len();
-        if len == 0 {
-            return (v_empty_list(), v_empty_list());
-        }
-
-        if len == 1 {
-            return (self.get(0).unwrap(), v_empty_list());
-        }
-
-        let slc = self.0.as_ref();
-        let offsets_end = offsets_end_pos(slc);
-
-        // Get the offset table
-        let offsets_table = &slc[4..offsets_end];
-
-        // Splice off the data section after the first item
-        let data_section = &self.0.slice(offsets_end..);
-        let first_offset = offset_at(slc, 0);
-        let next_offset = offset_at(slc, 1);
-        let length = next_offset - first_offset;
-        let data = data_section.slice(first_offset..next_offset);
-
-        // Now rebuild the offset table, subtracting the length of the first item
-        let mut new_offsets = Vec::with_capacity(offsets_table.len() - 4);
-        for i in 1..len {
-            let offset = offset_at(slc, i);
-            let new_offset = (offset - length) as u32;
-            new_offsets.extend_from_slice(&new_offset.to_le_bytes());
-        }
-
-        // Now reconstruct
-        let mut result = Vec::with_capacity(4 + new_offsets.len() + data.len());
-        result.extend_from_slice(&(new_offsets.len() as u32 + 4).to_le_bytes());
-        result.extend_from_slice(&new_offsets);
-        result.extend_from_slice(data_section.slice(next_offset..).as_ref());
-
-        (
-            Var::from_bytes(data).unwrap(),
-            Var::new(Variant::List(Self(Bytes::from(result)))),
-        )
+        let results = self.0.pop_front();
+        (results.0, Var::new(Variant::List(Self(results.1))))
     }
 
-    pub fn append(&self, other: &Self) -> Var {
-        let len = self.len();
-        if len == 0 {
-            return Var::new(Variant::List(other.clone()));
-        }
-
-        let other_len = other.len();
-        if other_len == 0 {
-            return Var::new(Variant::List(self.clone()));
-        }
-
-        // Find the starts of the two data sections
-        let slc = self.0.as_ref();
-        let oth_slc = other.0.as_ref();
-
-        let data_start_self = offsets_end_pos(slc);
-        let data_start_other = offsets_end_pos(oth_slc);
-
-        // Get their data sections
-        let data_self = &slc[data_start_self..];
-        let data_other = &oth_slc[data_start_other..];
-
-        // Get the two offsets tables
-        let offset_table_self = &slc[4..data_start_self];
-        let offset_table_other = &oth_slc[4..data_start_other];
-
-        let self_offset_len = offset_table_self.len();
-
-        // Construct a new offset table, leaving self intact and then adjusting other.
-        let mut new_offset_table = Vec::with_capacity(self_offset_len + offset_table_other.len());
-        new_offset_table.extend_from_slice(offset_table_self);
-        for i in 0..other_len {
-            let offset = offset_at(oth_slc, i);
-            let new_offset = (offset + data_self.len()) as u32;
-            new_offset_table.extend_from_slice(&new_offset.to_le_bytes());
-        }
-
-        let mut result =
-            Vec::with_capacity(4 + new_offset_table.len() + data_self.len() + data_other.len());
-        result.extend_from_slice(&(new_offset_table.len() as u32 + 4).to_le_bytes());
-        result.extend_from_slice(&new_offset_table);
-        result.extend_from_slice(data_self);
-        result.extend_from_slice(data_other);
-
-        Var::new(Variant::List(Self(Bytes::from(result))))
+    pub fn append(&mut self, other: &Self) -> Var {
+        Var::new(Variant::List(Self(self.0.append(other.0.clone()))))
     }
 
-    pub fn remove_at(&self, index: usize) -> Var {
-        let len = self.len();
-        if len == 0 {
-            return Var::new(Variant::List(self.clone()));
-        }
-
-        if len == 1 {
-            return v_empty_list();
-        }
-
-        // This will involve rebuilding both the offsets and data sections.
-        let slc = self.0.as_ref();
-        let old_data_start = offsets_end_pos(slc);
-
-        let old_data = &slc[old_data_start..];
-        let old_offsets = &slc[4..old_data_start];
-
-        let remove_item_offset =
-            u32::from_le_bytes(old_offsets[index * 4..(index + 1) * 4].try_into().unwrap())
-                as usize;
-        let remove_item_length = if index == len - 1 {
-            old_data.len() - remove_item_offset
-        } else {
-            let next_offset = offset_at(slc, index + 1);
-            next_offset - remove_item_offset
-        };
-
-        let mut new_offsets = Vec::with_capacity(old_offsets.len() - 4);
-        let mut new_data = Vec::with_capacity(old_data.len() - remove_item_length);
-
-        // Iterate to generate
-        for i in 0..len {
-            if i == index {
-                continue;
-            }
-
-            let offset = offset_at(slc, i);
-            let data = if i == len - 1 {
-                &old_data[offset..]
-            } else {
-                let next_offset = offset_at(slc, i + 1);
-                &old_data[offset..next_offset]
-            };
-            let new_offset = new_data.len() as u32;
-            new_data.extend_from_slice(data);
-            new_offsets.extend_from_slice(&new_offset.to_le_bytes());
-        }
-
-        let mut result = Vec::with_capacity(4 + new_offsets.len() + new_data.len());
-        result.extend_from_slice(&(new_offsets.len() as u32 + 4).to_le_bytes());
-        result.extend_from_slice(&new_offsets);
-        result.extend_from_slice(&new_data);
-        Var::new(Variant::List(Self(Bytes::from(result))))
+    pub fn remove_at(&mut self, index: usize) -> Var {
+        Var::new(Variant::List(Self(self.0.remove_at(index))))
     }
 
     /// Remove the first found instance of the given value from the list.
     #[must_use]
-    pub fn setremove(&self, value: &Var) -> Var {
-        let len = self.len();
-        if len == 0 {
-            return Var::new(Variant::List(self.clone()));
-        }
-
-        if len == 1 {
-            if self.get(0).unwrap().eq(value) {
-                return v_empty_list();
-            }
-            return Var::new(Variant::List(self.clone()));
-        }
-
-        // This will involve rebuilding both the offsets and data sections.
-        let slc = self.0.as_ref();
-        let old_data_start = offsets_end_pos(slc);
-
-        let old_data = &self.0.slice(old_data_start..);
-        let old_offsets = &slc[4..old_data_start];
-
-        let mut new_offsets = Vec::with_capacity(old_offsets.len() - 4);
-        let mut new_data = Vec::with_capacity(old_data.len());
-
-        // Iterate to generate
-        let mut found = false;
-        for i in 0..len {
-            let offset = offset_at(slc, i);
-            let data = if i == len - 1 {
-                old_data.slice(offset..)
-            } else {
-                let next_offset = offset_at(slc, i + 1);
-                old_data.slice(offset..next_offset)
-            };
-            let v = Var::from_bytes(data.clone()).unwrap();
-            if !found && v.eq(value) {
-                found = true;
-                continue;
-            }
-
-            let new_offset = new_data.len() as u32;
-            new_data.extend_from_slice(data.as_ref());
-            new_offsets.extend_from_slice(&new_offset.to_le_bytes());
-        }
-
-        let mut result = Vec::with_capacity(4 + new_offsets.len() + new_data.len());
-        result.extend_from_slice(&(new_offsets.len() as u32 + 4).to_le_bytes());
-        result.extend_from_slice(&new_offsets);
-        result.extend_from_slice(&new_data);
-        Var::new(Variant::List(Self(Bytes::from(result))))
+    pub fn setremove(&mut self, value: &Var) -> Var {
+        Var::new(Variant::List(Self(self.0.setremove(value))))
     }
 
-    pub fn insert(&self, index: isize, value: Var) -> Var {
-        let index = if index < 0 {
-            0
-        } else {
-            min(index as usize, self.len())
-        };
-
-        // Special case if inserting at end, it's just push
-        if index == self.len() {
-            return self.push(value);
-        }
-
-        // Special case if we're empty.
-        if self.is_empty() {
-            return Var::new(Variant::List(Self::from_slice(&[value])));
-        }
-
-        // Accumulate up to the insertion point, building the new offsets and data sections.
-        // Then add the new item, and then add the rest of the items.
-        let slc = self.0.as_ref();
-        let old_data_start = offsets_end_pos(slc);
-        let old_data = &slc[old_data_start..];
-        let old_offsets = &slc[4..old_data_start];
-
-        let mut new_offsets = Vec::with_capacity(old_offsets.len() + 4);
-        let mut new_data = Vec::with_capacity(old_data.len() + value.as_bytes().unwrap().len());
-
-        for i in 0..self.len() {
-            if i == index {
-                let new_offset = new_data.len() as u32;
-                new_offsets.extend_from_slice(&new_offset.to_le_bytes());
-                new_data.extend_from_slice(value.as_bytes().unwrap().as_ref());
-            }
-            let offset = offset_at(slc, i);
-            let length = if i == self.len() - 1 {
-                old_data.len() - offset
-            } else {
-                let next_offset = offset_at(slc, i + 1);
-                next_offset - offset
-            };
-            let new_offset = new_data.len() as u32;
-            new_offsets.extend_from_slice(&new_offset.to_le_bytes());
-            new_data.extend_from_slice(&old_data[offset..offset + length]);
-        }
-
-        let mut result = Vec::with_capacity(4 + new_offsets.len() + new_data.len());
-        result.extend_from_slice(&(new_offsets.len() as u32 + 4).to_le_bytes());
-        result.extend_from_slice(&new_offsets);
-        result.extend_from_slice(&new_data);
-        Var::new(Variant::List(Self(Bytes::from(result))))
+    pub fn insert(&mut self, index: isize, value: Var) -> Var {
+        Var::new(Variant::List(Self(self.0.insert(index, value))))
     }
 
-    pub fn set(&self, index: usize, value: Var) -> Var {
-        let len = self.len();
-        if index >= len {
-            return Var::new(Variant::List(self.clone()));
-        }
-
-        // This will involve rebuilding both the offsets and data sections.
-        let slc = self.0.as_ref();
-        let old_data_start = offsets_end_pos(slc);
-
-        let old_data = &self.0.slice(old_data_start..);
-        let old_offsets = &slc[4..old_data_start];
-
-        let mut new_offsets = Vec::with_capacity(old_offsets.len());
-        let mut new_data = Vec::with_capacity(old_data.len());
-
-        // Iterate to generate
-        for i in 0..len {
-            let offset = offset_at(slc, i);
-            let data = if i == len - 1 {
-                old_data.slice(offset..)
-            } else {
-                let next_offset = offset_at(slc, i + 1);
-                old_data.slice(offset..next_offset)
-            };
-            if i == index {
-                let new_offset = new_data.len() as u32;
-                new_offsets.extend_from_slice(&new_offset.to_le_bytes());
-                new_data.extend_from_slice(value.as_bytes().unwrap().as_ref());
-            } else {
-                let new_offset = new_data.len() as u32;
-                new_offsets.extend_from_slice(&new_offset.to_le_bytes());
-                new_data.extend_from_slice(data.as_ref());
-            }
-        }
-
-        let mut result = Vec::with_capacity(4 + new_offsets.len() + new_data.len());
-        result.extend_from_slice(&(new_offsets.len() as u32 + 4).to_le_bytes());
-        result.extend_from_slice(&new_offsets);
-        result.extend_from_slice(&new_data);
-        Var::new(Variant::List(Self(Bytes::from(result))))
+    pub fn set(&mut self, index: usize, value: Var) -> Var {
+        Var::new(Variant::List(Self(self.0.set(index, value))))
     }
 
     // Case insensitive
@@ -492,67 +125,32 @@ impl From<List> for Vec<Var> {
 
 impl AsByteBuffer for List {
     fn size_bytes(&self) -> usize {
-        self.0.len()
+        self.0.size_bytes()
     }
 
     fn with_byte_buffer<R, F: FnMut(&[u8]) -> R>(&self, mut f: F) -> Result<R, EncodingError> {
-        Ok(f(self.0.as_ref()))
+        self.0.with_byte_buffer(|buf| f(buf))
     }
 
     fn make_copy_as_vec(&self) -> Result<Vec<u8>, EncodingError> {
-        Ok(self.0.as_ref().to_vec())
+        self.0.make_copy_as_vec()
     }
 
     fn from_bytes(bytes: Bytes) -> Result<Self, DecodingError>
     where
         Self: Sized,
     {
-        Ok(Self(bytes))
+        Ok(Self(ListImpl::from_bytes(bytes)?))
     }
 
     fn as_bytes(&self) -> Result<Bytes, EncodingError> {
-        Ok(self.0.clone())
+        self.0.as_bytes()
     }
 }
 
 impl Default for List {
     fn default() -> Self {
         Self::new()
-    }
-}
-
-impl Display for List {
-    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-        write!(f, "{{")?;
-        let mut first = true;
-        for v in self.iter() {
-            if !first {
-                write!(f, ", ")?;
-            }
-            first = false;
-            write!(f, "{v}")?;
-        }
-        write!(f, "}}")
-    }
-}
-
-impl Encode for List {
-    fn encode<E: Encoder>(&self, encoder: &mut E) -> Result<(), EncodeError> {
-        self.0.as_ref().encode(encoder)
-    }
-}
-
-impl Decode for List {
-    fn decode<D: Decoder>(decoder: &mut D) -> Result<Self, DecodeError> {
-        let vec = Vec::<u8>::decode(decoder)?;
-        Ok(Self(Bytes::from(vec)))
-    }
-}
-
-impl<'de> BorrowDecode<'de> for List {
-    fn borrow_decode<D: BorrowDecoder<'de>>(decoder: &mut D) -> Result<Self, DecodeError> {
-        let vec = Vec::<u8>::borrow_decode(decoder)?;
-        Ok(Self(Bytes::from(vec)))
     }
 }
 
@@ -613,22 +211,37 @@ impl From<&[Var]> for List {
     }
 }
 
+impl Display for List {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        write!(f, "{{")?;
+        let mut first = true;
+        for v in self.iter() {
+            if !first {
+                write!(f, ", ")?;
+            }
+            first = false;
+            write!(f, "{v}")?;
+        }
+        write!(f, "}}")
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::var::list::List;
-    use crate::var::{v_int, v_list, v_string, Variant};
+    use crate::var::{v_int, v_list, v_string};
 
     #[test]
     pub fn weird_moo_insert_scenarios() {
         // MOO supports negative indexes, which just floor to 0...
-        let list = List::from_slice(&[v_int(1), v_int(2), v_int(3)]);
+        let mut list = List::from_slice(&[v_int(1), v_int(2), v_int(3)]);
         assert_eq!(
             list.insert(-1, v_int(0)),
             v_list(&[v_int(0), v_int(1), v_int(2), v_int(3)])
         );
 
         // MOO supports indexes beyond length of the list, which just append to the end...
-        let list = List::from_slice(&[v_int(1), v_int(2), v_int(3)]);
+        let mut list = List::from_slice(&[v_int(1), v_int(2), v_int(3)]);
         assert_eq!(
             list.insert(100, v_int(0)),
             v_list(&[v_int(1), v_int(2), v_int(3), v_int(0)])
@@ -639,180 +252,5 @@ mod tests {
     pub fn list_display() {
         let list = List::from_slice(&[v_int(1), v_string("foo".into()), v_int(3)]);
         assert_eq!(format!("{list}"), "{1, \"foo\", 3}");
-    }
-
-    #[test]
-    pub fn list_make_get() {
-        let l = List::new();
-        assert_eq!(l.len(), 0);
-        assert!(l.is_empty());
-        // MOO is a bit weird here, it returns None for out of bounds.
-        assert_eq!(l.get(0), None);
-
-        let l = List::from_slice(&[v_int(1)]);
-        assert_eq!(l.len(), 1);
-        assert!(!l.is_empty());
-        assert_eq!(l.get(0), Some(v_int(1)));
-        assert_eq!(l.get(1), None);
-
-        let l = List::from_slice(&[v_int(1), v_int(2), v_int(3)]);
-        assert_eq!(l.len(), 3);
-        assert!(!l.is_empty());
-
-        assert_eq!(l.get(0), Some(v_int(1)));
-        assert_eq!(l.get(1), Some(v_int(2)));
-        assert_eq!(l.get(2), Some(v_int(3)));
-    }
-
-    #[test]
-    pub fn list_push() {
-        let l = List::new();
-        let l = l.push(v_int(1));
-        let Variant::List(l) = l.variant() else {
-            panic!()
-        };
-
-        assert_eq!(l.len(), 1);
-        let l = l.push(v_int(2));
-        let Variant::List(l) = l.variant() else {
-            panic!()
-        };
-
-        assert_eq!(l.len(), 2);
-        let l = l.push(v_int(3));
-        let Variant::List(l) = l.variant() else {
-            panic!()
-        };
-
-        assert_eq!(l.len(), 3);
-
-        assert_eq!(l.get(0), Some(v_int(1)));
-        assert_eq!(l.get(2), Some(v_int(3)));
-        assert_eq!(l.get(1), Some(v_int(2)));
-    }
-
-    #[test]
-    fn list_pop_front() {
-        let l = List::from_slice(&[v_int(1), v_int(2), v_int(3)]);
-        let (item, l) = l.pop_front();
-        let Variant::List(l) = l.variant() else {
-            panic!()
-        };
-
-        assert_eq!(item, v_int(1));
-        let (item, l) = l.pop_front();
-        let Variant::List(l) = l.variant() else {
-            panic!()
-        };
-
-        assert_eq!(item, v_int(2));
-        let (item, l) = l.pop_front();
-        let Variant::List(l) = l.variant() else {
-            panic!()
-        };
-
-        assert_eq!(item, v_int(3));
-        assert_eq!(l.len(), 0);
-    }
-
-    #[test]
-    fn test_list_append() {
-        let l1 = List::from_slice(&[v_int(1), v_int(2), v_int(3)]);
-        let l2 = List::from_slice(&[v_int(4), v_int(5), v_int(6)]);
-        let l = l1.append(&l2);
-        let Variant::List(l) = l.variant() else {
-            panic!()
-        };
-        assert_eq!(l.len(), 6);
-        assert_eq!(l.get(0), Some(v_int(1)));
-        assert_eq!(l.get(5), Some(v_int(6)));
-    }
-
-    #[test]
-    fn test_list_remove() {
-        let l = List::from_slice(&[v_int(1), v_int(2), v_int(3)]);
-
-        let l = l.remove_at(1);
-        let Variant::List(l) = l.variant() else {
-            panic!()
-        };
-        assert_eq!(l.len(), 2);
-        assert_eq!(l.get(1), Some(v_int(3)));
-        assert_eq!(l.get(0), Some(v_int(1)));
-    }
-
-    #[test]
-    fn test_list_setremove() {
-        let l = List::from_slice(&[v_int(1), v_int(2), v_int(3), v_int(2)]);
-        let l = l.setremove(&v_int(2));
-        let Variant::List(l) = l.variant() else {
-            panic!()
-        };
-        assert_eq!(l.len(), 3);
-        assert_eq!(l.get(0), Some(v_int(1)));
-        assert_eq!(l.get(1), Some(v_int(3)));
-        assert_eq!(l.get(2), Some(v_int(2)));
-
-        // setremove til empty
-        let l = List::from_slice(&[v_int(1)]);
-        let l = l.setremove(&v_int(1));
-        let Variant::List(l) = l.variant() else {
-            panic!()
-        };
-        assert_eq!(l.len(), 0);
-        assert_eq!(l.get(0), None);
-    }
-
-    #[test]
-    fn test_list_insert() {
-        let l = List::new();
-        let l = l.insert(0, v_int(4));
-        let Variant::List(l) = l.variant() else {
-            panic!()
-        };
-        assert_eq!(l.len(), 1);
-        assert_eq!(l.get(0), Some(v_int(4)));
-
-        let l = l.insert(0, v_int(3));
-        let Variant::List(l) = l.variant() else {
-            panic!()
-        };
-        assert_eq!(l.len(), 2);
-        assert_eq!(l.get(0), Some(v_int(3)));
-        assert_eq!(l.get(1), Some(v_int(4)));
-
-        let l = l.insert(-1, v_int(5));
-        let Variant::List(l) = l.variant() else {
-            panic!()
-        };
-        assert_eq!(l.len(), 3);
-        assert_eq!(l.get(0), Some(v_int(5)));
-        assert_eq!(l.get(1), Some(v_int(3)));
-        assert_eq!(l.get(2), Some(v_int(4)));
-    }
-
-    #[test]
-    fn test_list_set() {
-        let l = List::from_slice(&[v_int(1), v_int(2), v_int(3)]);
-        let l = l.set(1, v_int(4));
-        let Variant::List(l) = l.variant() else {
-            panic!()
-        };
-        assert_eq!(l.len(), 3);
-        assert_eq!(l.get(1), Some(v_int(4)));
-    }
-
-    #[test]
-    fn test_list_contains_case_insenstive() {
-        let l = List::from_slice(&[v_string("foo".into()), v_string("bar".into())]);
-        assert!(l.contains(&v_string("FOO".into())));
-        assert!(l.contains(&v_string("BAR".into())));
-    }
-
-    #[test]
-    fn test_list_contains_case_senstive() {
-        let l = List::from_slice(&[v_string("foo".into()), v_string("bar".into())]);
-        assert!(!l.contains_case_sensitive(&v_string("FOO".into())));
-        assert!(!l.contains_case_sensitive(&v_string("BAR".into())));
     }
 }

--- a/crates/values/src/var/list_impl_buffer.rs
+++ b/crates/values/src/var/list_impl_buffer.rs
@@ -1,0 +1,665 @@
+// Copyright (C) 2024 Ryan Daum <ryan.daum@gmail.com>
+//
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free Software
+// Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program. If not, see <https://www.gnu.org/licenses/>.
+//
+
+use std::cmp::min;
+
+use bincode::de::{BorrowDecoder, Decoder};
+use bincode::enc::Encoder;
+use bincode::error::{DecodeError, EncodeError};
+use bincode::{BorrowDecode, Decode, Encode};
+use bytes::Bytes;
+
+use crate::var::variant::Variant;
+use crate::var::{v_empty_list, Var};
+use crate::{AsByteBuffer, DecodingError, EncodingError};
+
+#[derive(Clone, Debug)]
+pub struct ListImplBuffer(Bytes);
+
+fn offsets_end_pos(buf: &[u8]) -> usize {
+    u32::from_le_bytes(buf[0..4].try_into().unwrap()) as usize
+}
+
+fn offset_at(buf: &[u8], index: usize) -> usize {
+    u32::from_le_bytes(buf[4 + index * 4..4 + (index + 1) * 4].try_into().unwrap()) as usize
+}
+
+impl ListImplBuffer {
+    pub fn new() -> Self {
+        Self(Bytes::from(Vec::new()))
+    }
+
+    pub fn len(&self) -> usize {
+        let l = self.0.len();
+        if l == 0 || l == 4 {
+            return 0;
+        }
+
+        let slc = self.0.as_ref();
+        let offsets_end = offsets_end_pos(slc);
+        let offsets_len = offsets_end - 4;
+        // The offsets table is 4 bytes per offset.
+        offsets_len >> 2
+    }
+
+    pub fn is_empty(&self) -> bool {
+        let l = self.0.len();
+        if l == 0 || l == 4 {
+            return true;
+        }
+        false
+    }
+
+    pub fn get(&self, index: usize) -> Option<Var> {
+        let len = self.len();
+        if index >= len {
+            return None;
+        }
+
+        let slc = self.0.as_ref();
+        let offsets_end = offsets_end_pos(slc);
+
+        // The offsets table is 4 bytes per offset.
+        let data_offset = offset_at(slc, index);
+
+        let data_section = &self.0.slice(offsets_end..);
+
+        // If this is the last item, we can just slice to the end of the data section.
+        if index == len - 1 {
+            let slice_ref = data_section.slice(data_offset..);
+            return Some(Var::from_bytes(slice_ref).expect("could not decode var"));
+        }
+
+        // Otherwise, we need to slice from this offset to the next offset.
+        let next_offset = offset_at(slc, index + 1);
+
+        // Note that the offsets are relative to the start of the data section.
+        let data = data_section.slice(data_offset..next_offset);
+        Var::from_bytes(data.clone()).ok()
+    }
+
+    pub fn from_slice(vec: &[Var]) -> Self {
+        let mut data = Vec::new();
+
+        let mut relative_offset: u32 = 0;
+        let mut offsets = Vec::with_capacity(vec.len() * 4);
+        for v in vec.iter() {
+            offsets.extend_from_slice(&relative_offset.to_le_bytes());
+            let vsr = v.as_bytes().unwrap();
+            let bytes = vsr.as_ref();
+            data.extend_from_slice(bytes);
+            relative_offset += bytes.len() as u32;
+        }
+
+        let mut result = Vec::with_capacity(4 + offsets.len() + data.len());
+        result.extend_from_slice(&(offsets.len() as u32 + 4).to_le_bytes());
+        result.extend_from_slice(&offsets);
+        result.extend_from_slice(&data);
+
+        Self(Bytes::from(result))
+    }
+
+    pub fn push(&self, v: Var) -> Self {
+        let len = self.len();
+
+        let data_sr = v.as_bytes().unwrap();
+
+        // Special case if we're empty.
+        if len == 0 {
+            let mut new_offsets = Vec::with_capacity(4);
+            let offset: u32 = 0;
+            new_offsets.extend_from_slice(&offset.to_le_bytes());
+
+            let mut result = Vec::with_capacity(4 + new_offsets.len() + data_sr.len());
+            result.extend_from_slice(&8u32.to_le_bytes());
+            result.extend_from_slice(&new_offsets);
+            result.extend_from_slice(data_sr.as_ref());
+
+            return Self(Bytes::from(result));
+        }
+
+        let slc = self.0.as_ref();
+        let offsets_end = offsets_end_pos(slc);
+
+        let existing_offset_table = &slc[4..offsets_end];
+        let existing_data = &slc[offsets_end..];
+
+        // Add the new offset to the offsets table. The new offset is end of the old data section,
+        // that is, the length of the whole buffer.
+        let mut new_offsets = Vec::with_capacity(existing_offset_table.len() + 4);
+        new_offsets.extend_from_slice(existing_offset_table);
+        let new_offset = existing_data.len() as u32;
+        new_offsets.extend_from_slice(&new_offset.to_le_bytes());
+
+        // Add the new data to the data section.
+        let mut new_data = Vec::with_capacity(existing_data.len() + data_sr.len());
+        new_data.extend_from_slice(existing_data);
+        new_data.extend_from_slice(data_sr.as_ref());
+
+        // Update offsets end
+        let new_offsets_end = new_offsets.len() as u32 + 4;
+
+        // Result is new_offsets_len + new_offsets + new_data
+        let mut result = Vec::with_capacity(4 + new_offsets.len() + new_data.len());
+        result.extend_from_slice(&new_offsets_end.to_le_bytes());
+        result.extend_from_slice(&new_offsets);
+        result.extend_from_slice(&new_data);
+
+        Self(Bytes::from(result))
+    }
+
+    pub fn pop_front(&self) -> (Var, Self) {
+        let len = self.len();
+        if len == 0 {
+            return (v_empty_list(), self.clone());
+        }
+
+        if len == 1 {
+            return (self.get(0).unwrap(), ListImplBuffer::new());
+        }
+
+        let slc = self.0.as_ref();
+        let offsets_end = offsets_end_pos(slc);
+
+        // Get the offset table
+        let offsets_table = &slc[4..offsets_end];
+
+        // Splice off the data section after the first item
+        let data_section = &self.0.slice(offsets_end..);
+        let first_offset = offset_at(slc, 0);
+        let next_offset = offset_at(slc, 1);
+        let length = next_offset - first_offset;
+        let data = data_section.slice(first_offset..next_offset);
+
+        // Now rebuild the offset table, subtracting the length of the first item
+        let mut new_offsets = Vec::with_capacity(offsets_table.len() - 4);
+        for i in 1..len {
+            let offset = offset_at(slc, i);
+            let new_offset = (offset - length) as u32;
+            new_offsets.extend_from_slice(&new_offset.to_le_bytes());
+        }
+
+        // Now reconstruct
+        let mut result = Vec::with_capacity(4 + new_offsets.len() + data.len());
+        result.extend_from_slice(&(new_offsets.len() as u32 + 4).to_le_bytes());
+        result.extend_from_slice(&new_offsets);
+        result.extend_from_slice(data_section.slice(next_offset..).as_ref());
+
+        (Var::from_bytes(data).unwrap(), Self(Bytes::from(result)))
+    }
+
+    pub fn append(&self, other: Self) -> Self {
+        let len = self.len();
+        if len == 0 {
+            return other.clone();
+        }
+
+        let other_len = other.len();
+        if other_len == 0 {
+            return self.clone();
+        }
+
+        // Find the starts of the two data sections
+        let slc = self.0.as_ref();
+        let oth_slc = other.0.as_ref();
+
+        let data_start_self = offsets_end_pos(slc);
+        let data_start_other = offsets_end_pos(oth_slc);
+
+        // Get their data sections
+        let data_self = &slc[data_start_self..];
+        let data_other = &oth_slc[data_start_other..];
+
+        // Get the two offsets tables
+        let offset_table_self = &slc[4..data_start_self];
+        let offset_table_other = &oth_slc[4..data_start_other];
+
+        let self_offset_len = offset_table_self.len();
+
+        // Construct a new offset table, leaving self intact and then adjusting other.
+        let mut new_offset_table = Vec::with_capacity(self_offset_len + offset_table_other.len());
+        new_offset_table.extend_from_slice(offset_table_self);
+        for i in 0..other_len {
+            let offset = offset_at(oth_slc, i);
+            let new_offset = (offset + data_self.len()) as u32;
+            new_offset_table.extend_from_slice(&new_offset.to_le_bytes());
+        }
+
+        let mut result =
+            Vec::with_capacity(4 + new_offset_table.len() + data_self.len() + data_other.len());
+        result.extend_from_slice(&(new_offset_table.len() as u32 + 4).to_le_bytes());
+        result.extend_from_slice(&new_offset_table);
+        result.extend_from_slice(data_self);
+        result.extend_from_slice(data_other);
+
+        Self(Bytes::from(result))
+    }
+
+    pub fn remove_at(&self, index: usize) -> Self {
+        let len = self.len();
+        if len == 0 {
+            return self.clone();
+        }
+
+        if len == 1 {
+            return ListImplBuffer::new();
+        }
+
+        // This will involve rebuilding both the offsets and data sections.
+        let slc = self.0.as_ref();
+        let old_data_start = offsets_end_pos(slc);
+
+        let old_data = &slc[old_data_start..];
+        let old_offsets = &slc[4..old_data_start];
+
+        let remove_item_offset =
+            u32::from_le_bytes(old_offsets[index * 4..(index + 1) * 4].try_into().unwrap())
+                as usize;
+        let remove_item_length = if index == len - 1 {
+            old_data.len() - remove_item_offset
+        } else {
+            let next_offset = offset_at(slc, index + 1);
+            next_offset - remove_item_offset
+        };
+
+        let mut new_offsets = Vec::with_capacity(old_offsets.len() - 4);
+        let mut new_data = Vec::with_capacity(old_data.len() - remove_item_length);
+
+        // Iterate to generate
+        for i in 0..len {
+            if i == index {
+                continue;
+            }
+
+            let offset = offset_at(slc, i);
+            let data = if i == len - 1 {
+                &old_data[offset..]
+            } else {
+                let next_offset = offset_at(slc, i + 1);
+                &old_data[offset..next_offset]
+            };
+            let new_offset = new_data.len() as u32;
+            new_data.extend_from_slice(data);
+            new_offsets.extend_from_slice(&new_offset.to_le_bytes());
+        }
+
+        let mut result = Vec::with_capacity(4 + new_offsets.len() + new_data.len());
+        result.extend_from_slice(&(new_offsets.len() as u32 + 4).to_le_bytes());
+        result.extend_from_slice(&new_offsets);
+        result.extend_from_slice(&new_data);
+        Self(Bytes::from(result))
+    }
+
+    /// Remove the first found instance of the given value from the list.
+    #[must_use]
+    pub fn setremove(&self, value: &Var) -> Self {
+        let len = self.len();
+        if len == 0 {
+            return self.clone();
+        }
+
+        if len == 1 {
+            if self.get(0).unwrap().eq(value) {
+                return ListImplBuffer::new();
+            }
+            return self.clone();
+        }
+
+        // This will involve rebuilding both the offsets and data sections.
+        let slc = self.0.as_ref();
+        let old_data_start = offsets_end_pos(slc);
+
+        let old_data = &self.0.slice(old_data_start..);
+        let old_offsets = &slc[4..old_data_start];
+
+        let mut new_offsets = Vec::with_capacity(old_offsets.len() - 4);
+        let mut new_data = Vec::with_capacity(old_data.len());
+
+        // Iterate to generate
+        let mut found = false;
+        for i in 0..len {
+            let offset = offset_at(slc, i);
+            let data = if i == len - 1 {
+                old_data.slice(offset..)
+            } else {
+                let next_offset = offset_at(slc, i + 1);
+                old_data.slice(offset..next_offset)
+            };
+            let v = Var::from_bytes(data.clone()).unwrap();
+            if !found && v.eq(value) {
+                found = true;
+                continue;
+            }
+
+            let new_offset = new_data.len() as u32;
+            new_data.extend_from_slice(data.as_ref());
+            new_offsets.extend_from_slice(&new_offset.to_le_bytes());
+        }
+
+        let mut result = Vec::with_capacity(4 + new_offsets.len() + new_data.len());
+        result.extend_from_slice(&(new_offsets.len() as u32 + 4).to_le_bytes());
+        result.extend_from_slice(&new_offsets);
+        result.extend_from_slice(&new_data);
+        Self(Bytes::from(result))
+    }
+
+    pub fn insert(&self, index: isize, value: Var) -> Self {
+        let index = if index < 0 {
+            0
+        } else {
+            min(index as usize, self.len())
+        };
+
+        // Special case if inserting at end, it's just push
+        if index == self.len() {
+            return self.push(value);
+        }
+
+        // Special case if we're empty.
+        if self.is_empty() {
+            return Self::from_slice(&[value]);
+        }
+
+        // Accumulate up to the insertion point, building the new offsets and data sections.
+        // Then add the new item, and then add the rest of the items.
+        let slc = self.0.as_ref();
+        let old_data_start = offsets_end_pos(slc);
+        let old_data = &slc[old_data_start..];
+        let old_offsets = &slc[4..old_data_start];
+
+        let mut new_offsets = Vec::with_capacity(old_offsets.len() + 4);
+        let mut new_data = Vec::with_capacity(old_data.len() + value.as_bytes().unwrap().len());
+
+        for i in 0..self.len() {
+            if i == index {
+                let new_offset = new_data.len() as u32;
+                new_offsets.extend_from_slice(&new_offset.to_le_bytes());
+                new_data.extend_from_slice(value.as_bytes().unwrap().as_ref());
+            }
+            let offset = offset_at(slc, i);
+            let length = if i == self.len() - 1 {
+                old_data.len() - offset
+            } else {
+                let next_offset = offset_at(slc, i + 1);
+                next_offset - offset
+            };
+            let new_offset = new_data.len() as u32;
+            new_offsets.extend_from_slice(&new_offset.to_le_bytes());
+            new_data.extend_from_slice(&old_data[offset..offset + length]);
+        }
+
+        let mut result = Vec::with_capacity(4 + new_offsets.len() + new_data.len());
+        result.extend_from_slice(&(new_offsets.len() as u32 + 4).to_le_bytes());
+        result.extend_from_slice(&new_offsets);
+        result.extend_from_slice(&new_data);
+        Self(Bytes::from(result))
+    }
+
+    pub fn set(&self, index: usize, value: Var) -> Self {
+        let len = self.len();
+        if index >= len {
+            return self.clone();
+        }
+
+        // This will involve rebuilding both the offsets and data sections.
+        let slc = self.0.as_ref();
+        let old_data_start = offsets_end_pos(slc);
+
+        let old_data = &self.0.slice(old_data_start..);
+        let old_offsets = &slc[4..old_data_start];
+
+        let mut new_offsets = Vec::with_capacity(old_offsets.len());
+        let mut new_data = Vec::with_capacity(old_data.len());
+
+        // Iterate to generate
+        for i in 0..len {
+            let offset = offset_at(slc, i);
+            let data = if i == len - 1 {
+                old_data.slice(offset..)
+            } else {
+                let next_offset = offset_at(slc, i + 1);
+                old_data.slice(offset..next_offset)
+            };
+            if i == index {
+                let new_offset = new_data.len() as u32;
+                new_offsets.extend_from_slice(&new_offset.to_le_bytes());
+                new_data.extend_from_slice(value.as_bytes().unwrap().as_ref());
+            } else {
+                let new_offset = new_data.len() as u32;
+                new_offsets.extend_from_slice(&new_offset.to_le_bytes());
+                new_data.extend_from_slice(data.as_ref());
+            }
+        }
+
+        let mut result = Vec::with_capacity(4 + new_offsets.len() + new_data.len());
+        result.extend_from_slice(&(new_offsets.len() as u32 + 4).to_le_bytes());
+        result.extend_from_slice(&new_offsets);
+        result.extend_from_slice(&new_data);
+        Self(Bytes::from(result))
+    }
+
+    // Case insensitive
+    pub fn contains(&self, v: &Var) -> bool {
+        self.iter().any(|item| item.eq(v))
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = Var> + '_ {
+        (0..self.len()).map(move |i| self.get(i).unwrap())
+    }
+
+    pub fn contains_case_sensitive(&self, v: &Var) -> bool {
+        if let Variant::Str(s) = v.variant() {
+            for item in self.iter() {
+                if let Variant::Str(s2) = item.variant() {
+                    if s.as_str() == s2.as_str() {
+                        return true;
+                    }
+                }
+            }
+            return false;
+        }
+        self.contains(v)
+    }
+}
+
+impl AsByteBuffer for ListImplBuffer {
+    fn size_bytes(&self) -> usize {
+        self.0.len()
+    }
+
+    fn with_byte_buffer<R, F: FnMut(&[u8]) -> R>(&self, mut f: F) -> Result<R, EncodingError> {
+        Ok(f(self.0.as_ref()))
+    }
+
+    fn make_copy_as_vec(&self) -> Result<Vec<u8>, EncodingError> {
+        Ok(self.0.as_ref().to_vec())
+    }
+
+    fn from_bytes(bytes: Bytes) -> Result<Self, DecodingError>
+    where
+        Self: Sized,
+    {
+        Ok(Self(bytes))
+    }
+
+    fn as_bytes(&self) -> Result<Bytes, EncodingError> {
+        Ok(self.0.clone())
+    }
+}
+
+impl Encode for ListImplBuffer {
+    fn encode<E: Encoder>(&self, encoder: &mut E) -> Result<(), EncodeError> {
+        self.0.as_ref().encode(encoder)
+    }
+}
+
+impl Decode for ListImplBuffer {
+    fn decode<D: Decoder>(decoder: &mut D) -> Result<Self, DecodeError> {
+        let vec = Vec::<u8>::decode(decoder)?;
+        Ok(Self(Bytes::from(vec)))
+    }
+}
+
+impl<'de> BorrowDecode<'de> for ListImplBuffer {
+    fn borrow_decode<D: BorrowDecoder<'de>>(decoder: &mut D) -> Result<Self, DecodeError> {
+        let vec = Vec::<u8>::borrow_decode(decoder)?;
+        Ok(Self(Bytes::from(vec)))
+    }
+}
+
+impl From<Vec<Var>> for ListImplBuffer {
+    fn from(value: Vec<Var>) -> Self {
+        Self::from_slice(&value)
+    }
+}
+
+impl From<&[Var]> for ListImplBuffer {
+    fn from(value: &[Var]) -> Self {
+        Self::from_slice(value)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::var::list_impl_buffer::ListImplBuffer;
+    use crate::var::{v_int, v_string};
+
+    #[test]
+    pub fn list_make_get() {
+        let l = ListImplBuffer::new();
+        assert_eq!(l.len(), 0);
+        assert!(l.is_empty());
+        // MOO is a bit weird here, it returns None for out of bounds.
+        assert_eq!(l.get(0), None);
+
+        let l = ListImplBuffer::from_slice(&[v_int(1)]);
+        assert_eq!(l.len(), 1);
+        assert!(!l.is_empty());
+        assert_eq!(l.get(0), Some(v_int(1)));
+        assert_eq!(l.get(1), None);
+
+        let l = ListImplBuffer::from_slice(&[v_int(1), v_int(2), v_int(3)]);
+        assert_eq!(l.len(), 3);
+        assert!(!l.is_empty());
+
+        assert_eq!(l.get(0), Some(v_int(1)));
+        assert_eq!(l.get(1), Some(v_int(2)));
+        assert_eq!(l.get(2), Some(v_int(3)));
+    }
+
+    #[test]
+    pub fn list_push() {
+        let l = ListImplBuffer::new();
+        let l = l.push(v_int(1));
+
+        assert_eq!(l.len(), 1);
+        let l = l.push(v_int(2));
+        assert_eq!(l.len(), 2);
+        let l = l.push(v_int(3));
+        assert_eq!(l.len(), 3);
+
+        assert_eq!(l.get(0), Some(v_int(1)));
+        assert_eq!(l.get(2), Some(v_int(3)));
+        assert_eq!(l.get(1), Some(v_int(2)));
+    }
+
+    #[test]
+    fn list_pop_front() {
+        let l = ListImplBuffer::from_slice(&[v_int(1), v_int(2), v_int(3)]);
+        let (item, l) = l.pop_front();
+        assert_eq!(item, v_int(1));
+        let (item, l) = l.pop_front();
+        assert_eq!(item, v_int(2));
+        let (item, l) = l.pop_front();
+        assert_eq!(item, v_int(3));
+        assert_eq!(l.len(), 0);
+    }
+
+    #[test]
+    fn test_list_append() {
+        let l1 = ListImplBuffer::from_slice(&[v_int(1), v_int(2), v_int(3)]);
+        let l2 = ListImplBuffer::from_slice(&[v_int(4), v_int(5), v_int(6)]);
+        let l = l1.append(l2);
+        assert_eq!(l.len(), 6);
+        assert_eq!(l.get(0), Some(v_int(1)));
+        assert_eq!(l.get(5), Some(v_int(6)));
+    }
+
+    #[test]
+    fn test_list_remove() {
+        let l = ListImplBuffer::from_slice(&[v_int(1), v_int(2), v_int(3)]);
+
+        let l = l.remove_at(1);
+        assert_eq!(l.len(), 2);
+        assert_eq!(l.get(1), Some(v_int(3)));
+        assert_eq!(l.get(0), Some(v_int(1)));
+    }
+
+    #[test]
+    fn test_list_setremove() {
+        let l = ListImplBuffer::from_slice(&[v_int(1), v_int(2), v_int(3), v_int(2)]);
+        let l = l.setremove(&v_int(2));
+        assert_eq!(l.len(), 3);
+        assert_eq!(l.get(0), Some(v_int(1)));
+        assert_eq!(l.get(1), Some(v_int(3)));
+        assert_eq!(l.get(2), Some(v_int(2)));
+
+        // setremove til empty
+        let l = ListImplBuffer::from_slice(&[v_int(1)]);
+        let l = l.setremove(&v_int(1));
+        assert_eq!(l.len(), 0);
+        assert_eq!(l.get(0), None);
+    }
+
+    #[test]
+    fn test_list_insert() {
+        let l = ListImplBuffer::new();
+        let l = l.insert(0, v_int(4));
+        assert_eq!(l.len(), 1);
+        assert_eq!(l.get(0), Some(v_int(4)));
+
+        let l = l.insert(0, v_int(3));
+        assert_eq!(l.len(), 2);
+        assert_eq!(l.get(0), Some(v_int(3)));
+        assert_eq!(l.get(1), Some(v_int(4)));
+
+        let l = l.insert(-1, v_int(5));
+        assert_eq!(l.len(), 3);
+        assert_eq!(l.get(0), Some(v_int(5)));
+        assert_eq!(l.get(1), Some(v_int(3)));
+        assert_eq!(l.get(2), Some(v_int(4)));
+    }
+
+    #[test]
+    fn test_list_set() {
+        let l = ListImplBuffer::from_slice(&[v_int(1), v_int(2), v_int(3)]);
+        let l = l.set(1, v_int(4));
+        assert_eq!(l.len(), 3);
+        assert_eq!(l.get(1), Some(v_int(4)));
+    }
+
+    #[test]
+    fn test_list_contains_case_insenstive() {
+        let l = ListImplBuffer::from_slice(&[v_string("foo".into()), v_string("bar".into())]);
+        assert!(l.contains(&v_string("FOO".into())));
+        assert!(l.contains(&v_string("BAR".into())));
+    }
+
+    #[test]
+    fn test_list_contains_case_senstive() {
+        let l = ListImplBuffer::from_slice(&[v_string("foo".into()), v_string("bar".into())]);
+        assert!(!l.contains_case_sensitive(&v_string("FOO".into())));
+        assert!(!l.contains_case_sensitive(&v_string("BAR".into())));
+    }
+}

--- a/crates/values/src/var/list_impl_vector.rs
+++ b/crates/values/src/var/list_impl_vector.rs
@@ -1,0 +1,412 @@
+// Copyright (C) 2024 Ryan Daum <ryan.daum@gmail.com>
+//
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free Software
+// Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program. If not, see <https://www.gnu.org/licenses/>.
+//
+
+use std::cmp::min;
+use std::ops::{Index, Range, RangeFrom, RangeFull, RangeTo};
+use std::sync::Arc;
+
+use crate::BincodeAsByteBufferExt;
+use bincode::{Decode, Encode};
+
+use crate::var::variant::Variant;
+use crate::var::{v_empty_list, Var};
+
+#[derive(Clone, Debug, Encode, Decode, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct ListImplVector {
+    // TODO: Implement our own zero-copy list type and get rid of bincoding
+    //   To support nested content, would require an offsets table at the front, etc.
+    //   Take a look at how flatbufers, capnproto, and other zero-copy serialization formats do this.
+    inner: Arc<Vec<Var>>,
+}
+
+impl ListImplVector {
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            inner: Arc::new(Vec::new()),
+        }
+    }
+
+    #[must_use]
+    pub fn from_vec(vec: Vec<Var>) -> Self {
+        Self {
+            inner: Arc::new(vec),
+        }
+    }
+
+    pub fn from_slice(vec: &[Var]) -> Self {
+        Self {
+            inner: Arc::new(vec.to_vec()),
+        }
+    }
+
+    #[must_use]
+    pub fn push(&mut self, v: Var) -> Self {
+        // If there's only one copy of us, mutate that directly.
+        match Arc::get_mut(&mut self.inner) {
+            Some(vec) => {
+                vec.push(v);
+                self.clone()
+            }
+            None => {
+                let mut new_vec = (*self.inner).clone();
+                new_vec.push(v);
+                Self::from_vec(new_vec)
+            }
+        }
+    }
+
+    /// Take the first item from the front, and return (item, `new_list`)
+    #[must_use]
+    pub fn pop_front(&self) -> (Var, Self) {
+        if self.inner.is_empty() {
+            return (v_empty_list(), Self::new());
+        }
+        let mut new_list = (*self.inner).clone();
+        let item = new_list.remove(0);
+        (item.clone(), Self::from_vec(new_list))
+    }
+
+    #[must_use]
+    pub fn append(&mut self, other: Self) -> Self {
+        match Arc::get_mut(&mut self.inner) {
+            Some(vec) => {
+                vec.extend_from_slice(&other.inner);
+                self.clone()
+            }
+            None => {
+                let mut new_list = (*self.inner).clone();
+                new_list.extend_from_slice(&other.inner);
+                Self::from_vec(new_list)
+            }
+        }
+    }
+
+    #[must_use]
+    pub fn remove_at(&mut self, index: usize) -> Self {
+        match Arc::get_mut(&mut self.inner) {
+            Some(vec) => {
+                vec.remove(index);
+                self.clone()
+            }
+            None => {
+                let mut new_list = (*self.inner).clone();
+                new_list.remove(index);
+                Self::from_vec(new_list)
+            }
+        }
+    }
+
+    /// Remove the first found instance of the given value from the list.
+    #[must_use]
+    pub fn setremove(&mut self, value: &Var) -> Self {
+        if self.inner.is_empty() {
+            return self.clone();
+        }
+        match Arc::get_mut(&mut self.inner) {
+            Some(vec) => {
+                for i in 0..vec.len() {
+                    if vec[i].eq(value) {
+                        vec.remove(i);
+                        break;
+                    }
+                }
+                self.clone()
+            }
+            None => {
+                let mut new_list = Vec::with_capacity(self.inner.len() - 1);
+                let mut found = false;
+                for v in self.inner.iter() {
+                    if !found && v.eq(value) {
+                        found = true;
+                        continue;
+                    }
+                    new_list.push(v.clone());
+                }
+                Self::from_vec(new_list)
+            }
+        }
+    }
+
+    #[must_use]
+    pub fn insert(&mut self, index: isize, v: Var) -> Self {
+        match Arc::get_mut(&mut self.inner) {
+            Some(vec) => {
+                let index = if index < 0 {
+                    0
+                } else {
+                    min(index as usize, vec.len())
+                };
+                vec.insert(index, v);
+                self.clone()
+            }
+            None => {
+                let mut new_list = Vec::with_capacity(self.inner.len() + 1);
+                let index = if index < 0 {
+                    0
+                } else {
+                    min(index as usize, self.inner.len())
+                };
+                new_list.extend_from_slice(&self.inner[..index]);
+                new_list.push(v);
+                new_list.extend_from_slice(&self.inner[index..]);
+                Self::from_vec(new_list)
+            }
+        }
+    }
+
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.inner.len()
+    }
+
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.inner.is_empty()
+    }
+
+    // "in" operator is case insensitive...
+    #[must_use]
+    pub fn contains(&self, v: &Var) -> bool {
+        self.inner.contains(v)
+    }
+
+    // but bf_is_member is not... sigh.
+    #[must_use]
+    pub fn contains_case_sensitive(&self, v: &Var) -> bool {
+        if let Variant::Str(s) = v.variant() {
+            for item in self.inner.iter() {
+                if let Variant::Str(s2) = item.variant() {
+                    if s.as_str() == s2.as_str() {
+                        return true;
+                    }
+                }
+            }
+            return false;
+        }
+        self.inner.contains(v)
+    }
+
+    #[must_use]
+    pub fn get(&self, index: usize) -> Option<Var> {
+        self.inner.get(index).cloned()
+    }
+
+    #[must_use]
+    pub fn set(&mut self, index: usize, value: Var) -> Self {
+        match Arc::get_mut(&mut self.inner) {
+            Some(vec) => {
+                vec[index] = value;
+                self.clone()
+            }
+            None => {
+                let mut new_vec = (*self.inner).clone();
+                new_vec[index] = value;
+                Self::from_vec(new_vec)
+            }
+        }
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = &Var> {
+        self.inner.iter()
+    }
+}
+
+impl From<ListImplVector> for Vec<Var> {
+    fn from(val: ListImplVector) -> Self {
+        val.inner[..].to_vec()
+    }
+}
+
+impl Default for ListImplVector {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Index<usize> for ListImplVector {
+    type Output = Var;
+
+    fn index(&self, index: usize) -> &Self::Output {
+        &self.inner[index]
+    }
+}
+
+impl Index<Range<usize>> for ListImplVector {
+    type Output = [Var];
+
+    fn index(&self, index: Range<usize>) -> &Self::Output {
+        &self.inner[index]
+    }
+}
+
+impl Index<RangeFrom<usize>> for ListImplVector {
+    type Output = [Var];
+
+    fn index(&self, index: RangeFrom<usize>) -> &Self::Output {
+        &self.inner[index]
+    }
+}
+
+impl Index<RangeTo<usize>> for ListImplVector {
+    type Output = [Var];
+
+    fn index(&self, index: RangeTo<usize>) -> &Self::Output {
+        &self.inner[index]
+    }
+}
+
+impl Index<RangeFull> for ListImplVector {
+    type Output = [Var];
+
+    fn index(&self, index: RangeFull) -> &Self::Output {
+        &self.inner[index]
+    }
+}
+
+impl BincodeAsByteBufferExt for ListImplVector {}
+
+#[cfg(test)]
+mod tests {
+    use crate::var::list_impl_vector::ListImplVector;
+    use crate::var::{v_int, v_string};
+
+    #[test]
+    pub fn list_make_get() {
+        let l = ListImplVector::new();
+        assert_eq!(l.len(), 0);
+        assert!(l.is_empty());
+        // MOO is a bit weird here, it returns None for out of bounds.
+        assert_eq!(l.get(0), None);
+
+        let l = ListImplVector::from_slice(&[v_int(1)]);
+        assert_eq!(l.len(), 1);
+        assert!(!l.is_empty());
+        assert_eq!(l.get(0), Some(v_int(1)));
+        assert_eq!(l.get(1), None);
+
+        let l = ListImplVector::from_slice(&[v_int(1), v_int(2), v_int(3)]);
+        assert_eq!(l.len(), 3);
+        assert!(!l.is_empty());
+
+        assert_eq!(l.get(0), Some(v_int(1)));
+        assert_eq!(l.get(1), Some(v_int(2)));
+        assert_eq!(l.get(2), Some(v_int(3)));
+    }
+
+    #[test]
+    pub fn list_push() {
+        let mut l = ListImplVector::new();
+        let mut l = l.push(v_int(1));
+
+        assert_eq!(l.len(), 1);
+        let mut l = l.push(v_int(2));
+        assert_eq!(l.len(), 2);
+        let l = l.push(v_int(3));
+        assert_eq!(l.len(), 3);
+
+        assert_eq!(l.get(0), Some(v_int(1)));
+        assert_eq!(l.get(2), Some(v_int(3)));
+        assert_eq!(l.get(1), Some(v_int(2)));
+    }
+
+    #[test]
+    fn list_pop_front() {
+        let l = ListImplVector::from_slice(&[v_int(1), v_int(2), v_int(3)]);
+        let (item, l) = l.pop_front();
+        assert_eq!(item, v_int(1));
+        let (item, l) = l.pop_front();
+        assert_eq!(item, v_int(2));
+        let (item, l) = l.pop_front();
+        assert_eq!(item, v_int(3));
+        assert_eq!(l.len(), 0);
+    }
+
+    #[test]
+    fn test_list_append() {
+        let mut l1 = ListImplVector::from_slice(&[v_int(1), v_int(2), v_int(3)]);
+        let l2 = ListImplVector::from_slice(&[v_int(4), v_int(5), v_int(6)]);
+        let l = l1.append(l2);
+        assert_eq!(l.len(), 6);
+        assert_eq!(l.get(0), Some(v_int(1)));
+        assert_eq!(l.get(5), Some(v_int(6)));
+    }
+
+    #[test]
+    fn test_list_remove() {
+        let mut l = ListImplVector::from_slice(&[v_int(1), v_int(2), v_int(3)]);
+
+        let l = l.remove_at(1);
+        assert_eq!(l.len(), 2);
+        assert_eq!(l.get(1), Some(v_int(3)));
+        assert_eq!(l.get(0), Some(v_int(1)));
+    }
+
+    #[test]
+    fn test_list_setremove() {
+        let mut l = ListImplVector::from_slice(&[v_int(1), v_int(2), v_int(3), v_int(2)]);
+        let l = l.setremove(&v_int(2));
+        assert_eq!(l.len(), 3);
+        assert_eq!(l.get(0), Some(v_int(1)));
+        assert_eq!(l.get(1), Some(v_int(3)));
+        assert_eq!(l.get(2), Some(v_int(2)));
+
+        // setremove til empty
+        let mut l = ListImplVector::from_slice(&[v_int(1)]);
+        let l = l.setremove(&v_int(1));
+        assert_eq!(l.len(), 0);
+        assert_eq!(l.get(0), None);
+    }
+
+    #[test]
+    fn test_list_insert() {
+        let mut l = ListImplVector::new();
+        let mut l = l.insert(0, v_int(4));
+        assert_eq!(l.len(), 1);
+        assert_eq!(l.get(0), Some(v_int(4)));
+
+        let mut l = l.insert(0, v_int(3));
+        assert_eq!(l.len(), 2);
+        assert_eq!(l.get(0), Some(v_int(3)));
+        assert_eq!(l.get(1), Some(v_int(4)));
+
+        let l = l.insert(-1, v_int(5));
+        assert_eq!(l.len(), 3);
+        assert_eq!(l.get(0), Some(v_int(5)));
+        assert_eq!(l.get(1), Some(v_int(3)));
+        assert_eq!(l.get(2), Some(v_int(4)));
+    }
+
+    #[test]
+    fn test_list_set() {
+        let mut l = ListImplVector::from_slice(&[v_int(1), v_int(2), v_int(3)]);
+        let l = l.set(1, v_int(4));
+        assert_eq!(l.len(), 3);
+        assert_eq!(l.get(1), Some(v_int(4)));
+    }
+
+    #[test]
+    fn test_list_contains_case_insenstive() {
+        let l = ListImplVector::from_slice(&[v_string("foo".into()), v_string("bar".into())]);
+        assert!(l.contains(&v_string("FOO".into())));
+        assert!(l.contains(&v_string("BAR".into())));
+    }
+
+    #[test]
+    fn test_list_contains_case_senstive() {
+        let l = ListImplVector::from_slice(&[v_string("foo".into()), v_string("bar".into())]);
+        assert!(!l.contains_case_sensitive(&v_string("FOO".into())));
+        assert!(!l.contains_case_sensitive(&v_string("BAR".into())));
+    }
+}

--- a/crates/values/src/var/mod.rs
+++ b/crates/values/src/var/mod.rs
@@ -84,7 +84,7 @@ pub struct Var {
 
 impl Var {
     #[must_use]
-    pub(crate) fn new(value: Variant) -> Self {
+    pub fn new(value: Variant) -> Self {
         Self { value }
     }
 
@@ -209,12 +209,12 @@ pub fn v_err(e: Error) -> Var {
 
 #[must_use]
 pub fn v_list(l: &[Var]) -> Var {
-    Var::new(Variant::List(List::from_vec(l.to_vec())))
+    Var::new(Variant::List(List::from_slice(l)))
 }
 
 #[must_use]
 pub fn v_listv(l: Vec<Var>) -> Var {
-    Var::new(Variant::List(List::from_vec(l)))
+    Var::new(Variant::List(List::from_slice(&l)))
 }
 
 #[must_use]

--- a/crates/values/src/var/objid.rs
+++ b/crates/values/src/var/objid.rs
@@ -14,8 +14,10 @@
 
 use crate::encode::{DecodingError, EncodingError};
 
+use crate::AsByteBuffer;
 use binary_layout::LayoutAs;
 use bincode::{Decode, Encode};
+use daumtils::SliceRef;
 use std::fmt::{Debug, Display, Formatter};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Encode, Decode)]
@@ -52,36 +54,36 @@ impl Objid {
     }
 }
 
-// impl AsByteBuffer for Objid {
-//     fn size_bytes(&self) -> usize {
-//         8
-//     }
-//
-//     fn with_byte_buffer<R, F: FnMut(&[u8]) -> R>(&self, f: F) -> Result<R, EncodingError> {
-//         Ok(f(&self.0.to_le_bytes()))
-//     }
-//
-//     fn make_copy_as_vec(&self) -> Result<Vec<u8>, EncodingError> {
-//         Ok(self.0.to_le_bytes().to_vec())
-//     }
-//
-//     fn from_sliceref(bytes: SliceRef) -> Result<Self, DecodingError>
-//     where
-//         Self: Sized,
-//     {
-//         let bytes = bytes.as_slice();
-//         if bytes.len() != 8 {
-//             return Err(DecodingError::CouldNotDecode(format!(
-//                 "Expected 8 bytes, got {}",
-//                 bytes.len()
-//             )));
-//         }
-//         let mut buf = [0u8; 8];
-//         buf.copy_from_slice(bytes);
-//         Ok(Self(i64::from_le_bytes(buf)))
-//     }
-//
-//     fn as_sliceref(&self) -> Result<SliceRef, EncodingError> {
-//         Ok(SliceRef::from_vec(self.make_copy_as_vec()?))
-//     }
-// }
+impl AsByteBuffer for Objid {
+    fn size_bytes(&self) -> usize {
+        8
+    }
+
+    fn with_byte_buffer<R, F: FnMut(&[u8]) -> R>(&self, mut f: F) -> Result<R, EncodingError> {
+        Ok(f(&self.0.to_le_bytes()))
+    }
+
+    fn make_copy_as_vec(&self) -> Result<Vec<u8>, EncodingError> {
+        Ok(self.0.to_le_bytes().to_vec())
+    }
+
+    fn from_sliceref(bytes: SliceRef) -> Result<Self, DecodingError>
+    where
+        Self: Sized,
+    {
+        let bytes = bytes.as_slice();
+        if bytes.len() != 8 {
+            return Err(DecodingError::CouldNotDecode(format!(
+                "Expected 8 bytes, got {}",
+                bytes.len()
+            )));
+        }
+        let mut buf = [0u8; 8];
+        buf.copy_from_slice(bytes);
+        Ok(Self(i64::from_le_bytes(buf)))
+    }
+
+    fn as_sliceref(&self) -> Result<SliceRef, EncodingError> {
+        Ok(SliceRef::from_vec(self.make_copy_as_vec()?))
+    }
+}

--- a/crates/values/src/var/objid.rs
+++ b/crates/values/src/var/objid.rs
@@ -12,13 +12,14 @@
 // this program. If not, see <https://www.gnu.org/licenses/>.
 //
 
-use crate::encode::{DecodingError, EncodingError};
+use std::fmt::{Debug, Display, Formatter};
 
-use crate::AsByteBuffer;
 use binary_layout::LayoutAs;
 use bincode::{Decode, Encode};
 use bytes::Bytes;
-use std::fmt::{Debug, Display, Formatter};
+
+use crate::encode::{DecodingError, EncodingError};
+use crate::AsByteBuffer;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Encode, Decode)]
 pub struct Objid(pub i64);

--- a/crates/values/src/var/objid.rs
+++ b/crates/values/src/var/objid.rs
@@ -17,7 +17,7 @@ use crate::encode::{DecodingError, EncodingError};
 use crate::AsByteBuffer;
 use binary_layout::LayoutAs;
 use bincode::{Decode, Encode};
-use daumtils::SliceRef;
+use bytes::Bytes;
 use std::fmt::{Debug, Display, Formatter};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Encode, Decode)]
@@ -67,11 +67,11 @@ impl AsByteBuffer for Objid {
         Ok(self.0.to_le_bytes().to_vec())
     }
 
-    fn from_sliceref(bytes: SliceRef) -> Result<Self, DecodingError>
+    fn from_bytes(bytes: Bytes) -> Result<Self, DecodingError>
     where
         Self: Sized,
     {
-        let bytes = bytes.as_slice();
+        let bytes = bytes.as_ref();
         if bytes.len() != 8 {
             return Err(DecodingError::CouldNotDecode(format!(
                 "Expected 8 bytes, got {}",
@@ -83,7 +83,7 @@ impl AsByteBuffer for Objid {
         Ok(Self(i64::from_le_bytes(buf)))
     }
 
-    fn as_sliceref(&self) -> Result<SliceRef, EncodingError> {
-        Ok(SliceRef::from_vec(self.make_copy_as_vec()?))
+    fn as_bytes(&self) -> Result<Bytes, EncodingError> {
+        Ok(Bytes::from(self.make_copy_as_vec()?))
     }
 }

--- a/crates/values/src/var/string.rs
+++ b/crates/values/src/var/string.rs
@@ -16,7 +16,6 @@ use std::fmt::{Display, Formatter};
 use std::hash::Hash;
 use std::ops::Range;
 use std::str::FromStr;
-use std::sync::Arc;
 
 use bincode::{Decode, Encode};
 

--- a/crates/values/src/var/string.rs
+++ b/crates/values/src/var/string.rs
@@ -17,24 +17,35 @@ use std::hash::Hash;
 use std::ops::Range;
 use std::str::FromStr;
 
-use bincode::{Decode, Encode};
+use crate::{AsByteBuffer, DecodingError, EncodingError};
+use bincode::de::{BorrowDecoder, Decoder};
+use bincode::enc::Encoder;
+use bincode::error::{DecodeError, EncodeError};
+use bincode::{BorrowDecode, Decode, Encode};
+use daumtils::SliceRef;
 
 use crate::var::error::Error;
-use crate::var::{v_err, v_str, v_string, Var};
+use crate::var::{v_err, v_str, v_string, List, Var};
 
-#[derive(Clone, Encode, Decode, Ord, PartialOrd, Debug)]
-pub struct Str {
-    inner: Arc<String>,
+#[derive(Clone, Debug)]
+pub struct Str(SliceRef);
+
+fn transmutey(src: &SliceRef) -> &str {
+    let s = src.as_slice();
+    unsafe { std::mem::transmute(s) }
 }
 
 impl Str {
     #[must_use]
     pub fn from_string(s: String) -> Self {
-        Self { inner: Arc::new(s) }
+        let s = s.into_bytes();
+        let sr = SliceRef::from_vec(s);
+        Self(sr)
     }
 
     pub fn get(&self, offset: usize) -> Option<Var> {
-        let r = self.inner.get(offset..=offset);
+        let s = transmutey(&self.0);
+        let r = s.get(offset..offset + 1);
         r.map(v_str)
     }
 
@@ -43,54 +54,55 @@ impl Str {
         if r.len() != 1 {
             return v_err(Error::E_RANGE);
         }
-        if offset >= self.inner.len() {
+        if offset >= self.0.len() {
             return v_err(Error::E_RANGE);
         }
-        let mut s = self.inner.as_str().to_string();
+        let mut s = transmutey(&self.0).to_string();
         s.replace_range(offset..=offset, r.as_str());
         v_string(s)
     }
 
     pub fn get_range(&self, range: Range<usize>) -> Option<Var> {
-        let r = self.inner.get(range);
+        let s = transmutey(&self.0);
+        let r = s.get(range);
         r.map(v_str)
     }
 
     #[must_use]
     pub fn append(&self, other: &Self) -> Var {
-        v_string(format!("{}{}", self.inner, other.inner))
+        v_string(format!("{}{}", self.0, other.0))
     }
 
     #[must_use]
     pub fn append_str(&self, other: &str) -> Var {
-        v_string(format!("{}{}", self.inner, other))
+        v_string(format!("{}{}", self.0, other))
     }
 
     #[must_use]
     pub fn append_string(&self, other: String) -> Var {
-        v_string(format!("{}{}", self.inner, other))
+        v_string(format!("{}{}", self.0, other))
     }
 
     #[must_use]
     pub fn len(&self) -> usize {
-        self.inner.len()
+        self.0.len()
     }
 
     #[must_use]
     pub fn is_empty(&self) -> bool {
-        self.inner.is_empty()
+        self.0.is_empty()
     }
 
     #[must_use]
     pub fn as_str(&self) -> &str {
-        self.inner.as_str()
+        transmutey(&self.0)
     }
 
     #[must_use]
     pub fn substring(&self, range: Range<usize>) -> Self {
-        Self {
-            inner: Arc::new(self.inner[range].to_string()),
-        }
+        let s = transmutey(&self.0);
+        let s = s.get(range).unwrap_or("");
+        Self::from_string(s.to_string())
     }
 }
 
@@ -98,14 +110,17 @@ impl Str {
 // bf_is_member and bf_strcmp.
 impl PartialEq for Str {
     fn eq(&self, other: &Self) -> bool {
-        self.inner.eq_ignore_ascii_case(other.inner.as_str())
+        let s = transmutey(&self.0);
+        let o = transmutey(&other.0);
+        s.eq_ignore_ascii_case(o)
     }
 }
 impl Eq for Str {}
 
 impl Hash for Str {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        self.inner.to_lowercase().hash(state)
+        let s = transmutey(&self.0);
+        s.to_lowercase().hash(state)
     }
 }
 
@@ -113,14 +128,73 @@ impl FromStr for Str {
     type Err = ();
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Ok(Self {
-            inner: Arc::new(s.to_string()),
-        })
+        let s = s.to_string();
+        Ok(Self::from_string(s))
     }
 }
 
 impl Display for Str {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        f.write_fmt(format_args!("{}", self.inner))
+        f.write_fmt(format_args!("{}", self.0))
+    }
+}
+
+impl Encode for Str {
+    fn encode<E: Encoder>(&self, encoder: &mut E) -> Result<(), EncodeError> {
+        let str = self.as_str().to_string();
+        str.encode(encoder)
+    }
+}
+
+impl Decode for Str {
+    fn decode<D: Decoder>(decoder: &mut D) -> Result<Self, DecodeError> {
+        let str = String::decode(decoder)?;
+        Ok(Self::from_string(str))
+    }
+}
+
+impl<'de> BorrowDecode<'de> for Str {
+    fn borrow_decode<D: BorrowDecoder<'de>>(decoder: &mut D) -> Result<Self, DecodeError> {
+        let str = String::borrow_decode(decoder)?;
+        Ok(Self::from_string(str))
+    }
+}
+
+impl Ord for Str {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        let s = transmutey(&self.0);
+        let o = transmutey(&other.0);
+        s.to_lowercase().cmp(&o.to_lowercase())
+    }
+}
+
+impl PartialOrd for Str {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl AsByteBuffer for Str {
+    fn size_bytes(&self) -> usize {
+        self.0.len()
+    }
+
+    fn with_byte_buffer<R, F: FnMut(&[u8]) -> R>(&self, mut f: F) -> Result<R, EncodingError> {
+        Ok(f(self.0.as_slice()))
+    }
+
+    fn make_copy_as_vec(&self) -> Result<Vec<u8>, EncodingError> {
+        Ok(self.0.as_slice().to_vec())
+    }
+
+    fn from_sliceref(bytes: SliceRef) -> Result<Self, DecodingError>
+    where
+        Self: Sized,
+    {
+        Ok(Self(bytes))
+    }
+
+    fn as_sliceref(&self) -> Result<SliceRef, EncodingError> {
+        Ok(self.0.clone())
     }
 }

--- a/crates/values/src/var/variant.rs
+++ b/crates/values/src/var/variant.rs
@@ -12,8 +12,6 @@
 // this program. If not, see <https://www.gnu.org/licenses/>.
 //
 
-use bincode::{Decode, Encode};
-
 use crate::var::error::Error;
 use crate::var::list::List;
 use crate::var::objid::Objid;

--- a/crates/values/src/var/variant.rs
+++ b/crates/values/src/var/variant.rs
@@ -16,8 +16,6 @@ use crate::var::error::Error;
 use crate::var::list::List;
 use crate::var::objid::Objid;
 use crate::var::string::Str;
-use crate::{AsByteBuffer, DecodingError, EncodingError};
-use daumtils::SliceRef;
 use std::fmt::{Display, Formatter, Result as FmtResult};
 
 use super::Var;

--- a/crates/values/src/var/variant.rs
+++ b/crates/values/src/var/variant.rs
@@ -16,11 +16,13 @@ use crate::var::error::Error;
 use crate::var::list::List;
 use crate::var::objid::Objid;
 use crate::var::string::Str;
+use crate::{AsByteBuffer, DecodingError, EncodingError};
+use daumtils::SliceRef;
 use std::fmt::{Display, Formatter, Result as FmtResult};
 
 use super::Var;
 
-#[derive(Clone, Encode, Decode, Debug)]
+#[derive(Clone, Debug)]
 pub enum Variant {
     None,
     Str(Str),

--- a/crates/values/src/var/variant.rs
+++ b/crates/values/src/var/variant.rs
@@ -12,11 +12,12 @@
 // this program. If not, see <https://www.gnu.org/licenses/>.
 //
 
+use std::fmt::{Display, Formatter, Result as FmtResult};
+
 use crate::var::error::Error;
 use crate::var::list::List;
 use crate::var::objid::Objid;
 use crate::var::string::Str;
-use std::fmt::{Display, Formatter, Result as FmtResult};
 
 use super::Var;
 

--- a/crates/values/src/var/varops.rs
+++ b/crates/values/src/var/varops.rs
@@ -90,7 +90,7 @@ impl Var {
             return v_err(E_TYPE);
         };
 
-        match l.iter().position(|x| x == v) {
+        match l.iter().position(|x| x == *v) {
             None => v_int(0),
             Some(i) => v_int(i as i64 + 1),
         }
@@ -187,7 +187,8 @@ impl Var {
                 }
                 let mut res = Vec::with_capacity((to - from + 1) as usize);
                 for i in from..=to {
-                    res.push(l[(i - 1) as usize].clone());
+                    let v = l.get((i - 1) as usize).unwrap();
+                    res.push(v);
                 }
                 Ok(v_listv(res))
             }
@@ -234,8 +235,10 @@ impl Var {
             }
             (Variant::List(base_list), Variant::List(value_list)) => {
                 let mut ans: Vec<Self> = Vec::with_capacity(newsize as usize);
+
+                let base_list = base_list.iter().collect::<Vec<Self>>();
                 ans.extend_from_slice(&base_list[..from - 1]);
-                ans.extend(value_list.iter().cloned());
+                ans.extend(value_list.iter());
                 ans.extend_from_slice(&base_list[to..]);
                 v_listv(ans)
             }

--- a/crates/values/src/var/varops.rs
+++ b/crates/values/src/var/varops.rs
@@ -12,14 +12,16 @@
 // this program. If not, see <https://www.gnu.org/licenses/>.
 //
 
+use std::ops::{Div, Mul, Neg, Sub};
+
+use num_traits::Zero;
+use paste::paste;
+
 use crate::var::error::Error;
 use crate::var::error::Error::{E_INVARG, E_RANGE, E_TYPE};
 use crate::var::variant::Variant;
 use crate::var::{v_empty_list, v_empty_str, v_listv, Var};
 use crate::var::{v_err, v_float, v_int};
-use num_traits::Zero;
-use paste::paste;
-use std::ops::{Div, Mul, Neg, Sub};
 
 macro_rules! binary_numeric_coercion_op {
     ($op:tt ) => {

--- a/crates/web-host/src/host/mod.rs
+++ b/crates/web-host/src/host/mod.rs
@@ -53,7 +53,7 @@ pub fn var_as_json(v: &Var) -> serde_json::Value {
         Variant::List(l) => {
             let mut v = Vec::new();
             for e in l.iter() {
-                v.push(var_as_json(e));
+                v.push(var_as_json(&e));
             }
             serde_json::Value::Array(v)
         }


### PR DESCRIPTION
Long range plan is to remove use of bincode packing for DB values, and to use own-bespoke formats.

A lot of implicit bincoding was happening through the AsByteBuffer -> Encode/Decode extension trait.

I removed that umbrella extension trait then dealt with the fallout.