### PR TITLE
Persistent tasks database implementation

### DIFF
--- a/crates/daemon/src/tasks_wt.rs
+++ b/crates/daemon/src/tasks_wt.rs
@@ -1,0 +1,461 @@
+// Copyright (C) 2024 Ryan Daum <ryan.daum@gmail.com>
+//
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free Software
+// Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program. If not, see <https://www.gnu.org/licenses/>.
+//
+
+//! An implementation of the TasksDb using Wiredtiger
+
+use moor_db_wiredtiger::{
+    Connection, CreateConfig, CursorConfig, DataSource, Datum, Error, Isolation, LogConfig,
+    OpenConfig, SessionConfig, SyncMethod, TransactionSync,
+};
+use moor_kernel::tasks::{TaskId, TasksDb, TasksDbError};
+use moor_kernel::SuspendedTask;
+use moor_values::BINCODE_CONFIG;
+use std::path::Path;
+use std::sync::Arc;
+use tracing::error;
+
+pub struct WiredTigerTasksDb {
+    connection: Arc<Connection>,
+    tasks_table: DataSource,
+    session_config: SessionConfig,
+}
+
+impl WiredTigerTasksDb {
+    pub fn open(path: Option<&Path>) -> (Self, bool) {
+        let tmpdir = match path {
+            Some(_path) => None,
+            None => {
+                let tmpdir = tempfile::tempdir().expect("Unable to create temporary directory");
+                Some(tmpdir)
+            }
+        };
+        let db_path = match path {
+            Some(path) => path,
+            None => {
+                let path = tmpdir.as_ref().unwrap().path();
+                path
+            }
+        };
+
+        let transient = path.is_none();
+        let mut options = OpenConfig::new()
+            .create(true)
+            .cache_size(1 << 30)
+            .cache_cursors(true)
+            .in_memory(transient);
+
+        if !transient {
+            std::fs::create_dir_all(db_path).expect("Failed to create database directory");
+            options = options
+                .log(LogConfig::new().enabled(true))
+                .transaction_sync(
+                    TransactionSync::new()
+                        .enabled(true)
+                        .method(SyncMethod::Fsync),
+                );
+        }
+        let connection = Connection::open(db_path, options).unwrap();
+        let session_config = SessionConfig::new().isolation(Isolation::Snapshot);
+        let tasks_table = DataSource::Table("tasks".to_string());
+
+        // Check for existence of tasks table, and if it's not there, create it.
+        let check_session = connection
+            .clone()
+            .open_session(session_config.clone())
+            .expect("Failed to open session");
+        let is_fresh = if check_session.open_cursor(&tasks_table, None).is_err() {
+            let config = CreateConfig::new().columns(&["task_id", "task"]);
+
+            check_session
+                .create(&tasks_table, Some(config))
+                .expect("Failed to create tasks table");
+            true
+        } else {
+            false
+        };
+
+        (
+            Self {
+                connection,
+                tasks_table,
+                session_config,
+            },
+            is_fresh,
+        )
+    }
+}
+
+impl TasksDb for WiredTigerTasksDb {
+    fn load_tasks(&self) -> Result<Vec<SuspendedTask>, TasksDbError> {
+        // Scan the entire tasks table, deserializing each record into a SuspendedTask
+        let session = self
+            .connection
+            .clone()
+            .open_session(self.session_config.clone())
+            .map_err(|e| {
+                error!("Failed to open session: {:?}", e);
+                TasksDbError::CouldNotLoadTasks
+            })?;
+
+        session.begin_transaction(None).unwrap();
+        let cursor = session
+            .open_cursor(&self.tasks_table, Some(CursorConfig::new().raw(true)))
+            .map_err(|e| {
+                error!("Failed to open cursor: {:?}", e);
+                TasksDbError::CouldNotLoadTasks
+            })?;
+
+        cursor.reset().map_err(|e| {
+            error!("Failed to reset cursor to start: {:?}", e);
+            TasksDbError::CouldNotLoadTasks
+        })?;
+
+        let mut tasks = vec![];
+        loop {
+            match cursor.next() {
+                Ok(_) => {}
+                Err(Error::NotFound) => {
+                    break;
+                }
+                Err(e) => {
+                    error!("Failed to advance cursor: {:?}", e);
+                    return Err(TasksDbError::CouldNotLoadTasks);
+                }
+            }
+
+            let Ok(task_id) = cursor.get_key() else {
+                return Ok(tasks);
+            };
+
+            let task_id = TaskId::from_le_bytes(task_id.as_slice().try_into().unwrap());
+
+            let Ok(task_bytes) = cursor.get_value() else {
+                return Err(TasksDbError::CouldNotLoadTasks);
+            };
+
+            let (task, _): (SuspendedTask, usize) =
+                bincode::decode_from_slice(task_bytes.as_slice(), *BINCODE_CONFIG)
+                    .map_err(|e| {
+                        error!("Failed to deserialize record: {:?}", e);
+                        TasksDbError::CouldNotLoadTasks
+                    })
+                    .expect("Failed to deserialize record");
+            if task_id != task.task.task_id {
+                panic!("Task ID mismatch: {:?} != {:?}", task_id, task.task.task_id);
+            }
+            tasks.push(task);
+        }
+        Ok(tasks)
+    }
+
+    fn save_task(&self, task: &SuspendedTask) -> Result<(), TasksDbError> {
+        let session = self
+            .connection
+            .clone()
+            .open_session(self.session_config.clone())
+            .map_err(|e| {
+                error!("Failed to open session: {:?}", e);
+                TasksDbError::CouldNotLoadTasks
+            })?;
+
+        session.begin_transaction(None).unwrap();
+        let cursor = session
+            .open_cursor(&self.tasks_table, Some(CursorConfig::new().raw(true)))
+            .map_err(|e| {
+                error!("Failed to open cursor: {:?}", e);
+                TasksDbError::CouldNotLoadTasks
+            })?;
+
+        let task_id = task.task.task_id.to_le_bytes();
+        let task_bytes = bincode::encode_to_vec(task, *BINCODE_CONFIG).map_err(|e| {
+            error!("Failed to serialize record: {:?}", e);
+            TasksDbError::CouldNotLoadTasks
+        })?;
+
+        cursor
+            .set_key(Datum::from_vec(task_id.to_vec()))
+            .map_err(|e| {
+                error!("Failed to set key: {:?}", e);
+                TasksDbError::CouldNotLoadTasks
+            })?;
+        cursor.set_value(Datum::from_vec(task_bytes)).map_err(|e| {
+            error!("Failed to set value: {:?}", e);
+            TasksDbError::CouldNotLoadTasks
+        })?;
+
+        cursor.insert().map_err(|e| {
+            error!("Failed to insert record: {:?}", e);
+            TasksDbError::CouldNotLoadTasks
+        })?;
+
+        session.commit().map_err(|e| {
+            error!("Failed to commit transaction: {:?}", e);
+            TasksDbError::CouldNotLoadTasks
+        })?;
+
+        Ok(())
+    }
+
+    fn delete_task(&self, task_id: TaskId) -> Result<(), TasksDbError> {
+        let session = self
+            .connection
+            .clone()
+            .open_session(self.session_config.clone())
+            .map_err(|e| {
+                error!("Failed to open session: {:?}", e);
+                TasksDbError::CouldNotLoadTasks
+            })?;
+
+        session.begin_transaction(None).unwrap();
+        let cursor = session
+            .open_cursor(&self.tasks_table, Some(CursorConfig::new().raw(true)))
+            .map_err(|e| {
+                error!("Failed to open cursor: {:?}", e);
+                TasksDbError::CouldNotLoadTasks
+            })?;
+
+        let task_id = task_id.to_le_bytes();
+
+        cursor
+            .set_key(Datum::from_vec(task_id.to_vec()))
+            .map_err(|e| {
+                error!("Failed to set key: {:?}", e);
+                TasksDbError::CouldNotLoadTasks
+            })?;
+        cursor.remove().map_err(|e| {
+            error!("Failed to remove record: {:?}", e);
+            TasksDbError::CouldNotLoadTasks
+        })?;
+
+        session.commit().map_err(|e| {
+            error!("Failed to commit transaction: {:?}", e);
+            TasksDbError::CouldNotLoadTasks
+        })?;
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::tasks_wt::WiredTigerTasksDb;
+    use moor_kernel::tasks::sessions::NoopClientSession;
+    use moor_kernel::tasks::{ServerOptions, TaskStart, TasksDb};
+    use moor_kernel::{SuspendedTask, Task, WakeCondition};
+    use moor_values::SYSTEM_OBJECT;
+    use std::sync::atomic::AtomicBool;
+    use std::sync::Arc;
+
+    // Verify creation of an empty DB, including creation of tables.
+    #[test]
+    fn open_reopen() {
+        let tmpdir = tempfile::tempdir().expect("Unable to create temporary directory");
+        let path = tmpdir.path();
+        {
+            let (db, is_fresh) = WiredTigerTasksDb::open(Some(path));
+            assert!(is_fresh);
+            let tasks = db.load_tasks().unwrap();
+            assert_eq!(tasks.len(), 0);
+        }
+        {
+            let (db, is_fresh) = WiredTigerTasksDb::open(Some(path));
+            assert!(!is_fresh);
+            let tasks = db.load_tasks().unwrap();
+            assert_eq!(tasks.len(), 0);
+        }
+    }
+
+    // Verify putting a single task into a fresh db, closing it and reopening it, and getting it out
+    #[test]
+    fn save_load() {
+        let task_id = 0;
+        let so = ServerOptions {
+            bg_seconds: 0,
+            bg_ticks: 0,
+            fg_seconds: 0,
+            fg_ticks: 0,
+            max_stack_depth: 0,
+        };
+
+        /*
+         perms: Objid,
+        server_options: &ServerOptions,
+        kill_switch: Arc<AtomicBool>,
+         */
+        let task = Task::new(
+            task_id,
+            SYSTEM_OBJECT,
+            Arc::new(TaskStart::StartEval {
+                player: SYSTEM_OBJECT,
+                program: Default::default(),
+            }),
+            SYSTEM_OBJECT,
+            &so,
+            Arc::new(AtomicBool::new(false)),
+        );
+
+        // Mock task...
+        let suspended = SuspendedTask {
+            wake_condition: WakeCondition::Never,
+            task,
+            session: Arc::new(NoopClientSession::new()),
+            result_sender: None,
+        };
+        let tmpdir = tempfile::tempdir().expect("Unable to create temporary directory");
+        let path = tmpdir.path();
+
+        {
+            let (db, is_fresh) = WiredTigerTasksDb::open(Some(path));
+            assert!(is_fresh);
+            db.save_task(&suspended).unwrap();
+            let tasks = db.load_tasks().unwrap();
+            assert_eq!(tasks.len(), 1);
+            assert_eq!(tasks[0].task.task_id, task_id);
+        }
+
+        {
+            let (db, is_fresh) = WiredTigerTasksDb::open(Some(path));
+            assert!(!is_fresh);
+            let tasks = db.load_tasks().unwrap();
+            assert_eq!(tasks.len(), 1);
+            assert_eq!(tasks[0].task.task_id, task_id);
+        }
+    }
+
+    // Create a series of tasks, save them, load them, and verify they are the same.
+    #[test]
+    fn save_load_multiple() {
+        let mut tasks = vec![];
+        for task_id in 0..50 {
+            let so = ServerOptions {
+                bg_seconds: 0,
+                bg_ticks: 0,
+                fg_seconds: 0,
+                fg_ticks: 0,
+                max_stack_depth: 0,
+            };
+
+            let task = Task::new(
+                task_id,
+                SYSTEM_OBJECT,
+                Arc::new(TaskStart::StartEval {
+                    player: SYSTEM_OBJECT,
+                    program: Default::default(),
+                }),
+                SYSTEM_OBJECT,
+                &so,
+                Arc::new(AtomicBool::new(false)),
+            );
+
+            // Mock task...
+            let suspended = SuspendedTask {
+                wake_condition: WakeCondition::Never,
+                task,
+                session: Arc::new(NoopClientSession::new()),
+                result_sender: None,
+            };
+            tasks.push(suspended);
+        }
+
+        // Write em
+        let tmpdir = tempfile::tempdir().expect("Unable to create temporary directory");
+        let path = tmpdir.path();
+        {
+            let (db, is_fresh) = WiredTigerTasksDb::open(Some(path));
+            assert!(is_fresh);
+            for task in tasks.iter() {
+                db.save_task(task).unwrap();
+            }
+        }
+
+        // Load em
+        let (db, is_fresh) = WiredTigerTasksDb::open(Some(path));
+        assert!(!is_fresh);
+        let loaded_tasks = db.load_tasks().unwrap();
+        assert_eq!(loaded_tasks.len(), tasks.len());
+        for (task, loaded_task) in tasks.iter().zip(loaded_tasks.iter()) {
+            assert_eq!(task.task.task_id, loaded_task.task.task_id);
+        }
+    }
+
+    // Create a series of tasks, save them, delete a few, and load verify the rest are there and
+    // the deleted are not.
+    #[test]
+    fn save_delete_load_multiple() {
+        let mut tasks = vec![];
+        for task_id in 0..50 {
+            let so = ServerOptions {
+                bg_seconds: 0,
+                bg_ticks: 0,
+                fg_seconds: 0,
+                fg_ticks: 0,
+                max_stack_depth: 0,
+            };
+
+            let task = Task::new(
+                task_id,
+                SYSTEM_OBJECT,
+                Arc::new(TaskStart::StartEval {
+                    player: SYSTEM_OBJECT,
+                    program: Default::default(),
+                }),
+                SYSTEM_OBJECT,
+                &so,
+                Arc::new(AtomicBool::new(false)),
+            );
+
+            // Mock task...
+            let suspended = SuspendedTask {
+                wake_condition: WakeCondition::Never,
+                task,
+                session: Arc::new(NoopClientSession::new()),
+                result_sender: None,
+            };
+            tasks.push(suspended);
+        }
+
+        // Write em
+        let tmpdir = tempfile::tempdir().expect("Unable to create temporary directory");
+        let path = tmpdir.path();
+        {
+            let (db, is_fresh) = WiredTigerTasksDb::open(Some(path));
+            assert!(is_fresh);
+            for task in tasks.iter() {
+                db.save_task(task).unwrap();
+            }
+        }
+
+        {
+            // Delete some
+            let (db, is_fresh) = WiredTigerTasksDb::open(Some(path));
+            assert!(!is_fresh);
+            for task_id in 0..50 {
+                if task_id % 2 == 0 {
+                    db.delete_task(task_id).unwrap();
+                }
+            }
+        }
+
+        // Load em
+        let (db, is_fresh) = WiredTigerTasksDb::open(Some(path));
+        assert!(!is_fresh);
+        let loaded_tasks = db.load_tasks().unwrap();
+        assert_eq!(loaded_tasks.len(), 25);
+
+        // Go through the loaded tasks and make sure the deleted ones are not there.
+        for task in loaded_tasks.iter() {
+            assert!(task.task.task_id % 2 != 0);
+        }
+    }
+}

--- a/crates/db-wiredtiger/src/bindings/session_config.rs
+++ b/crates/db-wiredtiger/src/bindings/session_config.rs
@@ -30,6 +30,7 @@ impl Isolation {
     }
 }
 
