### PR TITLE
test: port `recycle` tests from Stunt

### DIFF
--- a/crates/db/src/db_worldstate.rs
+++ b/crates/db/src/db_worldstate.rs
@@ -14,7 +14,6 @@
 
 use uuid::Uuid;
 
-use bytes::Bytes;
 use moor_values::model::HasUuid;
 use moor_values::model::ObjSet;
 use moor_values::model::Perms;

--- a/crates/kernel/src/builtins/bf_objects.rs
+++ b/crates/kernel/src/builtins/bf_objects.rs
@@ -199,6 +199,16 @@ fn bf_recycle(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
         return Err(BfErr::Code(E_TYPE));
     };
 
+    let valid = bf_args.world_state.valid(*obj);
+    if valid == Ok(false)
+        || valid
+            .err()
+            .map(|e| e.database_error_msg() == Some("NotFound"))
+            .unwrap_or_default()
+    {
+        return Err(BfErr::Code(E_INVARG));
+    }
+
     // Check if the given task perms can control the object before continuing.
     if !bf_args
         .world_state

--- a/crates/kernel/src/builtins/bf_properties.rs
+++ b/crates/kernel/src/builtins/bf_properties.rs
@@ -204,7 +204,7 @@ fn bf_add_property(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
             *location,
             *location,
             name.as_str(),
-            bf_args.caller_perms(),
+            attrs.owner.unwrap(),
             attrs.flags.unwrap(),
             Some(value),
         )

--- a/crates/kernel/testsuite/moot/create.moot
+++ b/crates/kernel/testsuite/moot/create.moot
@@ -89,3 +89,8 @@ OBJ
 ; create($tmp2);
 ; return $tmp2.initialize_called;
 1
+
+// Test that the default owner is the caller
+@programmer
+; return create($nothing).owner;
+#4

--- a/crates/kernel/testsuite/moot/recycle.moot
+++ b/crates/kernel/testsuite/moot/recycle.moot
@@ -70,6 +70,7 @@ E_PERM
 >    "$object.recycle_called = $object.recycle_called + 1;"
 > });
 ; return $object.recycle_called;
+0
 
 // test_that_calling_recycle_on_a_recycled_object_fails
 @programmer

--- a/crates/kernel/testsuite/moot/recycle.moot
+++ b/crates/kernel/testsuite/moot/recycle.moot
@@ -1,0 +1,112 @@
+// Adapted from https://github.com/toddsundsted/stunt/blob/a4158f5835f1beb9d754c92fd5b3a137e459aabf/test/test_recycle.rb
+
+// test_that_the_first_argument_is_required 
+@programmer
+; recycle();
+E_ARGS
+
+// test_that_the_first_argument_can_be_an_object
+@wizard
+; recycle(1);
+E_TYPE
+; recycle(1.0);
+E_TYPE
+; recycle("foobar");
+E_TYPE
+; recycle({});
+E_TYPE
+; recycle($nothing);
+E_INVARG
+; recycle(create($nothing));
+
+// test_that_the_first_argument_must_be_valid
+@programmer
+; $object = create($nothing); recycle($object); recycle($object);
+E_INVARG
+
+// test_that_a_wizard_can_recycle_anything
+@wizard
+; $tmp1 = create($nothing); $tmp1.w = 0;
+; $tmp2 = create($nothing); $tmp2.w = 1;
+; add_property($tmp2, "x", 0, {player, "r"});
+; $tmp2.x = create($nothing); $tmp2.x.w = 0;
+; recycle($tmp2.x);
+; recycle($tmp2);
+; recycle($tmp1);
+
+// test_that_a_programmer_can_only_recycle_things_it_controls
+// Note: Stunt requires the `w` bit to be set for `recycle()`.
+//       MOO and moor, don"t so this test looks very different.
+@wizard
+; $object = create($nothing);
+@programmer
+; recycle($object);
+E_PERM
+
+// test_that_recycling_an_object_calls_recycle
+@programmer
+; $object = create($nothing);
+; add_property($object, "recycle_called", 0, {player, ""});
+; add_verb($object, {player, "xd", "recycle"}, {"this", "none", "this"});
+; set_verb_code($object, "recycle", {
+>    "typeof(this) == OBJ || raise(E_INVARG);",
+>    "$object.recycle_called = $object.recycle_called + 1;"
+> });
+; return $object.recycle_called;
+0
+; recycle(create($object));
+; return $object.recycle_called;
+1
+; recycle(create($object));
+; return $object.recycle_called;
+2
+
+// test_that_calling_recycle_when_recycling_an_object_fails
+; $object = create($nothing);
+; add_property($object, "recycle_called", 0, {player, ""});
+; add_verb($object, {player, "xd", "recycle"}, {"this", "none", "this"});
+; set_verb_code($object, "recycle", {
+>    "typeof(this) == OBJ || raise(E_INVARG);",
+>    "$object.recycle_called = $object.recycle_called + 1;"
+> });
+; return $object.recycle_called;
+
+// test_that_calling_recycle_on_a_recycled_object_fails
+@programmer
+; $object = create($nothing);
+; add_property($object, "keep", 0, {player, ""});
+; add_verb($object, {player, "xd", "recycle"}, {"this", "none", "this"});
+; set_verb_code($object, "recycle", {
+>   "typeof(this) == OBJ || raise(E_INVARG);",
+>   "$object.keep = this;"
+> });
+; return typeof($object.keep) == INT;
+1
+; return recycle(create($object));
+0
+; return typeof($object.keep) == OBJ;
+1
+; recycle($object.keep);
+E_INVARG
+; return valid($object.keep);
+0
+
+// test_that_recycling_an_object_DOES_NOT_recycle_values_in_properties_defined_on_the_object
+@wizard
+; $object = create($nothing);
+; add_property($object, "recycle_called", 0, {player, ""});
+; add_verb($object, {player, "xd", "recycle"}, {"this", "none", "this"});
+; set_verb_code($object, "recycle", {
+>   "$object.recycle_called = $object.recycle_called + 1;"
+> });
+; add_verb($object, {player, "xd", "go"}, {"this", "none", "this"});
+; set_verb_code($object, "go", {
+>   "x = create($object);",
+>   "add_property(x, \"next\", 0, {player, \"\"});",
+>   "x.next = create($object);",
+>   "recycle(x);"
+> });
+; $object.recycle_called = 0;
+; $object:go();
+; return $object.recycle_called;
+1

