### PR TITLE
Make the integration network hermetic

### DIFF
--- a/crates/daemon/src/rpc_server.rs
+++ b/crates/daemon/src/rpc_server.rs
@@ -89,6 +89,8 @@ impl RpcServer {
             "Creating new RPC server; with {} ZMQ IO threads...",
             zmq_context.get_io_threads().unwrap()
         );
+
+        // The socket for publishing narrative events.
         let publish = zmq_context
             .socket(SocketType::PUB)
             .expect("Unable to create ZMQ PUB socket");
@@ -1088,8 +1090,7 @@ pub(crate) fn zmq_loop(
             t_rpc_server.ping_pong().expect("Unable to play ping-pong");
         })?;
 
-    // We need to bind a generic publisher to the narrative endpoint, so that subsequent sessions
-    // are visible...
+    // Listen on the RPC socket for incoming requests, so that we can reply.
     let rpc_socket = zmq_ctx.socket(zmq::REP)?;
     rpc_socket.bind(&rpc_endpoint)?;
 

--- a/crates/moot/src/lib.rs
+++ b/crates/moot/src/lib.rs
@@ -421,7 +421,7 @@ impl TelnetMootRunner {
                     );
                     return client;
                 } else if start.elapsed() > Duration::from_secs(5) {
-                    panic!("Failed to connect to daemon");
+                    panic!("Failed to connect to server @ {}", self.port);
                 } else {
                     std::thread::sleep(Duration::from_millis(10));
                 }

--- a/crates/telnet-host/src/main.rs
+++ b/crates/telnet-host/src/main.rs
@@ -84,7 +84,7 @@ async fn main() -> Result<(), eyre::Error> {
         args.narrative_server.as_str(),
     );
 
-    info!("Host started.");
+    info!("Host started, listening @ {}...", args.telnet_address);
     select! {
         msg = listen_loop => {
             msg?;

--- a/crates/telnet-host/src/telnet.rs
+++ b/crates/telnet-host/src/telnet.rs
@@ -353,7 +353,7 @@ pub async fn telnet_listen_loop(
                 "Accepted connection"
             );
 
-            let rcp_request_sock = request(&zmq_ctx)
+            let rpc_request_sock = request(&zmq_ctx)
                 .set_rcvtimeo(100)
                 .set_sndtimeo(100)
                 .connect(rpc_address.as_str())
@@ -362,7 +362,7 @@ pub async fn telnet_listen_loop(
             // And let the RPC server know we're here, and it should start sending events on the
             // narrative subscription.
             debug!(rpc_address, "Contacting RPC server to establish connection");
-            let mut rpc_client = RpcSendClient::new(rcp_request_sock);
+            let mut rpc_client = RpcSendClient::new(rpc_request_sock);
 
             let (token, connection_oid) = match rpc_client
                 .make_rpc_call(client_id, ConnectionEstablish(peer_addr.to_string()))


### PR DESCRIPTION
For https://github.com/rdaum/moor/issues/342

* Switch to zmq IPC sockets for daemon/host with a UUID in the path to avoid conflict
* Dynamically choose the telnet listening port based on what's available

