### PR TITLE
fix(telnet-host): properly crash; crash fails tests

### DIFF
--- a/crates/kernel/testsuite/moot_suite.rs
+++ b/crates/kernel/testsuite/moot_suite.rs
@@ -132,6 +132,7 @@ fn test(db: Arc<dyn Database + Send + Sync>, path: &Path) {
     execute_moot_test(
         SchedulerMootRunner::new(scheduler.clone(), Arc::new(NoopClientSession::new())),
         path,
+        || Ok(()),
     );
 
     scheduler

--- a/crates/telnet-host/src/main.rs
+++ b/crates/telnet-host/src/main.rs
@@ -86,7 +86,8 @@ async fn main() -> Result<(), eyre::Error> {
 
     info!("Host started.");
     select! {
-        _ = listen_loop => {
+        msg = listen_loop => {
+            msg?;
             info!("ZMQ client loop exited, stopping...");
         }
         _ = hup_signal.recv() => {


### PR DESCRIPTION
# Setup

In one terminal, start `moor-telnet-host` and leave it running:

```console
[abesto@keyrit-desktop moor]$ cargo run -p moor-telnet-host
```

# Before

Attempting to start `moor-telnet-host` results in the new `moor-telnet-host` exiting cleanly with status 0:

```console
[abesto@keyrit-desktop moor]$ cargo run -p moor-telnet-host
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.10s
     Running `target/debug/moor-telnet-host`
2024-06-26T22:15:26.478132Z  INFO main moor_telnet_host: crates/telnet-host/src/main.rs:87: Host started.
2024-06-26T22:15:26.478236Z  INFO main moor_telnet_host: crates/telnet-host/src/main.rs:90: ZMQ client loop exited, stopping...
2024-06-26T22:15:26.478274Z  INFO main moor_telnet_host: crates/telnet-host/src/main.rs:99: Done.
[abesto@keyrit-desktop moor]$ echo $?
0
```

As a side-effect, tests can get *very* confused - they can end up talking to the wrong telnet host / daemon / MOO server.

# After

`moor-telnet-host` crashes correctly:

```console
[abesto@keyrit-desktop moor]$ cargo run -p moor-telnet-host
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.09s
     Running `target/debug/moor-telnet-host`
2024-06-26T22:16:54.662057Z  INFO main moor_telnet_host: crates/telnet-host/src/main.rs:87: Host started.
Error: 
   0: Address already in use (os error 98)

Location:
   crates/telnet-host/src/telnet.rs:339

Backtrace omitted. Run with RUST_BACKTRACE=1 environment variable to display it.
Run with RUST_BACKTRACE=full to include source snippets.
```

Networked tests notice this, and act accordingly:

```console
[abesto@keyrit-desktop moor]$ cargo test -p moor-telnet-host test_suspend_read_notify
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.09s
     Running unittests src/main.rs (target/debug/deps/moor_telnet_host-edc79f55e714fe1e)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running tests/integration_test.rs (target/debug/deps/integration_test-f74627a034bcf313)

running 1 test
test test_suspend_read_notify ... FAILED

failures:

---- test_suspend_read_notify stdout ----
[daemon]: 2024-06-26T22:18:10.407089Z  INFO main moor_daemon: crates/daemon/src/main.rs:230: Daemon starting...
Test definition: /home/abesto/moor/crates/telnet-host/tests/moot/suspend_read_notify.moot
51038 >> connect #3
[telnet-host]: 2024-06-26T22:18:10.511314Z  INFO main moor_telnet_host: crates/telnet-host/src/main.rs:87: Host started.
[telnet-host]: Error: 
[telnet-host]:    0: Address already in use (os error 98)
[telnet-host]: 
[telnet-host]: Location:
[telnet-host]:    crates/telnet-host/src/telnet.rs:339
[telnet-host]: 
[telnet-host]: Backtrace omitted. Run with RUST_BACKTRACE=1 environment variable to display it.
[telnet-host]: Run with RUST_BACKTRACE=full to include source snippets.
[daemon]: 2024-06-26T22:18:10.524272Z  INFO main moor_daemon: crates/daemon/src/main.rs:235: Opened database path="test.db"
--- %< ---
51038 << *** Connected ***
51038 >> ; return 200; "moot-line:1"; "TelnetMootRunner::eval";
51038 << 200
thread 'test_suspend_read_notify' panicked at /home/abesto/moor/crates/moot/src/lib.rs:503:33:
Invalid state before processing line 2: Unexpected exit: telnet-host: Some(ExitStatus(unix_wait_status(256)))

Location:
    crates/moot/src/lib.rs:334:17
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
Killing telnet-host (pid=580834)
Killing daemon (pid=580824)


failures:
    test_suspend_read_notify

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 1 filtered out; finished in 0.48s

error: test failed, to rerun pass `-p moor-telnet-host --test integration_test`
```