### PR TITLE
Remove redundant fields from scatter opcode

### DIFF
--- a/crates/compiler/src/codegen.rs
+++ b/crates/compiler/src/codegen.rs
@@ -16,7 +16,6 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use itertools::Itertools;
 use tracing::error;
 
 use moor_values::var::Var;
@@ -215,19 +214,6 @@ impl CodegenState {
         right: &Expr,
     ) -> Result<(), CompileError> {
         self.generate_expr(right)?;
-        let nargs = scatter.len();
-        let nreq = scatter
-            .iter()
-            .filter(|s| s.kind == ScatterKind::Required)
-            .count();
-        let nrest = match scatter
-            .iter()
-            .positions(|s| s.kind == ScatterKind::Rest)
-            .last()
-        {
-            None => nargs + 1,
-            Some(rest) => rest + 1,
-        };
         let labels: Vec<(&ScatterItem, ScatterLabel)> = scatter
             .iter()
             .map(|s| {
@@ -248,9 +234,6 @@ impl CodegenState {
             .collect();
         let done = self.make_jump_label(None);
         self.emit(Op::Scatter(Box::new(ScatterArgs {
-            nargs,
-            nreq,
-            rest: nrest,
             labels: labels.iter().map(|(_, l)| l.clone()).collect(),
             done,
         })));

--- a/crates/compiler/src/codegen.rs
+++ b/crates/compiler/src/codegen.rs
@@ -320,6 +320,7 @@ impl CodegenState {
                         Ok(n) => self.emit(Op::ImmInt(n)),
                         Err(_) => self.emit(Op::ImmBigInt(*i)),
                     },
+                    Variant::Float(f) => self.emit(Op::ImmFloat(*f)),
                     Variant::Err(e) => {
                         self.emit(Op::ImmErr(*e));
                     }

--- a/crates/compiler/src/codegen_tests.rs
+++ b/crates/compiler/src/codegen_tests.rs
@@ -1010,9 +1010,6 @@ mod tests {
             vec![
                 Push(binary.find_var("args")),
                 Scatter(Box::new(ScatterArgs {
-                    nargs: 3,
-                    nreq: 3,
-                    rest: 4,
                     labels: vec![
                         ScatterLabel::Required(a),
                         ScatterLabel::Required(b),
@@ -1049,9 +1046,6 @@ mod tests {
             vec![
                 Push(binary.find_var("args")),
                 Scatter(Box::new(ScatterArgs {
-                    nargs: 3,
-                    nreq: 2,
-                    rest: 4,
                     labels: vec![
                         ScatterLabel::Required(first),
                         ScatterLabel::Required(second),
@@ -1094,9 +1088,6 @@ mod tests {
             vec![
                 Push(binary.find_var("args")),
                 Scatter(Box::new(ScatterArgs {
-                    nargs: 4,
-                    nreq: 2,
-                    rest: 4,
                     labels: vec![
                         ScatterLabel::Required(a),
                         ScatterLabel::Required(b),
@@ -1145,9 +1136,6 @@ mod tests {
             vec![
                 Push(binary.find_var("args")),
                 Scatter(Box::new(ScatterArgs {
-                    nargs: 6,
-                    nreq: 2,
-                    rest: 4,
                     labels: vec![
                         ScatterLabel::Required(a),
                         ScatterLabel::Optional(b, None),
@@ -1224,9 +1212,6 @@ mod tests {
                 ImmInt(1),
                 Ref,
                 Scatter(Box::new(ScatterArgs {
-                    nargs: 4,
-                    nreq: 2,
-                    rest: 4,
                     labels: vec![
                         ScatterLabel::Required(a),
                         ScatterLabel::Required(b),

--- a/crates/compiler/src/decompile.rs
+++ b/crates/compiler/src/decompile.rs
@@ -14,8 +14,8 @@
 
 use std::collections::{HashMap, VecDeque};
 
-use moor_values::var::Variant;
 use moor_values::var::{v_err, v_int, v_none, v_objid, Var};
+use moor_values::var::{v_float, Variant};
 
 use crate::ast::{
     Arg, BinaryOp, CatchCodes, CondArm, ExceptArm, Expr, ScatterItem, ScatterKind, Stmt, StmtNode,
@@ -834,6 +834,9 @@ impl Decompile {
             }
             Op::ImmBigInt(i) => {
                 self.push_expr(Expr::Value(v_int(i)));
+            }
+            Op::ImmFloat(f) => {
+                self.push_expr(Expr::Value(v_float(f)));
             }
             Op::ImmErr(e) => {
                 self.push_expr(Expr::Value(v_err(e)));

--- a/crates/compiler/src/opcode.rs
+++ b/crates/compiler/src/opcode.rs
@@ -101,9 +101,6 @@ pub enum ScatterLabel {
 
 #[derive(Clone, Debug, PartialEq, Eq, Ord, PartialOrd, Encode, Decode)]
 pub struct ScatterArgs {
-    pub nargs: usize,
-    pub nreq: usize,
-    pub rest: usize,
     pub labels: Vec<ScatterLabel>,
     pub done: Label,
 }

--- a/crates/compiler/src/opcode.rs
+++ b/crates/compiler/src/opcode.rs
@@ -18,7 +18,7 @@ use moor_values::var::Objid;
 
 use crate::labels::{Label, Name, Offset};
 
-#[derive(Clone, Debug, PartialEq, Eq, Ord, PartialOrd, Encode, Decode)]
+#[derive(Clone, Debug, PartialEq, PartialOrd, Encode, Decode)]
 pub enum Op {
     Add,
     And(Label),
@@ -48,6 +48,7 @@ pub enum Op {
     IfQues(Label),
     Imm(Label),
     ImmBigInt(i64),
+    ImmFloat(f64),
     ImmEmptyList,
     ImmErr(Error),
     ImmInt(i32),

--- a/crates/compiler/src/program.rs
+++ b/crates/compiler/src/program.rs
@@ -27,7 +27,7 @@ lazy_static! {
 }
 
 /// The result of compilation. The set of instructions, fork vectors, variable offsets, literals.
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Encode, Decode)]
+#[derive(Clone, Debug, PartialEq, PartialOrd, Encode, Decode)]
 pub struct Program {
     /// All the literals referenced in this program.
     pub literals: Vec<Var>,

--- a/crates/kernel/src/vm/activation.rs
+++ b/crates/kernel/src/vm/activation.rs
@@ -65,7 +65,7 @@ pub(crate) struct HandlerLabel {
 
 /// The MOO stack-frame specific portions of the activation:
 ///   the value stack, local variables, program, program counter, handler stack, etc.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq)]
 pub(crate) struct Frame {
     /// The program of the verb that is currently being executed.
     pub(crate) program: Program,
@@ -94,7 +94,7 @@ pub(crate) struct Frame {
 }
 
 /// Activation frame for the call stack.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq)]
 pub(crate) struct Activation {
     /// Frame
     pub(crate) frame: Frame,

--- a/crates/kernel/src/vm/vm_call.rs
+++ b/crates/kernel/src/vm/vm_call.rs
@@ -42,7 +42,7 @@ pub(crate) fn args_literal(args: &List) -> String {
 }
 
 /// The set of parameters for a scheduler-requested *resolved* verb method dispatch.
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct VerbExecutionRequest {
     /// The applicable permissions.
     pub permissions: Objid,

--- a/crates/kernel/src/vm/vm_execute.rs
+++ b/crates/kernel/src/vm/vm_execute.rs
@@ -30,9 +30,9 @@ use moor_values::model::{VerbInfo, WorldStateError};
 use moor_values::var::Error::{
     E_ARGS, E_DIV, E_INVARG, E_INVIND, E_MAXREC, E_RANGE, E_TYPE, E_VARNF,
 };
-use moor_values::var::Objid;
 use moor_values::var::Variant;
 use moor_values::var::{v_bool, v_empty_list, v_err, v_int, v_list, v_none, v_obj, v_objid, Var};
+use moor_values::var::{v_float, Objid};
 use moor_values::var::{v_listv, Error};
 
 use crate::vm::activation::{Activation, HandlerType};
@@ -40,7 +40,7 @@ use crate::vm::vm_unwind::{FinallyReason, UncaughtException};
 use crate::vm::{VMExecState, VM};
 
 /// The set of parameters for a VM-requested fork.
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Fork {
     /// The player. This is in the activation as well, but it's nicer to have it up here and
     /// explicit
@@ -67,7 +67,7 @@ pub struct VmExecParams {
     pub scheduler_sender: Sender<(TaskId, SchedulerControlMsg)>,
     pub max_stack_depth: usize,
 }
-#[derive(Eq, PartialEq, Debug, Clone)]
+#[derive(PartialEq, Debug, Clone)]
 pub enum ExecutionResult {
     /// Execution of this call stack is complete.
     Complete(Var),
@@ -329,6 +329,9 @@ impl VM {
                 }
                 Op::ImmBigInt(val) => {
                     f.push(v_int(*val));
+                }
+                Op::ImmFloat(val) => {
+                    f.push(v_float(*val));
                 }
                 Op::ImmInt(val) => {
                     f.push(v_int(*val as i64));

--- a/crates/values/src/var/list.rs
+++ b/crates/values/src/var/list.rs
@@ -12,7 +12,6 @@
 // this program. If not, see <https://www.gnu.org/licenses/>.
 //
 
-
 use std::fmt::{Display, Formatter, Result as FmtResult};
 use std::hash::{Hash, Hasher};
 


### PR DESCRIPTION
These counts weren't necessary, because they can be derived from the content of the opcode itself.