--- a/crates/kernel/testsuite/moot_suite.rs
+++ b/crates/kernel/testsuite/moot_suite.rs
@@ -56,21 +56,26 @@ impl MootRunner for SchedulerMootRunner {
     type Error = SchedulerError;
 
     fn eval<S: Into<String>>(&mut self, player: Objid, command: S) -> Result<Var, SchedulerError> {
+        let command = command.into();
+        eprintln!("{player} >> ; {command}");
         scheduler_test_utils::call_eval(
             self.scheduler.clone(),
             self.session.clone(),
             player,
-            command.into(),
+            command,
         )
+        .inspect(|var| eprintln!("{player} << {var}"))
     }
 
     fn command<S: AsRef<str>>(&mut self, player: Objid, command: S) -> Result<Var, SchedulerError> {
+        eprintln!("{player} >> ; {}", command.as_ref());
         scheduler_test_utils::call_command(
             self.scheduler.clone(),
             self.session.clone(),
             player,
             command.as_ref(),
         )
+        .inspect(|var| eprintln!("{player} << {var}"))
     }
 
     fn none(&self) -> Var {

--- a/crates/moot/Test.db
+++ b/crates/moot/Test.db
@@ -136,6 +136,7 @@ else
 endif
 .
 #2:0
+set_task_perms(player);
 notify(player, "-=!-^-!=-");
 try
     notify(player, toliteral(eval(argstr + ";")[2]));

--- a/crates/moot/tests/moot_lmoo.rs
+++ b/crates/moot/tests/moot_lmoo.rs
@@ -84,7 +84,7 @@ impl TelnetMootRunner {
     fn resolve_response(&mut self, response: String) -> Result<String, std::io::Error> {
         // Resolve the response; for example, the test assertion may be `$object`; resolve it to the object's specific number.
         self.client(WIZARD).command(format!(
-            "; {response}; \"TelnetMootRunner::resolve_response\";"
+            "; return {response}; \"TelnetMootRunner::resolve_response\";"
         ))
     }
 }
@@ -128,10 +128,13 @@ fn test_moo(path: &Path) {
 
     let mut state = MootState::new(TelnetMootRunner::new(), WIZARD);
     for (line_no, line) in f.lines().enumerate() {
+        let line = line.unwrap();
+        let line_no = line_no + 1;
         state = state
-            .process_line(line_no + 1, &line.unwrap())
-            .wrap_err(format!("line {}", line_no + 1))
+            .process_line(line_no, &line)
+            .wrap_err(format!("line {}", line_no))
             .unwrap();
+        //eprintln!("[{line_no}] {line} {state:?}");
     }
     state.finalize().unwrap();
 }

--- a/crates/values/src/model/mod.rs
+++ b/crates/values/src/model/mod.rs
@@ -126,6 +126,14 @@ impl WorldStateError {
             }
         }
     }
+
+    pub fn database_error_msg(&self) -> Option<&str> {
+        if let Self::DatabaseError(msg) = self {
+            Some(msg)
+        } else {
+            None
+        }
+    }
 }
 
 pub trait ValSet<V: AsByteBuffer>: FromIterator<V> {


### PR DESCRIPTION
* Verified this passes against MOO-1.8.1
* We have some failures against `moor`. First one:

```
assertion failed: `(left == right)`: Line 18: recycle($nothing);

Diff < left / right > :
<E_INVIND
>E_INVARG
```