### PR TITLE
Major refactoring of Scheduler/Task

### DIFF
--- a/crates/kernel/src/builtins/bf_server.rs
+++ b/crates/kernel/src/builtins/bf_server.rs
@@ -71,7 +71,6 @@ fn bf_notify(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
         .map_err(world_state_bf_err)?;
 
     let event = NarrativeEvent::notify_text(bf_args.exec_state.caller(), msg.to_string());
-
     bf_args
         .scheduler_sender
         .send((
@@ -81,7 +80,7 @@ fn bf_notify(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
                 event,
             },
         ))
-        .expect("scheduler is not listening");
+        .ok();
 
     // MOO docs say this should return none, but in reality it returns 1?
     Ok(Ret(v_int(1)))
@@ -444,7 +443,7 @@ fn bf_queued_tasks(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
         .scheduler_sender
         .send((
             bf_args.exec_state.task_id,
-            SchedulerControlMsg::DescribeOtherTasks(send),
+            SchedulerControlMsg::RequestQueuedTasks(send),
         ))
         .expect("scheduler is not listening");
     let tasks = receive.recv().expect("scheduler is not listening");

--- a/crates/kernel/src/builtins/bf_server.rs
+++ b/crates/kernel/src/builtins/bf_server.rs
@@ -80,7 +80,7 @@ fn bf_notify(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
                 event,
             },
         ))
-        .ok();
+        .expect("Unable to contact scheduler for Notify");
 
     // MOO docs say this should return none, but in reality it returns 1?
     Ok(Ret(v_int(1)))

--- a/crates/kernel/src/tasks/mod.rs
+++ b/crates/kernel/src/tasks/mod.rs
@@ -14,9 +14,6 @@
 
 use crate::tasks::scheduler::TaskResult;
 use moor_values::var::{List, Objid};
-use std::cell::Cell;
-use std::marker::PhantomData;
-use std::sync::MutexGuard;
 use std::time::SystemTime;
 
 pub mod command_parse;
@@ -41,9 +38,6 @@ impl TaskHandle {
         self.1
     }
 }
-
-pub(crate) type PhantomUnsync = PhantomData<Cell<()>>;
-pub(crate) type PhantomUnsend = PhantomData<MutexGuard<'static, ()>>;
 
 /// The minimum set of information needed to make a *resolution* call for a verb.
 #[derive(Debug, Clone, Eq, PartialEq)]

--- a/crates/kernel/src/tasks/task.rs
+++ b/crates/kernel/src/tasks/task.rs
@@ -27,7 +27,7 @@ use crossbeam_channel::Sender;
 
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
-use std::time::{Duration, Instant, SystemTime};
+use std::time::{Duration, Instant};
 
 use tracing::{error, trace, warn};
 
@@ -55,11 +55,6 @@ pub struct Task {
     pub(crate) task_id: TaskId,
     /// What I was asked to do.
     pub(crate) task_start: Arc<TaskStart>,
-    /// When this task will begin execution.
-    /// For currently execution tasks this is when the task actually began running.
-    /// For tasks in suspension, this is when they will wake up.
-    /// If the task is in indefinite suspension, this is None.
-    pub(crate) scheduled_start_time: Option<SystemTime>,
     /// The player on behalf of whom this task is running. Who owns this task.
     pub(crate) player: Objid,
     /// The permissions of the task -- the object on behalf of which all permissions are evaluated.
@@ -162,7 +157,6 @@ impl Task {
             task_id,
             player,
             task_start,
-            scheduled_start_time: None,
             vm_host,
             perms,
             kill_switch,
@@ -272,7 +266,6 @@ impl Task {
                     .start_fork(self.task_id, fork_request, *suspended);
             }
             TaskStart::StartEval { player, program } => {
-                self.scheduled_start_time = None;
                 self.vm_host
                     .start_eval(self.task_id, *player, program.clone(), world_state);
             }

--- a/crates/kernel/src/tasks/task.rs
+++ b/crates/kernel/src/tasks/task.rs
@@ -767,7 +767,6 @@ mod tests {
         // Now we can simulate resumption...
         resume_task.vm_host.resume_execution(v_int(0));
 
-        // Now we can simulate resumption...
         let tx = db.new_world_state().unwrap();
         Task::run_task_loop(resume_task, control_sender, tx);
         let (task_id, msg) = control_receiver.recv().unwrap();

--- a/crates/kernel/src/vm/exec_state.rs
+++ b/crates/kernel/src/vm/exec_state.rs
@@ -12,8 +12,9 @@
 // this program. If not, see <https://www.gnu.org/licenses/>.
 //
 
-use crate::tasks::{PhantomUnsend, PhantomUnsync, TaskId};
+use crate::tasks::TaskId;
 use crate::vm::activation::{Activation, Caller};
+use daumtils::PhantomUnsync;
 use moor_values::var::Objid;
 use moor_values::var::Var;
 use moor_values::NOTHING;
@@ -41,7 +42,6 @@ pub struct VMExecState {
     /// The amount of time the task is allowed to run.
     pub(crate) maximum_time: Option<Duration>,
 
-    unsend: PhantomUnsend,
     unsync: PhantomUnsync,
 }
 
@@ -55,7 +55,6 @@ impl VMExecState {
             max_ticks,
             tick_slice: 0,
             maximum_time: None,
-            unsend: Default::default(),
             unsync: Default::default(),
         }
     }

--- a/crates/kernel/src/vm/vm_call.rs
+++ b/crates/kernel/src/vm/vm_call.rs
@@ -13,7 +13,7 @@
 //
 
 use std::sync::Arc;
-use tracing::{debug, trace};
+use tracing::trace;
 
 use moor_values::model::WorldState;
 use moor_values::model::WorldStateError;
@@ -247,7 +247,7 @@ impl VM {
         }
         let bf = self.builtins[bf_func_num].clone();
 
-        debug!(
+        trace!(
             "Calling builtin: {}({}) caller_perms: {}",
             BUILTIN_DESCRIPTORS[bf_func_num].name,
             args_literal(&args),


### PR DESCRIPTION
**Sorry this one is going to be hard to read as any kind of diff. If you're worried, I recommend just reading the whole of scheduler.rs and task.rs. **

Highlights:
  * Suspended tasks no longer hog a thread and idle. Instead their thread ends and they are moved into a suspended vector inside the scheduler itself.
  * Tasks that start in a delayed state (e.g. forks) now no longer use a thread with a manual delay. Instead they begin their life in suspended state and are picked up by the scheduler tick.
  * Gut the remainder of the complicated dispatch logic that was leftover from the old async/tokio version of this code. Intermediate result objects (which used to be processed in batch) are gone, and actions are immediately acted on. This should be a lot easier to read now.

I believe this paves the way for a more testable, robust future.