### PR TITLE
Default to ZMQ IPC sockets for RPC connections

### DIFF
--- a/crates/console-host/src/main.rs
+++ b/crates/console-host/src/main.rs
@@ -39,7 +39,7 @@ struct Args {
         long,
         value_name = "rpc-server",
         help = "RPC server address",
-        default_value = "tcp://0.0.0.0:7899"
+        default_value = "ipc:///tmp/moor_rpc.sock"
     )]
     rpc_server: String,
 
@@ -47,7 +47,7 @@ struct Args {
         long,
         value_name = "narrative-server",
         help = "Narrative server address",
-        default_value = "tcp://0.0.0.0:7898"
+        default_value = "ipc:///tmp/moor_narrative.sock"
     )]
     narrative_server: String,
 

--- a/crates/daemon/src/main.rs
+++ b/crates/daemon/src/main.rs
@@ -88,7 +88,7 @@ struct Args {
         long,
         value_name = "rpc-listen",
         help = "RPC server address",
-        default_value = "tcp://0.0.0.0:7899"
+        default_value = "ipc:///tmp/moor_rpc.sock"
     )]
     rpc_listen: String,
 
@@ -96,7 +96,7 @@ struct Args {
         long,
         value_name = "narrative-listen",
         help = "Narrative server address",
-        default_value = "tcp://0.0.0.0:7898"
+        default_value = "ipc:///tmp/moor_narrative.sock"
     )]
     narrative_listen: String,
 

--- a/crates/telnet-host/src/main.rs
+++ b/crates/telnet-host/src/main.rs
@@ -36,7 +36,7 @@ struct Args {
         long,
         value_name = "rpc-server",
         help = "RPC server address",
-        default_value = "tcp://0.0.0.0:7899"
+        default_value = "ipc:///tmp/moor_rpc.sock"
     )]
     rpc_server: String,
 
@@ -44,7 +44,7 @@ struct Args {
         long,
         value_name = "narrative-server",
         help = "Narrative server address",
-        default_value = "tcp://0.0.0.0:7898"
+        default_value = "ipc:///tmp/moor_narrative.sock"
     )]
     narrative_server: String,
 

--- a/crates/web-host/src/main.rs
+++ b/crates/web-host/src/main.rs
@@ -41,7 +41,7 @@ struct Args {
         long,
         value_name = "rpc-server",
         help = "RPC server address",
-        default_value = "tcp://0.0.0.0:7899"
+        default_value = "ipc:///tmp/moor_rpc.sock"
     )]
     rpc_server: String,
 
@@ -49,7 +49,7 @@ struct Args {
         long,
         value_name = "narrative-server",
         help = "Narrative server address",
-        default_value = "tcp://0.0.0.0:7898"
+        default_value = "ipc:///tmp/moor_narrative.sock"
     )]
     narrative_server: String,
 }


### PR DESCRIPTION
Switches the default binding for the ZMQ connections to use ipc://

90% of the time we'll be running these things on the same host. The option is still there to use tcp:// if not.