+#[derive(Clone)]
 pub struct SessionConfig {
     cache_cursors: Option<bool>,
     cache_max_wait_ms: Option<i64>,

--- a/crates/db-wiredtiger/src/lib.rs
+++ b/crates/db-wiredtiger/src/lib.rs
@@ -19,6 +19,8 @@ pub use crate::worldstate::wt_worldstate::WiredTigerDB;
 pub use crate::wtrel::rel_db::WiredTigerRelDb;
 pub use crate::wtrel::rel_transaction::WiredTigerRelTransaction;
 
+pub use crate::bindings::*;
+
 #[allow(dead_code, unused_imports)]
 mod bindings;
 mod worldstate;

--- a/crates/kernel/src/lib.rs
+++ b/crates/kernel/src/lib.rs
@@ -20,3 +20,6 @@ pub mod textdump;
 pub mod vm;
 
 pub use crate::tasks::scheduler_client::SchedulerClient;
+pub use crate::tasks::suspension::{SuspendedTask, WakeCondition};
+pub use crate::tasks::task::Task;
+pub use crate::tasks::{ServerOptions, TaskId};

--- a/crates/kernel/src/tasks/mod.rs
+++ b/crates/kernel/src/tasks/mod.rs
@@ -28,8 +28,8 @@ pub mod scheduler;
 pub mod sessions;
 
 pub(crate) mod scheduler_client;
-mod suspension;
-mod task;
+pub(crate) mod suspension;
+pub(crate) mod task;
 pub mod task_scheduler_client;
 mod tasks_db;
 pub mod vm_host;

--- a/crates/kernel/src/tasks/mod.rs
+++ b/crates/kernel/src/tasks/mod.rs
@@ -28,6 +28,7 @@ pub mod scheduler;
 pub mod sessions;
 
 pub(crate) mod scheduler_client;
+mod suspension;
 mod task;
 pub mod task_scheduler_client;
 mod tasks_db;

--- a/crates/kernel/src/tasks/mod.rs
+++ b/crates/kernel/src/tasks/mod.rs
@@ -289,7 +289,7 @@ pub mod scheduler_test_utils {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Encode, Decode)]
 pub enum TaskStart {
     /// The scheduler is telling the task to parse a command and execute whatever verbs are
     /// associated with it.

--- a/crates/kernel/src/tasks/mod.rs
+++ b/crates/kernel/src/tasks/mod.rs
@@ -136,17 +136,10 @@ pub mod vm_test_utils {
         let (scs_tx, _scs_rx) = crossbeam_channel::unbounded();
         let task_scheduler_client =
             crate::tasks::task_scheduler_client::TaskSchedulerClient::new(0, scs_tx);
-        let mut vm_host = VmHost::new(
-            0,
-            20,
-            90_000,
-            Duration::from_secs(5),
-            session.clone(),
-            task_scheduler_client.clone(),
-        );
+        let mut vm_host = VmHost::new(0, 20, 90_000, Duration::from_secs(5));
 
         let _vm_exec_params = VmExecParams {
-            task_scheduler_client,
+            task_scheduler_client: task_scheduler_client.clone(),
             max_stack_depth: 50,
         };
 
@@ -154,7 +147,12 @@ pub mod vm_test_utils {
 
         // Call repeatedly into exec until we ge either an error or Complete.
         loop {
-            match vm_host.exec_interpreter(0, world_state) {
+            match vm_host.exec_interpreter(
+                0,
+                world_state,
+                task_scheduler_client.clone(),
+                session.clone(),
+            ) {
                 VMHostResponse::ContinueOk => {
                     continue;
                 }

--- a/crates/kernel/src/tasks/scheduler.rs
+++ b/crates/kernel/src/tasks/scheduler.rs
@@ -51,7 +51,7 @@ use crate::matching::ws_match_env::WsMatchEnv;
 use crate::tasks::command_parse::ParseMatcher;
 use crate::tasks::scheduler::SchedulerError::VerbProgramFailed;
 use crate::tasks::scheduler_client::{SchedulerClient, SchedulerClientMsg};
-use crate::tasks::sessions::Session;
+use crate::tasks::sessions::{Session, SessionFactory};
 use crate::tasks::suspension::{SuspensionQ, WakeCondition};
 use crate::tasks::task::Task;
 use crate::tasks::task_scheduler_client::{TaskControlMsg, TaskSchedulerClient};
@@ -221,10 +221,10 @@ impl Scheduler {
     }
 
     /// Execute the scheduler loop, run from the server process.
-    #[instrument(skip(self))]
-    pub fn run(mut self) {
+    #[instrument(skip(self, bg_session_factory))]
+    pub fn run(mut self, bg_session_factory: Arc<dyn SessionFactory>) {
         // Rehydrate suspended tasks.
-        self.task_q.suspended.load_tasks();
+        self.task_q.suspended.load_tasks(bg_session_factory);
 
         self.running = true;
         info!("Starting scheduler loop");

--- a/crates/kernel/src/tasks/scheduler.rs
+++ b/crates/kernel/src/tasks/scheduler.rs
@@ -16,7 +16,7 @@ use std::collections::HashMap;
 use std::fs::File;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
-use std::time::{Duration, Instant, SystemTime};
+use std::time::{Duration, Instant};
 
 use bincode::{Decode, Encode};
 use crossbeam_channel::Sender;
@@ -52,12 +52,13 @@ use crate::tasks::command_parse::ParseMatcher;
 use crate::tasks::scheduler::SchedulerError::VerbProgramFailed;
 use crate::tasks::scheduler_client::{SchedulerClient, SchedulerClientMsg};
 use crate::tasks::sessions::Session;
+use crate::tasks::suspension::{SuspensionQ, WakeCondition};
 use crate::tasks::task::Task;
 use crate::tasks::task_scheduler_client::{TaskControlMsg, TaskSchedulerClient};
 use crate::tasks::tasks_db::TasksDb;
 use crate::tasks::{
-    ServerOptions, TaskDescription, TaskHandle, TaskId, TaskStart, DEFAULT_BG_SECONDS,
-    DEFAULT_BG_TICKS, DEFAULT_FG_SECONDS, DEFAULT_FG_TICKS, DEFAULT_MAX_STACK_DEPTH,
+    ServerOptions, TaskHandle, TaskId, TaskStart, DEFAULT_BG_SECONDS, DEFAULT_BG_TICKS,
+    DEFAULT_FG_SECONDS, DEFAULT_FG_TICKS, DEFAULT_MAX_STACK_DEPTH,
 };
 use crate::textdump::{make_textdump, TextdumpWriter};
 use crate::vm::Fork;
@@ -117,25 +118,6 @@ struct RunningTaskControl {
     result_sender: Option<oneshot::Sender<TaskResult>>,
 }
 
-/// State a suspended task sits in inside the `suspended` side of the task queue.
-/// When tasks are not running they are moved into these.
-pub struct SuspendedTask {
-    wake_condition: WakeCondition,
-    task: Task,
-    session: Arc<dyn Session>,
-    result_sender: Option<oneshot::Sender<TaskResult>>,
-}
-
-/// Possible conditions in which a suspended task can wake from suspension.
-enum WakeCondition {
-    /// This task will never wake up on its own, and must be manually woken with `bf_resume`
-    Never,
-    /// This task will wake up when the given time is reached.
-    Time(Instant),
-    /// This task will wake up when the given input request is fulfilled.
-    Input(Uuid),
-}
-
 /// The internal state of the task queue.
 struct TaskQ {
     /// Information about the active, running tasks. The actual `Task` is owned by the task thread
@@ -146,13 +128,6 @@ struct TaskQ {
     ///     Suspended foreground tasks that are either indefinitely suspended or will execute someday
     ///     Suspended tasks waiting for input from the player
     suspended: SuspensionQ,
-}
-
-/// Ties the local storage for suspended tasks in with a reference to the tasks DB, to allow for
-/// keeping them in sync.
-struct SuspensionQ {
-    tasks: HashMap<TaskId, SuspendedTask>,
-    tasks_database: Box<dyn TasksDb>,
 }
 
 /// Reasons a task might be aborted for a 'limit'
@@ -219,10 +194,7 @@ impl Scheduler {
     ) -> Self {
         let (task_control_sender, task_control_receiver) = crossbeam_channel::unbounded();
         let (scheduler_sender, scheduler_receiver) = crossbeam_channel::unbounded();
-        let suspension_q = SuspensionQ {
-            tasks: Default::default(),
-            tasks_database,
-        };
+        let suspension_q = SuspensionQ::new(tasks_database);
         let task_q = TaskQ {
             tasks: Default::default(),
             suspended: suspension_q,
@@ -1382,170 +1354,5 @@ impl TaskQ {
         }
         // Prune out non-background tasks for the player.
         self.suspended.prune_foreground_tasks(player);
-    }
-}
-
-impl SuspensionQ {
-    /// Load all tasks from the tasks database. Called on startup to reconstitute the task list
-    /// from the database.
-    fn load_tasks(&mut self) {
-        // LambdaMOO doesn't do anything special to filter out tasks that are too old, or tasks that
-        // are related to disconnected players, or anything like that.
-        // We'll just start them all up and let the scheduler handle them.
-        // This could in theory lead to a sudden glut of starting tasks firing up when the server
-        // restarts, but we'll just have to live with that for now.
-        let tasks = self
-            .tasks_database
-            .load_tasks()
-            .expect("Unable to reconstitute tasks from tasks database");
-        for task in tasks {
-            self.tasks.insert(task.task.task_id, task);
-        }
-    }
-
-    /// Add a task to the set of suspended tasks.
-    fn add_task(
-        &mut self,
-        wake_condition: WakeCondition,
-        task: Task,
-        session: Arc<dyn Session>,
-        result_sender: Option<oneshot::Sender<TaskResult>>,
-    ) {
-        let task_id = task.task_id;
-        let sr = SuspendedTask {
-            wake_condition,
-            task,
-            session,
-            result_sender,
-        };
-        if let Err(e) = self.tasks_database.save_task(&sr) {
-            error!(?e, "Could not save suspended task");
-        }
-        self.tasks.insert(task_id, sr);
-    }
-
-    /// Remove a task from the set of suspended tasks.
-    fn remove_task(&mut self, task_id: TaskId) -> Option<SuspendedTask> {
-        let task = self.tasks.remove(&task_id);
-        if task.is_some() {
-            if let Err(e) = self.tasks_database.delete_task(task_id) {
-                error!(?e, "Could not delete suspended task from tasks database");
-            }
-        }
-        task
-    }
-
-    /// Synchronize the suspended tasks with the tasks database. Called on shutdown.
-    fn save_tasks(&self) {
-        for (_, st) in self.tasks.iter() {
-            if let Err(e) = self.tasks_database.save_task(st) {
-                error!(?e, "Could not save suspended task");
-            }
-        }
-    }
-
-    /// Collect tasks that need to be woken up, pull them from our suspended list, and return them.
-    fn collect_wake_tasks(&mut self) -> Vec<SuspendedTask> {
-        let now = Instant::now();
-        let to_wake = self
-            .tasks
-            .iter()
-            .filter_map(move |(task_id, sr)| match &sr.wake_condition {
-                WakeCondition::Time(t) => (*t <= now).then_some(*task_id),
-                _ => None,
-            })
-            .collect::<Vec<_>>();
-        let mut tasks = vec![];
-        for task_id in to_wake {
-            let sr = self.tasks.remove(&task_id).unwrap();
-            tasks.push(sr);
-        }
-        tasks
-    }
-
-    /// Pull a task from the suspended list that is waiting for input, for the given player.
-    fn pull_task_for_input(
-        &mut self,
-        input_request_id: Uuid,
-        player: Objid,
-    ) -> Option<SuspendedTask> {
-        let (task_id, perms) = self.tasks.iter().find_map(|(task_id, sr)| {
-            if let WakeCondition::Input(request_id) = &sr.wake_condition {
-                if *request_id == input_request_id {
-                    Some((*task_id, sr.task.perms))
-                } else {
-                    None
-                }
-            } else {
-                None
-            }
-        })?;
-
-        // If the player doesn't match, we'll pretend we didn't even see it.
-        if perms != player {
-            warn!(
-                ?task_id,
-                ?input_request_id,
-                ?player,
-                "Task input request received for wrong player"
-            );
-            return None;
-        };
-
-        let sr = self.remove_task(task_id).expect("Corrupt task list");
-        Some(sr)
-    }
-
-    /// Get a nice friendly list of all tasks in suspension state.
-    fn tasks(&self) -> Vec<TaskDescription> {
-        let mut tasks = Vec::new();
-
-        // Suspended tasks.
-        for (_, sr) in self.tasks.iter() {
-            let start_time = match sr.wake_condition {
-                WakeCondition::Time(t) => {
-                    let distance_from_now = t.duration_since(Instant::now());
-                    Some(SystemTime::now() + distance_from_now)
-                }
-                _ => None,
-            };
-            tasks.push(TaskDescription {
-                task_id: sr.task.task_id,
-                start_time,
-                permissions: sr.task.perms,
-                verb_name: sr.task.vm_host.verb_name(),
-                verb_definer: sr.task.vm_host.verb_definer(),
-                line_number: sr.task.vm_host.line_number(),
-                this: sr.task.vm_host.this(),
-            });
-        }
-        tasks
-    }
-
-    /// Check if the task is suspended, and if so, return its permissions.
-    /// If `filter_input` is true, filter out WaitingInput tasks.
-    fn perms_check(&self, task_id: TaskId, filter_input: bool) -> Option<Objid> {
-        let sr = self.tasks.get(&task_id)?;
-        if filter_input {
-            if let WakeCondition::Input(_) = sr.wake_condition {
-                return None;
-            }
-        }
-        Some(sr.task.perms)
-    }
-
-    /// Remove all non-background tasks for the given player.
-    fn prune_foreground_tasks(&mut self, player: Objid) {
-        let to_remove = self
-            .tasks
-            .iter()
-            .filter_map(|(task_id, sr)| {
-                (!sr.task.task_start.is_background() && sr.task.player == player)
-                    .then_some(*task_id)
-            })
-            .collect::<Vec<_>>();
-        for task_id in to_remove {
-            self.remove_task(task_id);
-        }
     }
 }

--- a/crates/kernel/src/tasks/sessions.rs
+++ b/crates/kernel/src/tasks/sessions.rs
@@ -101,6 +101,14 @@ pub trait Session: Send + Sync {
     fn idle_seconds(&self, player: Objid) -> Result<f64, SessionError>;
 }
 
+/// A factory for creating background sessions, usually on task resumption on server restart.
+pub trait SessionFactory {
+    fn mk_background_session(
+        self: Arc<Self>,
+        player: Objid,
+    ) -> Result<Arc<dyn Session>, SessionError>;
+}
+
 #[derive(Debug, Error)]
 pub enum SessionError {
     #[error("No connection for player {0}")]

--- a/crates/kernel/src/tasks/suspension.rs
+++ b/crates/kernel/src/tasks/suspension.rs
@@ -1,0 +1,208 @@
+use crate::tasks::scheduler::TaskResult;
+use crate::tasks::sessions::Session;
+use crate::tasks::task::Task;
+use crate::tasks::{TaskDescription, TaskId, TasksDb};
+use moor_values::var::Objid;
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::{Instant, SystemTime};
+use tracing::{error, warn};
+use uuid::Uuid;
+
+/// State a suspended task sits in inside the `suspended` side of the task queue.
+/// When tasks are not running they are moved into these.
+pub struct SuspendedTask {
+    wake_condition: WakeCondition,
+    pub(crate) task: Task,
+    pub(crate) session: Arc<dyn Session>,
+    pub(crate) result_sender: Option<oneshot::Sender<TaskResult>>,
+}
+
+/// Possible conditions in which a suspended task can wake from suspension.
+pub enum WakeCondition {
+    /// This task will never wake up on its own, and must be manually woken with `bf_resume`
+    Never,
+    /// This task will wake up when the given time is reached.
+    Time(Instant),
+    /// This task will wake up when the given input request is fulfilled.
+    Input(Uuid),
+}
+
+/// Ties the local storage for suspended tasks in with a reference to the tasks DB, to allow for
+/// keeping them in sync.
+pub struct SuspensionQ {
+    tasks: HashMap<TaskId, SuspendedTask>,
+    tasks_database: Box<dyn TasksDb>,
+}
+
+impl SuspensionQ {
+    pub fn new(tasks_database: Box<dyn TasksDb>) -> Self {
+        Self {
+            tasks: Default::default(),
+            tasks_database,
+        }
+    }
+
+    /// Load all tasks from the tasks database. Called on startup to reconstitute the task list
+    /// from the database.
+    pub(crate) fn load_tasks(&mut self) {
+        // LambdaMOO doesn't do anything special to filter out tasks that are too old, or tasks that
+        // are related to disconnected players, or anything like that.
+        // We'll just start them all up and let the scheduler handle them.
+        // This could in theory lead to a sudden glut of starting tasks firing up when the server
+        // restarts, but we'll just have to live with that for now.
+        let tasks = self
+            .tasks_database
+            .load_tasks()
+            .expect("Unable to reconstitute tasks from tasks database");
+        for task in tasks {
+            self.tasks.insert(task.task.task_id, task);
+        }
+    }
+
+    /// Add a task to the set of suspended tasks.
+    pub(crate) fn add_task(
+        &mut self,
+        wake_condition: WakeCondition,
+        task: Task,
+        session: Arc<dyn Session>,
+        result_sender: Option<oneshot::Sender<TaskResult>>,
+    ) {
+        let task_id = task.task_id;
+        let sr = SuspendedTask {
+            wake_condition,
+            task,
+            session,
+            result_sender,
+        };
+        if let Err(e) = self.tasks_database.save_task(&sr) {
+            error!(?e, "Could not save suspended task");
+        }
+        self.tasks.insert(task_id, sr);
+    }
+
+    /// Remove a task from the set of suspended tasks.
+    pub(crate) fn remove_task(&mut self, task_id: TaskId) -> Option<SuspendedTask> {
+        let task = self.tasks.remove(&task_id);
+        if task.is_some() {
+            if let Err(e) = self.tasks_database.delete_task(task_id) {
+                error!(?e, "Could not delete suspended task from tasks database");
+            }
+        }
+        task
+    }
+
+    /// Synchronize the suspended tasks with the tasks database. Called on shutdown.
+    pub(crate) fn save_tasks(&self) {
+        for (_, st) in self.tasks.iter() {
+            if let Err(e) = self.tasks_database.save_task(st) {
+                error!(?e, "Could not save suspended task");
+            }
+        }
+    }
+
+    /// Collect tasks that need to be woken up, pull them from our suspended list, and return them.
+    pub(crate) fn collect_wake_tasks(&mut self) -> Vec<SuspendedTask> {
+        let now = Instant::now();
+        let to_wake = self
+            .tasks
+            .iter()
+            .filter_map(move |(task_id, sr)| match &sr.wake_condition {
+                WakeCondition::Time(t) => (*t <= now).then_some(*task_id),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        let mut tasks = vec![];
+        for task_id in to_wake {
+            let sr = self.tasks.remove(&task_id).unwrap();
+            tasks.push(sr);
+        }
+        tasks
+    }
+
+    /// Pull a task from the suspended list that is waiting for input, for the given player.
+    pub(crate) fn pull_task_for_input(
+        &mut self,
+        input_request_id: Uuid,
+        player: Objid,
+    ) -> Option<SuspendedTask> {
+        let (task_id, perms) = self.tasks.iter().find_map(|(task_id, sr)| {
+            if let WakeCondition::Input(request_id) = &sr.wake_condition {
+                if *request_id == input_request_id {
+                    Some((*task_id, sr.task.perms))
+                } else {
+                    None
+                }
+            } else {
+                None
+            }
+        })?;
+
+        // If the player doesn't match, we'll pretend we didn't even see it.
+        if perms != player {
+            warn!(
+                ?task_id,
+                ?input_request_id,
+                ?player,
+                "Task input request received for wrong player"
+            );
+            return None;
+        };
+
+        let sr = self.remove_task(task_id).expect("Corrupt task list");
+        Some(sr)
+    }
+
+    /// Get a nice friendly list of all tasks in suspension state.
+    pub(crate) fn tasks(&self) -> Vec<TaskDescription> {
+        let mut tasks = Vec::new();
+
+        // Suspended tasks.
+        for (_, sr) in self.tasks.iter() {
+            let start_time = match sr.wake_condition {
+                WakeCondition::Time(t) => {
+                    let distance_from_now = t.duration_since(Instant::now());
+                    Some(SystemTime::now() + distance_from_now)
+                }
+                _ => None,
+            };
+            tasks.push(TaskDescription {
+                task_id: sr.task.task_id,
+                start_time,
+                permissions: sr.task.perms,
+                verb_name: sr.task.vm_host.verb_name(),
+                verb_definer: sr.task.vm_host.verb_definer(),
+                line_number: sr.task.vm_host.line_number(),
+                this: sr.task.vm_host.this(),
+            });
+        }
+        tasks
+    }
+
+    /// Check if the task is suspended, and if so, return its permissions.
+    /// If `filter_input` is true, filter out WaitingInput tasks.
+    pub(crate) fn perms_check(&self, task_id: TaskId, filter_input: bool) -> Option<Objid> {
+        let sr = self.tasks.get(&task_id)?;
+        if filter_input {
+            if let WakeCondition::Input(_) = sr.wake_condition {
+                return None;
+            }
+        }
+        Some(sr.task.perms)
+    }
+
+    /// Remove all non-background tasks for the given player.
+    pub(crate) fn prune_foreground_tasks(&mut self, player: Objid) {
+        let to_remove = self
+            .tasks
+            .iter()
+            .filter_map(|(task_id, sr)| {
+                (!sr.task.task_start.is_background() && sr.task.player == player)
+                    .then_some(*task_id)
+            })
+            .collect::<Vec<_>>();
+        for task_id in to_remove {
+            self.remove_task(task_id);
+        }
+    }
+}

--- a/crates/kernel/src/tasks/suspension.rs
+++ b/crates/kernel/src/tasks/suspension.rs
@@ -50,17 +50,17 @@ pub enum WakeCondition {
 #[repr(u8)]
 #[derive(Encode, Decode, Debug)]
 pub enum WakeConditionType {
-    NEVER = 0,
-    TIME = 1,
-    INPUT = 2,
+    Never = 0,
+    Time = 1,
+    Input = 2,
 }
 
 impl WakeCondition {
     pub fn condition_type(&self) -> WakeConditionType {
         match self {
-            WakeCondition::Never => WakeConditionType::NEVER,
-            WakeCondition::Time(_) => WakeConditionType::TIME,
-            WakeCondition::Input(_) => WakeConditionType::INPUT,
+            WakeCondition::Never => WakeConditionType::Never,
+            WakeCondition::Time(_) => WakeConditionType::Time,
+            WakeCondition::Input(_) => WakeConditionType::Input,
         }
     }
 }
@@ -316,13 +316,13 @@ impl Decode for WakeCondition {
     fn decode<D: Decoder>(decoder: &mut D) -> Result<Self, DecodeError> {
         let type_code: WakeConditionType = Decode::decode(decoder)?;
         match type_code {
-            WakeConditionType::NEVER => Ok(WakeCondition::Never),
-            WakeConditionType::TIME => {
+            WakeConditionType::Never => Ok(WakeCondition::Never),
+            WakeConditionType::Time => {
                 let time_since_epoch_micros: u128 = Decode::decode(decoder)?;
                 let wake_time = from_epoch_micros_to_instant(time_since_epoch_micros);
                 Ok(WakeCondition::Time(wake_time))
             }
-            WakeConditionType::INPUT => {
+            WakeConditionType::Input => {
                 let uuid = Uuid::from_u128(Decode::decode(decoder)?);
                 Ok(WakeCondition::Input(uuid))
             }
@@ -334,13 +334,13 @@ impl<'de> BorrowDecode<'de> for WakeCondition {
     fn borrow_decode<D: BorrowDecoder<'de>>(decoder: &mut D) -> Result<Self, DecodeError> {
         let type_code: WakeConditionType = Decode::decode(decoder)?;
         match type_code {
-            WakeConditionType::NEVER => Ok(WakeCondition::Never),
-            WakeConditionType::TIME => {
+            WakeConditionType::Never => Ok(WakeCondition::Never),
+            WakeConditionType::Time => {
                 let time_since_epoch_micros: u128 = Decode::decode(decoder)?;
                 let wake_time = from_epoch_micros_to_instant(time_since_epoch_micros);
                 Ok(WakeCondition::Time(wake_time))
             }
-            WakeConditionType::INPUT => {
+            WakeConditionType::Input => {
                 let uuid = Uuid::from_u128(Decode::decode(decoder)?);
                 Ok(WakeCondition::Input(uuid))
             }

--- a/crates/kernel/src/tasks/task.rs
+++ b/crates/kernel/src/tasks/task.rs
@@ -62,7 +62,7 @@ lazy_static! {
 #[derive(Debug)]
 pub struct Task {
     /// My unique task id.
-    pub(crate) task_id: TaskId,
+    pub task_id: TaskId,
     /// What I was asked to do.
     pub(crate) task_start: Arc<TaskStart>,
     /// The player on behalf of whom this task is running. Who owns this task.

--- a/crates/kernel/src/tasks/tasks_db.rs
+++ b/crates/kernel/src/tasks/tasks_db.rs
@@ -12,7 +12,7 @@
 // this program. If not, see <https://www.gnu.org/licenses/>.
 //
 
-use crate::tasks::scheduler::SuspendedTask;
+use crate::tasks::suspension::SuspendedTask;
 use crate::tasks::TaskId;
 
 #[derive(Debug, thiserror::Error)]

--- a/crates/kernel/src/tasks/tasks_db.rs
+++ b/crates/kernel/src/tasks/tasks_db.rs
@@ -27,6 +27,7 @@ pub trait TasksDb: Send {
     fn load_tasks(&self) -> Result<Vec<SuspendedTask>, TasksDbError>;
     fn save_task(&self, task: &SuspendedTask) -> Result<(), TasksDbError>;
     fn delete_task(&self, task_id: TaskId) -> Result<(), TasksDbError>;
+    fn delete_all_tasks(&self) -> Result<(), TasksDbError>;
 }
 
 pub struct NoopTasksDb {}
@@ -41,6 +42,10 @@ impl TasksDb for NoopTasksDb {
     }
 
     fn delete_task(&self, _task_id: TaskId) -> Result<(), TasksDbError> {
+        Ok(())
+    }
+
+    fn delete_all_tasks(&self) -> Result<(), TasksDbError> {
         Ok(())
     }
 }

--- a/crates/kernel/src/vm/exec_state.rs
+++ b/crates/kernel/src/vm/exec_state.rs
@@ -14,6 +14,7 @@
 
 use crate::tasks::TaskId;
 use crate::vm::activation::{Activation, Caller};
+use bincode::{Decode, Encode};
 use daumtils::PhantomUnsync;
 use moor_values::var::Objid;
 use moor_values::var::Var;
@@ -24,6 +25,7 @@ use std::time::{Duration, SystemTime};
 /// The actual "VM" remains stateless and could be potentially re-used for multiple tasks,
 /// and swapped out at each level of the activation stack for different runtimes.
 /// e.g. a MOO VM, a WASM VM, a JS VM, etc. but all having access to the same shared state.
+#[derive(Encode, Decode)]
 pub struct VMExecState {
     /// The task ID of the task that for current stack of activations.
     pub(crate) task_id: TaskId,

--- a/crates/kernel/src/vm/vm_execute.rs
+++ b/crates/kernel/src/vm/vm_execute.rs
@@ -12,6 +12,7 @@
 // this program. If not, see <https://www.gnu.org/licenses/>.
 //
 
+use bincode::{Decode, Encode};
 use std::sync::Arc;
 use std::time::Duration;
 use tracing::debug;
@@ -40,7 +41,7 @@ use crate::vm::vm_unwind::{FinallyReason, UncaughtException};
 use crate::vm::{VMExecState, VM};
 
 /// The set of parameters for a VM-requested fork.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Encode, Decode)]
 pub struct Fork {
     /// The player. This is in the activation as well, but it's nicer to have it up here and
     /// explicit

--- a/crates/values/src/model/verb_info.rs
+++ b/crates/values/src/model/verb_info.rs
@@ -15,6 +15,10 @@
 use crate::encode::{DecodingError, EncodingError};
 use crate::model::verbdef::VerbDef;
 use crate::AsByteBuffer;
+use bincode::de::{BorrowDecoder, Decoder};
+use bincode::enc::Encoder;
+use bincode::error::{DecodeError, EncodeError};
+use bincode::{BorrowDecode, Decode, Encode};
 use bytes::{BufMut, Bytes};
 use std::convert::TryInto;
 
@@ -49,6 +53,27 @@ impl VerbInfo {
         // The binary is after the verbdef, which is prefixed with a u32 length.
         let vd_len = u32::from_le_bytes(self.0[0..4].try_into().unwrap()) as usize;
         self.0.slice(4 + vd_len..)
+    }
+}
+
+impl Encode for VerbInfo {
+    fn encode<E: Encoder>(&self, encoder: &mut E) -> Result<(), EncodeError> {
+        let bytes = self.0.to_vec();
+        bytes.encode(encoder)
+    }
+}
+
+impl Decode for VerbInfo {
+    fn decode<D: Decoder>(decoder: &mut D) -> Result<Self, DecodeError> {
+        let bytes_vec: Vec<u8> = Vec::decode(decoder)?;
+        Ok(Self(Bytes::from(bytes_vec)))
+    }
+}
+
+impl<'de> BorrowDecode<'de> for VerbInfo {
+    fn borrow_decode<D: BorrowDecoder<'de>>(decoder: &mut D) -> Result<Self, DecodeError> {
+        let bytes_vec: Vec<u8> = Vec::borrow_decode(decoder)?;
+        Ok(Self(Bytes::from(bytes_vec)))
     }
 }
 


### PR DESCRIPTION
Initial WiredTiger tasks DB implementation

This is a series of commits which pileup to implement persistent task save and load (on server restart). This is a feature that LambdaMOO has, allowing it to resume background tasks between server restarts, and is required for us to be at feature parity with 1.8.0.

Successfully persists stored tasks, and reconstitutes them on restart of the server.

Caveats:
.
- Implementation is for WiredTiger only, no Relbox yet
- The actual save/commit for each task currently blocks the Scheduler thread, and so could be a performance problem in the future that we will need to address by putting it into its own background thread.
- No tweaking has been done on the wiredtiger DB configuration to e.g. commit more cache and keep more memory resident, etc.
- No task loading from textdump yet, which is something we'd need before calling this feature complete.

Still this is major progress towards a 1.0 release.
