### PR TITLE
VM refactoring

### DIFF
--- a/crates/compiler/src/decompile.rs
+++ b/crates/compiler/src/decompile.rs
@@ -794,17 +794,6 @@ impl Decompile {
                 let e = Expr::List(vec![Arg::Splice(sp_expr)]);
                 self.push_expr(e);
             }
-            Op::GPut { id } => {
-                let e = Expr::Assign {
-                    left: Box::new(Expr::Id(id)),
-                    right: Box::new(self.pop_expr()?),
-                };
-                self.push_expr(e);
-            }
-            Op::GPush { id } => {
-                let e = Expr::Id(id);
-                self.push_expr(e)
-            }
             Op::PutProp => {
                 let rvalue = self.pop_expr()?;
                 let propname = self.pop_expr()?;

--- a/crates/compiler/src/opcode.rs
+++ b/crates/compiler/src/opcode.rs
@@ -40,8 +40,6 @@ pub enum Op {
     ForRange { id: Name, end_label: Label },
     Fork { fv_offset: Offset, id: Option<Name> },
     FuncCall { id: Name },
-    GPush { id: Name },
-    GPut { id: Name },
     Ge,
     GetProp,
     Gt,

--- a/crates/kernel/benches/vm_benches.rs
+++ b/crates/kernel/benches/vm_benches.rs
@@ -23,6 +23,7 @@ use criterion::{criterion_group, criterion_main, Criterion};
 
 use moor_compiler::compile;
 use moor_db_wiredtiger::WiredTigerDB;
+use moor_kernel::builtins::BuiltinRegistry;
 use moor_kernel::tasks::scheduler::AbortLimitReason;
 use moor_kernel::tasks::sessions::{NoopClientSession, Session};
 use moor_kernel::tasks::task_scheduler_client::TaskSchedulerClient;
@@ -115,6 +116,7 @@ fn execute(
             world_state,
             task_scheduler_client.clone(),
             session.clone(),
+            Arc::new(BuiltinRegistry::new()),
         ) {
             VMHostResponse::ContinueOk => {
                 continue;

--- a/crates/kernel/src/builtins/bf_list_sets.rs
+++ b/crates/kernel/src/builtins/bf_list_sets.rs
@@ -13,7 +13,6 @@
 //
 
 use std::ops::BitOr;
-use std::sync::Arc;
 
 use onig::{Region, SearchOptions, SyntaxOperator};
 
@@ -26,7 +25,7 @@ use moor_values::var::{v_listv, Error};
 use crate::bf_declare;
 use crate::builtins::BfRet::Ret;
 use crate::builtins::{BfCallState, BfErr, BfRet, BuiltinFunction};
-use crate::vm::vm_execute::one_to_zero_index;
+use crate::vm::moo_execute::one_to_zero_index;
 
 fn bf_is_member(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
     if bf_args.args.len() != 2 {
@@ -423,17 +422,17 @@ fn bf_substitute(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
 }
 bf_declare!(substitute, bf_substitute);
 
-pub(crate) fn register_bf_list_sets(builtins: &mut [Arc<dyn BuiltinFunction>]) {
-    builtins[offset_for_builtin("is_member")] = Arc::new(BfIsMember {});
-    builtins[offset_for_builtin("listinsert")] = Arc::new(BfListinsert {});
-    builtins[offset_for_builtin("listappend")] = Arc::new(BfListappend {});
-    builtins[offset_for_builtin("listdelete")] = Arc::new(BfListdelete {});
-    builtins[offset_for_builtin("listset")] = Arc::new(BfListset {});
-    builtins[offset_for_builtin("setadd")] = Arc::new(BfSetadd {});
-    builtins[offset_for_builtin("setremove")] = Arc::new(BfSetremove {});
-    builtins[offset_for_builtin("match")] = Arc::new(BfMatch {});
-    builtins[offset_for_builtin("rmatch")] = Arc::new(BfRmatch {});
-    builtins[offset_for_builtin("substitute")] = Arc::new(BfSubstitute {});
+pub(crate) fn register_bf_list_sets(builtins: &mut [Box<dyn BuiltinFunction>]) {
+    builtins[offset_for_builtin("is_member")] = Box::new(BfIsMember {});
+    builtins[offset_for_builtin("listinsert")] = Box::new(BfListinsert {});
+    builtins[offset_for_builtin("listappend")] = Box::new(BfListappend {});
+    builtins[offset_for_builtin("listdelete")] = Box::new(BfListdelete {});
+    builtins[offset_for_builtin("listset")] = Box::new(BfListset {});
+    builtins[offset_for_builtin("setadd")] = Box::new(BfSetadd {});
+    builtins[offset_for_builtin("setremove")] = Box::new(BfSetremove {});
+    builtins[offset_for_builtin("match")] = Box::new(BfMatch {});
+    builtins[offset_for_builtin("rmatch")] = Box::new(BfRmatch {});
+    builtins[offset_for_builtin("substitute")] = Box::new(BfSubstitute {});
 }
 
 #[cfg(test)]

--- a/crates/kernel/src/builtins/bf_list_sets.rs
+++ b/crates/kernel/src/builtins/bf_list_sets.rs
@@ -27,7 +27,6 @@ use crate::bf_declare;
 use crate::builtins::BfRet::Ret;
 use crate::builtins::{BfCallState, BfErr, BfRet, BuiltinFunction};
 use crate::vm::vm_execute::one_to_zero_index;
-use crate::vm::VM;
 
 fn bf_is_member(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
     if bf_args.args.len() != 2 {
@@ -424,19 +423,17 @@ fn bf_substitute(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
 }
 bf_declare!(substitute, bf_substitute);
 
-impl VM {
-    pub(crate) fn register_bf_list_sets(&mut self) {
-        self.builtins[offset_for_builtin("is_member")] = Arc::new(BfIsMember {});
-        self.builtins[offset_for_builtin("listinsert")] = Arc::new(BfListinsert {});
-        self.builtins[offset_for_builtin("listappend")] = Arc::new(BfListappend {});
-        self.builtins[offset_for_builtin("listdelete")] = Arc::new(BfListdelete {});
-        self.builtins[offset_for_builtin("listset")] = Arc::new(BfListset {});
-        self.builtins[offset_for_builtin("setadd")] = Arc::new(BfSetadd {});
-        self.builtins[offset_for_builtin("setremove")] = Arc::new(BfSetremove {});
-        self.builtins[offset_for_builtin("match")] = Arc::new(BfMatch {});
-        self.builtins[offset_for_builtin("rmatch")] = Arc::new(BfRmatch {});
-        self.builtins[offset_for_builtin("substitute")] = Arc::new(BfSubstitute {});
-    }
+pub(crate) fn register_bf_list_sets(builtins: &mut [Arc<dyn BuiltinFunction>]) {
+    builtins[offset_for_builtin("is_member")] = Arc::new(BfIsMember {});
+    builtins[offset_for_builtin("listinsert")] = Arc::new(BfListinsert {});
+    builtins[offset_for_builtin("listappend")] = Arc::new(BfListappend {});
+    builtins[offset_for_builtin("listdelete")] = Arc::new(BfListdelete {});
+    builtins[offset_for_builtin("listset")] = Arc::new(BfListset {});
+    builtins[offset_for_builtin("setadd")] = Arc::new(BfSetadd {});
+    builtins[offset_for_builtin("setremove")] = Arc::new(BfSetremove {});
+    builtins[offset_for_builtin("match")] = Arc::new(BfMatch {});
+    builtins[offset_for_builtin("rmatch")] = Arc::new(BfRmatch {});
+    builtins[offset_for_builtin("substitute")] = Arc::new(BfSubstitute {});
 }
 
 #[cfg(test)]

--- a/crates/kernel/src/builtins/bf_num.rs
+++ b/crates/kernel/src/builtins/bf_num.rs
@@ -25,7 +25,6 @@ use moor_values::var::{v_float, v_int, v_str};
 use crate::bf_declare;
 use crate::builtins::BfRet::Ret;
 use crate::builtins::{BfCallState, BfErr, BfRet, BuiltinFunction};
-use crate::vm::VM;
 
 fn bf_abs(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
     if bf_args.args.len() != 1 {
@@ -365,28 +364,26 @@ fn bf_trunc(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
 }
 bf_declare!(trunc, bf_trunc);
 
-impl VM {
-    pub(crate) fn register_bf_num(&mut self) {
-        self.builtins[offset_for_builtin("abs")] = Arc::new(BfAbs {});
-        self.builtins[offset_for_builtin("min")] = Arc::new(BfMin {});
-        self.builtins[offset_for_builtin("max")] = Arc::new(BfMax {});
-        self.builtins[offset_for_builtin("random")] = Arc::new(BfRandom {});
-        self.builtins[offset_for_builtin("floatstr")] = Arc::new(BfFloatstr {});
-        self.builtins[offset_for_builtin("sqrt")] = Arc::new(BfSqrt {});
-        self.builtins[offset_for_builtin("sin")] = Arc::new(BfSin {});
-        self.builtins[offset_for_builtin("cos")] = Arc::new(BfCos {});
-        self.builtins[offset_for_builtin("tan")] = Arc::new(BfTan {});
-        self.builtins[offset_for_builtin("asin")] = Arc::new(BfAsin {});
-        self.builtins[offset_for_builtin("acos")] = Arc::new(BfAcos {});
-        self.builtins[offset_for_builtin("atan")] = Arc::new(BfAtan {});
-        self.builtins[offset_for_builtin("sinh")] = Arc::new(BfSinh {});
-        self.builtins[offset_for_builtin("cosh")] = Arc::new(BfCosh {});
-        self.builtins[offset_for_builtin("tanh")] = Arc::new(BfTanh {});
-        self.builtins[offset_for_builtin("exp")] = Arc::new(BfExp {});
-        self.builtins[offset_for_builtin("log")] = Arc::new(BfLog {});
-        self.builtins[offset_for_builtin("log10")] = Arc::new(BfLog10 {});
-        self.builtins[offset_for_builtin("ceil")] = Arc::new(BfCeil {});
-        self.builtins[offset_for_builtin("floor")] = Arc::new(BfFloor {});
-        self.builtins[offset_for_builtin("trunc")] = Arc::new(BfTrunc {});
-    }
+pub(crate) fn register_bf_num(builtins: &mut [Arc<dyn BuiltinFunction>]) {
+    builtins[offset_for_builtin("abs")] = Arc::new(BfAbs {});
+    builtins[offset_for_builtin("min")] = Arc::new(BfMin {});
+    builtins[offset_for_builtin("max")] = Arc::new(BfMax {});
+    builtins[offset_for_builtin("random")] = Arc::new(BfRandom {});
+    builtins[offset_for_builtin("floatstr")] = Arc::new(BfFloatstr {});
+    builtins[offset_for_builtin("sqrt")] = Arc::new(BfSqrt {});
+    builtins[offset_for_builtin("sin")] = Arc::new(BfSin {});
+    builtins[offset_for_builtin("cos")] = Arc::new(BfCos {});
+    builtins[offset_for_builtin("tan")] = Arc::new(BfTan {});
+    builtins[offset_for_builtin("asin")] = Arc::new(BfAsin {});
+    builtins[offset_for_builtin("acos")] = Arc::new(BfAcos {});
+    builtins[offset_for_builtin("atan")] = Arc::new(BfAtan {});
+    builtins[offset_for_builtin("sinh")] = Arc::new(BfSinh {});
+    builtins[offset_for_builtin("cosh")] = Arc::new(BfCosh {});
+    builtins[offset_for_builtin("tanh")] = Arc::new(BfTanh {});
+    builtins[offset_for_builtin("exp")] = Arc::new(BfExp {});
+    builtins[offset_for_builtin("log")] = Arc::new(BfLog {});
+    builtins[offset_for_builtin("log10")] = Arc::new(BfLog10 {});
+    builtins[offset_for_builtin("ceil")] = Arc::new(BfCeil {});
+    builtins[offset_for_builtin("floor")] = Arc::new(BfFloor {});
+    builtins[offset_for_builtin("trunc")] = Arc::new(BfTrunc {});
 }

--- a/crates/kernel/src/builtins/bf_num.rs
+++ b/crates/kernel/src/builtins/bf_num.rs
@@ -12,8 +12,6 @@
 // this program. If not, see <https://www.gnu.org/licenses/>.
 //
 
-use std::sync::Arc;
-
 use decorum::R64;
 use rand::Rng;
 
@@ -364,26 +362,26 @@ fn bf_trunc(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
 }
 bf_declare!(trunc, bf_trunc);
 
-pub(crate) fn register_bf_num(builtins: &mut [Arc<dyn BuiltinFunction>]) {
-    builtins[offset_for_builtin("abs")] = Arc::new(BfAbs {});
-    builtins[offset_for_builtin("min")] = Arc::new(BfMin {});
-    builtins[offset_for_builtin("max")] = Arc::new(BfMax {});
-    builtins[offset_for_builtin("random")] = Arc::new(BfRandom {});
-    builtins[offset_for_builtin("floatstr")] = Arc::new(BfFloatstr {});
-    builtins[offset_for_builtin("sqrt")] = Arc::new(BfSqrt {});
-    builtins[offset_for_builtin("sin")] = Arc::new(BfSin {});
-    builtins[offset_for_builtin("cos")] = Arc::new(BfCos {});
-    builtins[offset_for_builtin("tan")] = Arc::new(BfTan {});
-    builtins[offset_for_builtin("asin")] = Arc::new(BfAsin {});
-    builtins[offset_for_builtin("acos")] = Arc::new(BfAcos {});
-    builtins[offset_for_builtin("atan")] = Arc::new(BfAtan {});
-    builtins[offset_for_builtin("sinh")] = Arc::new(BfSinh {});
-    builtins[offset_for_builtin("cosh")] = Arc::new(BfCosh {});
-    builtins[offset_for_builtin("tanh")] = Arc::new(BfTanh {});
-    builtins[offset_for_builtin("exp")] = Arc::new(BfExp {});
-    builtins[offset_for_builtin("log")] = Arc::new(BfLog {});
-    builtins[offset_for_builtin("log10")] = Arc::new(BfLog10 {});
-    builtins[offset_for_builtin("ceil")] = Arc::new(BfCeil {});
-    builtins[offset_for_builtin("floor")] = Arc::new(BfFloor {});
-    builtins[offset_for_builtin("trunc")] = Arc::new(BfTrunc {});
+pub(crate) fn register_bf_num(builtins: &mut [Box<dyn BuiltinFunction>]) {
+    builtins[offset_for_builtin("abs")] = Box::new(BfAbs {});
+    builtins[offset_for_builtin("min")] = Box::new(BfMin {});
+    builtins[offset_for_builtin("max")] = Box::new(BfMax {});
+    builtins[offset_for_builtin("random")] = Box::new(BfRandom {});
+    builtins[offset_for_builtin("floatstr")] = Box::new(BfFloatstr {});
+    builtins[offset_for_builtin("sqrt")] = Box::new(BfSqrt {});
+    builtins[offset_for_builtin("sin")] = Box::new(BfSin {});
+    builtins[offset_for_builtin("cos")] = Box::new(BfCos {});
+    builtins[offset_for_builtin("tan")] = Box::new(BfTan {});
+    builtins[offset_for_builtin("asin")] = Box::new(BfAsin {});
+    builtins[offset_for_builtin("acos")] = Box::new(BfAcos {});
+    builtins[offset_for_builtin("atan")] = Box::new(BfAtan {});
+    builtins[offset_for_builtin("sinh")] = Box::new(BfSinh {});
+    builtins[offset_for_builtin("cosh")] = Box::new(BfCosh {});
+    builtins[offset_for_builtin("tanh")] = Box::new(BfTanh {});
+    builtins[offset_for_builtin("exp")] = Box::new(BfExp {});
+    builtins[offset_for_builtin("log")] = Box::new(BfLog {});
+    builtins[offset_for_builtin("log10")] = Box::new(BfLog10 {});
+    builtins[offset_for_builtin("ceil")] = Box::new(BfCeil {});
+    builtins[offset_for_builtin("floor")] = Box::new(BfFloor {});
+    builtins[offset_for_builtin("trunc")] = Box::new(BfTrunc {});
 }

--- a/crates/kernel/src/builtins/bf_objects.rs
+++ b/crates/kernel/src/builtins/bf_objects.rs
@@ -34,7 +34,6 @@ use crate::builtins::BfRet::{Ret, VmInstr};
 use crate::builtins::{world_state_bf_err, BfCallState, BfErr, BfRet, BuiltinFunction};
 use crate::tasks::VerbCall;
 use crate::vm::ExecutionResult::ContinueVerb;
-use crate::vm::VM;
 
 lazy_static! {
     static ref INITIALIZE_SYM: Symbol = Symbol::mk("initialize");
@@ -705,19 +704,17 @@ fn bf_players(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
 }
 bf_declare!(players, bf_players);
 
-impl VM {
-    pub(crate) fn register_bf_objects(&mut self) {
-        self.builtins[offset_for_builtin("create")] = Arc::new(BfCreate {});
-        self.builtins[offset_for_builtin("valid")] = Arc::new(BfValid {});
-        self.builtins[offset_for_builtin("verbs")] = Arc::new(BfVerbs {});
-        self.builtins[offset_for_builtin("properties")] = Arc::new(BfProperties {});
-        self.builtins[offset_for_builtin("parent")] = Arc::new(BfParent {});
-        self.builtins[offset_for_builtin("children")] = Arc::new(BfChildren {});
-        self.builtins[offset_for_builtin("move")] = Arc::new(BfMove {});
-        self.builtins[offset_for_builtin("chparent")] = Arc::new(BfChparent {});
-        self.builtins[offset_for_builtin("set_player_flag")] = Arc::new(BfSetPlayerFlag {});
-        self.builtins[offset_for_builtin("recycle")] = Arc::new(BfRecycle {});
-        self.builtins[offset_for_builtin("max_object")] = Arc::new(BfMaxObject {});
-        self.builtins[offset_for_builtin("players")] = Arc::new(BfPlayers {});
-    }
+pub(crate) fn register_bf_objects(builtins: &mut [Arc<dyn BuiltinFunction>]) {
+    builtins[offset_for_builtin("create")] = Arc::new(BfCreate {});
+    builtins[offset_for_builtin("valid")] = Arc::new(BfValid {});
+    builtins[offset_for_builtin("verbs")] = Arc::new(BfVerbs {});
+    builtins[offset_for_builtin("properties")] = Arc::new(BfProperties {});
+    builtins[offset_for_builtin("parent")] = Arc::new(BfParent {});
+    builtins[offset_for_builtin("children")] = Arc::new(BfChildren {});
+    builtins[offset_for_builtin("move")] = Arc::new(BfMove {});
+    builtins[offset_for_builtin("chparent")] = Arc::new(BfChparent {});
+    builtins[offset_for_builtin("set_player_flag")] = Arc::new(BfSetPlayerFlag {});
+    builtins[offset_for_builtin("recycle")] = Arc::new(BfRecycle {});
+    builtins[offset_for_builtin("max_object")] = Arc::new(BfMaxObject {});
+    builtins[offset_for_builtin("players")] = Arc::new(BfPlayers {});
 }

--- a/crates/kernel/src/builtins/bf_objects.rs
+++ b/crates/kernel/src/builtins/bf_objects.rs
@@ -13,8 +13,6 @@
 //
 
 use lazy_static::lazy_static;
-use std::sync::Arc;
-
 use tracing::{debug, error, trace};
 
 use moor_compiler::offset_for_builtin;
@@ -704,17 +702,17 @@ fn bf_players(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
 }
 bf_declare!(players, bf_players);
 
-pub(crate) fn register_bf_objects(builtins: &mut [Arc<dyn BuiltinFunction>]) {
-    builtins[offset_for_builtin("create")] = Arc::new(BfCreate {});
-    builtins[offset_for_builtin("valid")] = Arc::new(BfValid {});
-    builtins[offset_for_builtin("verbs")] = Arc::new(BfVerbs {});
-    builtins[offset_for_builtin("properties")] = Arc::new(BfProperties {});
-    builtins[offset_for_builtin("parent")] = Arc::new(BfParent {});
-    builtins[offset_for_builtin("children")] = Arc::new(BfChildren {});
-    builtins[offset_for_builtin("move")] = Arc::new(BfMove {});
-    builtins[offset_for_builtin("chparent")] = Arc::new(BfChparent {});
-    builtins[offset_for_builtin("set_player_flag")] = Arc::new(BfSetPlayerFlag {});
-    builtins[offset_for_builtin("recycle")] = Arc::new(BfRecycle {});
-    builtins[offset_for_builtin("max_object")] = Arc::new(BfMaxObject {});
-    builtins[offset_for_builtin("players")] = Arc::new(BfPlayers {});
+pub(crate) fn register_bf_objects(builtins: &mut [Box<dyn BuiltinFunction>]) {
+    builtins[offset_for_builtin("create")] = Box::new(BfCreate {});
+    builtins[offset_for_builtin("valid")] = Box::new(BfValid {});
+    builtins[offset_for_builtin("verbs")] = Box::new(BfVerbs {});
+    builtins[offset_for_builtin("properties")] = Box::new(BfProperties {});
+    builtins[offset_for_builtin("parent")] = Box::new(BfParent {});
+    builtins[offset_for_builtin("children")] = Box::new(BfChildren {});
+    builtins[offset_for_builtin("move")] = Box::new(BfMove {});
+    builtins[offset_for_builtin("chparent")] = Box::new(BfChparent {});
+    builtins[offset_for_builtin("set_player_flag")] = Box::new(BfSetPlayerFlag {});
+    builtins[offset_for_builtin("recycle")] = Box::new(BfRecycle {});
+    builtins[offset_for_builtin("max_object")] = Box::new(BfMaxObject {});
+    builtins[offset_for_builtin("players")] = Box::new(BfPlayers {});
 }

--- a/crates/kernel/src/builtins/bf_objects.rs
+++ b/crates/kernel/src/builtins/bf_objects.rs
@@ -467,12 +467,11 @@ fn bf_move(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
             BF_MOVE_TRAMPOLINE_MOVE_CALL_EXITFUNC => {
                 trace!(what = ?what, where_to = ?*whereto, tramp, "move: moving object, calling exitfunc");
 
-                // Accept verb has been called, and returned. Check the result. Should be on stack,
-                // unless short-circuited, in which case we assume *false*
-                // TODO directly pushing into the stack like this is going to be a problem for
-                //  non-MOO interpreters. we need a more generic way of doing this
+                // Accept verb has been called, and returned. Check the result. Should be in our
+                // activation's return-value.
+                // Unless short-circuited, in which case we assume *false*
                 let result = if !shortcircuit {
-                    bf_args.exec_state.top().frame.peek_top().clone()
+                    bf_args.exec_state.top().frame.return_value()
                 } else {
                     v_int(0)
                 };

--- a/crates/kernel/src/builtins/bf_properties.rs
+++ b/crates/kernel/src/builtins/bf_properties.rs
@@ -12,8 +12,6 @@
 // this program. If not, see <https://www.gnu.org/licenses/>.
 //
 
-use std::sync::Arc;
-
 use moor_compiler::offset_for_builtin;
 use moor_values::model::{PropAttrs, PropFlag};
 use moor_values::util::BitEnum;
@@ -252,11 +250,11 @@ fn bf_delete_property(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
 }
 bf_declare!(delete_property, bf_delete_property);
 
-pub(crate) fn register_bf_properties(builtins: &mut [Arc<dyn BuiltinFunction>]) {
-    builtins[offset_for_builtin("property_info")] = Arc::new(BfPropertyInfo {});
-    builtins[offset_for_builtin("set_property_info")] = Arc::new(BfSetPropertyInfo {});
-    builtins[offset_for_builtin("is_clear_property")] = Arc::new(BfIsClearProperty {});
-    builtins[offset_for_builtin("clear_property")] = Arc::new(BfSetClearProperty {});
-    builtins[offset_for_builtin("add_property")] = Arc::new(BfAddProperty {});
-    builtins[offset_for_builtin("delete_property")] = Arc::new(BfDeleteProperty {});
+pub(crate) fn register_bf_properties(builtins: &mut [Box<dyn BuiltinFunction>]) {
+    builtins[offset_for_builtin("property_info")] = Box::new(BfPropertyInfo {});
+    builtins[offset_for_builtin("set_property_info")] = Box::new(BfSetPropertyInfo {});
+    builtins[offset_for_builtin("is_clear_property")] = Box::new(BfIsClearProperty {});
+    builtins[offset_for_builtin("clear_property")] = Box::new(BfSetClearProperty {});
+    builtins[offset_for_builtin("add_property")] = Box::new(BfAddProperty {});
+    builtins[offset_for_builtin("delete_property")] = Box::new(BfDeleteProperty {});
 }

--- a/crates/kernel/src/builtins/bf_properties.rs
+++ b/crates/kernel/src/builtins/bf_properties.rs
@@ -27,7 +27,6 @@ use crate::bf_declare;
 use crate::builtins::BfErr::Code;
 use crate::builtins::BfRet::Ret;
 use crate::builtins::{world_state_bf_err, BfCallState, BfErr, BfRet, BuiltinFunction};
-use crate::vm::VM;
 
 // property_info (obj <object>, str <prop-name>)              => list\
 //  {<owner>, <perms> }
@@ -252,13 +251,12 @@ fn bf_delete_property(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
     Ok(Ret(v_empty_list()))
 }
 bf_declare!(delete_property, bf_delete_property);
-impl VM {
-    pub(crate) fn register_bf_properties(&mut self) {
-        self.builtins[offset_for_builtin("property_info")] = Arc::new(BfPropertyInfo {});
-        self.builtins[offset_for_builtin("set_property_info")] = Arc::new(BfSetPropertyInfo {});
-        self.builtins[offset_for_builtin("is_clear_property")] = Arc::new(BfIsClearProperty {});
-        self.builtins[offset_for_builtin("clear_property")] = Arc::new(BfSetClearProperty {});
-        self.builtins[offset_for_builtin("add_property")] = Arc::new(BfAddProperty {});
-        self.builtins[offset_for_builtin("delete_property")] = Arc::new(BfDeleteProperty {});
-    }
+
+pub(crate) fn register_bf_properties(builtins: &mut [Arc<dyn BuiltinFunction>]) {
+    builtins[offset_for_builtin("property_info")] = Arc::new(BfPropertyInfo {});
+    builtins[offset_for_builtin("set_property_info")] = Arc::new(BfSetPropertyInfo {});
+    builtins[offset_for_builtin("is_clear_property")] = Arc::new(BfIsClearProperty {});
+    builtins[offset_for_builtin("clear_property")] = Arc::new(BfSetClearProperty {});
+    builtins[offset_for_builtin("add_property")] = Arc::new(BfAddProperty {});
+    builtins[offset_for_builtin("delete_property")] = Arc::new(BfDeleteProperty {});
 }

--- a/crates/kernel/src/builtins/bf_server.rs
+++ b/crates/kernel/src/builtins/bf_server.rs
@@ -774,8 +774,8 @@ fn bf_eval(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
             }));
         }
         BF_SERVER_EVAL_TRAMPOLINE_RESUME => {
-            // Value must be on stack,  and we then wrap that up in the {success, value} tuple.
-            let value = bf_args.exec_state.pop();
+            // Value must be on in our activation's "return value"
+            let value = bf_args.exec_state.top().frame.return_value();
             Ok(Ret(v_listv(vec![v_bool(true), value])))
         }
         _ => {

--- a/crates/kernel/src/builtins/bf_server.rs
+++ b/crates/kernel/src/builtins/bf_server.rs
@@ -35,7 +35,7 @@ use crate::bf_declare;
 use crate::builtins::BfRet::{Ret, VmInstr};
 use crate::builtins::{world_state_bf_err, BfCallState, BfErr, BfRet, BuiltinFunction};
 use crate::tasks::TaskId;
-use crate::vm::{ExecutionResult, VM};
+use crate::vm::ExecutionResult;
 
 fn bf_noop(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
     error!(
@@ -897,39 +897,37 @@ fn load_server_options(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
 }
 bf_declare!(load_server_options, load_server_options);
 
-impl VM {
-    pub(crate) fn register_bf_server(&mut self) {
-        self.builtins[offset_for_builtin("notify")] = Arc::new(BfNotify {});
-        self.builtins[offset_for_builtin("connected_players")] = Arc::new(BfConnectedPlayers {});
-        self.builtins[offset_for_builtin("is_player")] = Arc::new(BfIsPlayer {});
-        self.builtins[offset_for_builtin("caller_perms")] = Arc::new(BfCallerPerms {});
-        self.builtins[offset_for_builtin("set_task_perms")] = Arc::new(BfSetTaskPerms {});
-        self.builtins[offset_for_builtin("callers")] = Arc::new(BfCallers {});
-        self.builtins[offset_for_builtin("task_id")] = Arc::new(BfTaskId {});
-        self.builtins[offset_for_builtin("idle_seconds")] = Arc::new(BfIdleSeconds {});
-        self.builtins[offset_for_builtin("connected_seconds")] = Arc::new(BfConnectedSeconds {});
-        self.builtins[offset_for_builtin("connection_name")] = Arc::new(BfConnectionName {});
-        self.builtins[offset_for_builtin("time")] = Arc::new(BfTime {});
-        self.builtins[offset_for_builtin("ctime")] = Arc::new(BfCtime {});
-        self.builtins[offset_for_builtin("raise")] = Arc::new(BfRaise {});
-        self.builtins[offset_for_builtin("server_version")] = Arc::new(BfServerVersion {});
-        self.builtins[offset_for_builtin("shutdown")] = Arc::new(BfShutdown {});
-        self.builtins[offset_for_builtin("suspend")] = Arc::new(BfSuspend {});
-        self.builtins[offset_for_builtin("queued_tasks")] = Arc::new(BfQueuedTasks {});
-        self.builtins[offset_for_builtin("kill_task")] = Arc::new(BfKillTask {});
-        self.builtins[offset_for_builtin("resume")] = Arc::new(BfResume {});
-        self.builtins[offset_for_builtin("ticks_left")] = Arc::new(BfTicksLeft {});
-        self.builtins[offset_for_builtin("seconds_left")] = Arc::new(BfSecondsLeft {});
-        self.builtins[offset_for_builtin("boot_player")] = Arc::new(BfBootPlayer {});
-        self.builtins[offset_for_builtin("call_function")] = Arc::new(BfCallFunction {});
-        self.builtins[offset_for_builtin("server_log")] = Arc::new(BfServerLog {});
-        self.builtins[offset_for_builtin("function_info")] = Arc::new(BfFunctionInfo {});
-        self.builtins[offset_for_builtin("listeners")] = Arc::new(BfListeners {});
-        self.builtins[offset_for_builtin("eval")] = Arc::new(BfEval {});
-        self.builtins[offset_for_builtin("read")] = Arc::new(BfRead {});
-        self.builtins[offset_for_builtin("dump_database")] = Arc::new(BfDumpDatabase {});
-        self.builtins[offset_for_builtin("memory_usage")] = Arc::new(BfMemoryUsage {});
-        self.builtins[offset_for_builtin("db_disk_size")] = Arc::new(BfDbDiskSize {});
-        self.builtins[offset_for_builtin("load_server_options")] = Arc::new(BfLoadServerOptions {});
-    }
+pub(crate) fn register_bf_server(builtins: &mut [Arc<dyn BuiltinFunction>]) {
+    builtins[offset_for_builtin("notify")] = Arc::new(BfNotify {});
+    builtins[offset_for_builtin("connected_players")] = Arc::new(BfConnectedPlayers {});
+    builtins[offset_for_builtin("is_player")] = Arc::new(BfIsPlayer {});
+    builtins[offset_for_builtin("caller_perms")] = Arc::new(BfCallerPerms {});
+    builtins[offset_for_builtin("set_task_perms")] = Arc::new(BfSetTaskPerms {});
+    builtins[offset_for_builtin("callers")] = Arc::new(BfCallers {});
+    builtins[offset_for_builtin("task_id")] = Arc::new(BfTaskId {});
+    builtins[offset_for_builtin("idle_seconds")] = Arc::new(BfIdleSeconds {});
+    builtins[offset_for_builtin("connected_seconds")] = Arc::new(BfConnectedSeconds {});
+    builtins[offset_for_builtin("connection_name")] = Arc::new(BfConnectionName {});
+    builtins[offset_for_builtin("time")] = Arc::new(BfTime {});
+    builtins[offset_for_builtin("ctime")] = Arc::new(BfCtime {});
+    builtins[offset_for_builtin("raise")] = Arc::new(BfRaise {});
+    builtins[offset_for_builtin("server_version")] = Arc::new(BfServerVersion {});
+    builtins[offset_for_builtin("shutdown")] = Arc::new(BfShutdown {});
+    builtins[offset_for_builtin("suspend")] = Arc::new(BfSuspend {});
+    builtins[offset_for_builtin("queued_tasks")] = Arc::new(BfQueuedTasks {});
+    builtins[offset_for_builtin("kill_task")] = Arc::new(BfKillTask {});
+    builtins[offset_for_builtin("resume")] = Arc::new(BfResume {});
+    builtins[offset_for_builtin("ticks_left")] = Arc::new(BfTicksLeft {});
+    builtins[offset_for_builtin("seconds_left")] = Arc::new(BfSecondsLeft {});
+    builtins[offset_for_builtin("boot_player")] = Arc::new(BfBootPlayer {});
+    builtins[offset_for_builtin("call_function")] = Arc::new(BfCallFunction {});
+    builtins[offset_for_builtin("server_log")] = Arc::new(BfServerLog {});
+    builtins[offset_for_builtin("function_info")] = Arc::new(BfFunctionInfo {});
+    builtins[offset_for_builtin("listeners")] = Arc::new(BfListeners {});
+    builtins[offset_for_builtin("eval")] = Arc::new(BfEval {});
+    builtins[offset_for_builtin("read")] = Arc::new(BfRead {});
+    builtins[offset_for_builtin("dump_database")] = Arc::new(BfDumpDatabase {});
+    builtins[offset_for_builtin("memory_usage")] = Arc::new(BfMemoryUsage {});
+    builtins[offset_for_builtin("db_disk_size")] = Arc::new(BfDbDiskSize {});
+    builtins[offset_for_builtin("load_server_options")] = Arc::new(BfLoadServerOptions {});
 }

--- a/crates/kernel/src/builtins/bf_server.rs
+++ b/crates/kernel/src/builtins/bf_server.rs
@@ -13,7 +13,6 @@
 //
 
 use std::io::Read;
-use std::sync::Arc;
 use std::time::{Duration, SystemTime};
 
 use chrono::{DateTime, Local, TimeZone};
@@ -897,37 +896,37 @@ fn load_server_options(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
 }
 bf_declare!(load_server_options, load_server_options);
 
-pub(crate) fn register_bf_server(builtins: &mut [Arc<dyn BuiltinFunction>]) {
-    builtins[offset_for_builtin("notify")] = Arc::new(BfNotify {});
-    builtins[offset_for_builtin("connected_players")] = Arc::new(BfConnectedPlayers {});
-    builtins[offset_for_builtin("is_player")] = Arc::new(BfIsPlayer {});
-    builtins[offset_for_builtin("caller_perms")] = Arc::new(BfCallerPerms {});
-    builtins[offset_for_builtin("set_task_perms")] = Arc::new(BfSetTaskPerms {});
-    builtins[offset_for_builtin("callers")] = Arc::new(BfCallers {});
-    builtins[offset_for_builtin("task_id")] = Arc::new(BfTaskId {});
-    builtins[offset_for_builtin("idle_seconds")] = Arc::new(BfIdleSeconds {});
-    builtins[offset_for_builtin("connected_seconds")] = Arc::new(BfConnectedSeconds {});
-    builtins[offset_for_builtin("connection_name")] = Arc::new(BfConnectionName {});
-    builtins[offset_for_builtin("time")] = Arc::new(BfTime {});
-    builtins[offset_for_builtin("ctime")] = Arc::new(BfCtime {});
-    builtins[offset_for_builtin("raise")] = Arc::new(BfRaise {});
-    builtins[offset_for_builtin("server_version")] = Arc::new(BfServerVersion {});
-    builtins[offset_for_builtin("shutdown")] = Arc::new(BfShutdown {});
-    builtins[offset_for_builtin("suspend")] = Arc::new(BfSuspend {});
-    builtins[offset_for_builtin("queued_tasks")] = Arc::new(BfQueuedTasks {});
-    builtins[offset_for_builtin("kill_task")] = Arc::new(BfKillTask {});
-    builtins[offset_for_builtin("resume")] = Arc::new(BfResume {});
-    builtins[offset_for_builtin("ticks_left")] = Arc::new(BfTicksLeft {});
-    builtins[offset_for_builtin("seconds_left")] = Arc::new(BfSecondsLeft {});
-    builtins[offset_for_builtin("boot_player")] = Arc::new(BfBootPlayer {});
-    builtins[offset_for_builtin("call_function")] = Arc::new(BfCallFunction {});
-    builtins[offset_for_builtin("server_log")] = Arc::new(BfServerLog {});
-    builtins[offset_for_builtin("function_info")] = Arc::new(BfFunctionInfo {});
-    builtins[offset_for_builtin("listeners")] = Arc::new(BfListeners {});
-    builtins[offset_for_builtin("eval")] = Arc::new(BfEval {});
-    builtins[offset_for_builtin("read")] = Arc::new(BfRead {});
-    builtins[offset_for_builtin("dump_database")] = Arc::new(BfDumpDatabase {});
-    builtins[offset_for_builtin("memory_usage")] = Arc::new(BfMemoryUsage {});
-    builtins[offset_for_builtin("db_disk_size")] = Arc::new(BfDbDiskSize {});
-    builtins[offset_for_builtin("load_server_options")] = Arc::new(BfLoadServerOptions {});
+pub(crate) fn register_bf_server(builtins: &mut [Box<dyn BuiltinFunction>]) {
+    builtins[offset_for_builtin("notify")] = Box::new(BfNotify {});
+    builtins[offset_for_builtin("connected_players")] = Box::new(BfConnectedPlayers {});
+    builtins[offset_for_builtin("is_player")] = Box::new(BfIsPlayer {});
+    builtins[offset_for_builtin("caller_perms")] = Box::new(BfCallerPerms {});
+    builtins[offset_for_builtin("set_task_perms")] = Box::new(BfSetTaskPerms {});
+    builtins[offset_for_builtin("callers")] = Box::new(BfCallers {});
+    builtins[offset_for_builtin("task_id")] = Box::new(BfTaskId {});
+    builtins[offset_for_builtin("idle_seconds")] = Box::new(BfIdleSeconds {});
+    builtins[offset_for_builtin("connected_seconds")] = Box::new(BfConnectedSeconds {});
+    builtins[offset_for_builtin("connection_name")] = Box::new(BfConnectionName {});
+    builtins[offset_for_builtin("time")] = Box::new(BfTime {});
+    builtins[offset_for_builtin("ctime")] = Box::new(BfCtime {});
+    builtins[offset_for_builtin("raise")] = Box::new(BfRaise {});
+    builtins[offset_for_builtin("server_version")] = Box::new(BfServerVersion {});
+    builtins[offset_for_builtin("shutdown")] = Box::new(BfShutdown {});
+    builtins[offset_for_builtin("suspend")] = Box::new(BfSuspend {});
+    builtins[offset_for_builtin("queued_tasks")] = Box::new(BfQueuedTasks {});
+    builtins[offset_for_builtin("kill_task")] = Box::new(BfKillTask {});
+    builtins[offset_for_builtin("resume")] = Box::new(BfResume {});
+    builtins[offset_for_builtin("ticks_left")] = Box::new(BfTicksLeft {});
+    builtins[offset_for_builtin("seconds_left")] = Box::new(BfSecondsLeft {});
+    builtins[offset_for_builtin("boot_player")] = Box::new(BfBootPlayer {});
+    builtins[offset_for_builtin("call_function")] = Box::new(BfCallFunction {});
+    builtins[offset_for_builtin("server_log")] = Box::new(BfServerLog {});
+    builtins[offset_for_builtin("function_info")] = Box::new(BfFunctionInfo {});
+    builtins[offset_for_builtin("listeners")] = Box::new(BfListeners {});
+    builtins[offset_for_builtin("eval")] = Box::new(BfEval {});
+    builtins[offset_for_builtin("read")] = Box::new(BfRead {});
+    builtins[offset_for_builtin("dump_database")] = Box::new(BfDumpDatabase {});
+    builtins[offset_for_builtin("memory_usage")] = Box::new(BfMemoryUsage {});
+    builtins[offset_for_builtin("db_disk_size")] = Box::new(BfDbDiskSize {});
+    builtins[offset_for_builtin("load_server_options")] = Box::new(BfLoadServerOptions {});
 }

--- a/crates/kernel/src/builtins/bf_strings.rs
+++ b/crates/kernel/src/builtins/bf_strings.rs
@@ -26,7 +26,6 @@ use moor_values::var::{v_int, v_str, v_string};
 use crate::bf_declare;
 use crate::builtins::BfRet::Ret;
 use crate::builtins::{BfCallState, BfErr, BfRet, BuiltinFunction};
-use crate::vm::VM;
 
 fn strsub(subject: &str, what: &str, with: &str, case_matters: bool) -> String {
     let mut result = String::new();
@@ -220,16 +219,14 @@ fn bf_binary_hash(_bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
 }
 bf_declare!(binary_hash, bf_binary_hash);
 
-impl VM {
-    pub(crate) fn register_bf_strings(&mut self) {
-        self.builtins[offset_for_builtin("strsub")] = Arc::new(BfStrsub {});
-        self.builtins[offset_for_builtin("index")] = Arc::new(BfIndex {});
-        self.builtins[offset_for_builtin("rindex")] = Arc::new(BfRindex {});
-        self.builtins[offset_for_builtin("strcmp")] = Arc::new(BfStrcmp {});
-        self.builtins[offset_for_builtin("crypt")] = Arc::new(BfCrypt {});
-        self.builtins[offset_for_builtin("string_hash")] = Arc::new(BfStringHash {});
-        self.builtins[offset_for_builtin("binary_hash")] = Arc::new(BfBinaryHash {});
-    }
+pub(crate) fn register_bf_strings(builtins: &mut [Arc<dyn BuiltinFunction>]) {
+    builtins[offset_for_builtin("strsub")] = Arc::new(BfStrsub {});
+    builtins[offset_for_builtin("index")] = Arc::new(BfIndex {});
+    builtins[offset_for_builtin("rindex")] = Arc::new(BfRindex {});
+    builtins[offset_for_builtin("strcmp")] = Arc::new(BfStrcmp {});
+    builtins[offset_for_builtin("crypt")] = Arc::new(BfCrypt {});
+    builtins[offset_for_builtin("string_hash")] = Arc::new(BfStringHash {});
+    builtins[offset_for_builtin("binary_hash")] = Arc::new(BfBinaryHash {});
 }
 
 #[cfg(test)]

--- a/crates/kernel/src/builtins/bf_strings.rs
+++ b/crates/kernel/src/builtins/bf_strings.rs
@@ -13,8 +13,6 @@
 //
 
 use md5::Digest;
-use std::sync::Arc;
-
 use rand::distributions::Alphanumeric;
 use rand::Rng;
 
@@ -219,14 +217,14 @@ fn bf_binary_hash(_bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
 }
 bf_declare!(binary_hash, bf_binary_hash);
 
-pub(crate) fn register_bf_strings(builtins: &mut [Arc<dyn BuiltinFunction>]) {
-    builtins[offset_for_builtin("strsub")] = Arc::new(BfStrsub {});
-    builtins[offset_for_builtin("index")] = Arc::new(BfIndex {});
-    builtins[offset_for_builtin("rindex")] = Arc::new(BfRindex {});
-    builtins[offset_for_builtin("strcmp")] = Arc::new(BfStrcmp {});
-    builtins[offset_for_builtin("crypt")] = Arc::new(BfCrypt {});
-    builtins[offset_for_builtin("string_hash")] = Arc::new(BfStringHash {});
-    builtins[offset_for_builtin("binary_hash")] = Arc::new(BfBinaryHash {});
+pub(crate) fn register_bf_strings(builtins: &mut [Box<dyn BuiltinFunction>]) {
+    builtins[offset_for_builtin("strsub")] = Box::new(BfStrsub {});
+    builtins[offset_for_builtin("index")] = Box::new(BfIndex {});
+    builtins[offset_for_builtin("rindex")] = Box::new(BfRindex {});
+    builtins[offset_for_builtin("strcmp")] = Box::new(BfStrcmp {});
+    builtins[offset_for_builtin("crypt")] = Box::new(BfCrypt {});
+    builtins[offset_for_builtin("string_hash")] = Box::new(BfStringHash {});
+    builtins[offset_for_builtin("binary_hash")] = Box::new(BfBinaryHash {});
 }
 
 #[cfg(test)]

--- a/crates/kernel/src/builtins/bf_values.rs
+++ b/crates/kernel/src/builtins/bf_values.rs
@@ -25,7 +25,6 @@ use moor_values::AsByteBuffer;
 use crate::bf_declare;
 use crate::builtins::BfRet::Ret;
 use crate::builtins::{world_state_bf_err, BfCallState, BfErr, BfRet, BuiltinFunction};
-use crate::vm::VM;
 
 fn bf_typeof(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
     let arg = &bf_args.args[0];
@@ -188,20 +187,18 @@ fn bf_object_bytes(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
 }
 bf_declare!(object_bytes, bf_object_bytes);
 
-impl VM {
-    pub(crate) fn register_bf_values(&mut self) {
-        self.builtins[offset_for_builtin("typeof")] = Arc::new(BfTypeof {});
-        self.builtins[offset_for_builtin("tostr")] = Arc::new(BfTostr {});
-        self.builtins[offset_for_builtin("toliteral")] = Arc::new(BfToliteral {});
-        self.builtins[offset_for_builtin("toint")] = Arc::new(BfToint {});
-        self.builtins[offset_for_builtin("tonum")] = Arc::new(BfToint {});
-        self.builtins[offset_for_builtin("tonum")] = Arc::new(BfToint {});
-        self.builtins[offset_for_builtin("toobj")] = Arc::new(BfToobj {});
-        self.builtins[offset_for_builtin("tofloat")] = Arc::new(BfTofloat {});
-        self.builtins[offset_for_builtin("equal")] = Arc::new(BfEqual {});
-        self.builtins[offset_for_builtin("value_bytes")] = Arc::new(BfValueBytes {});
-        self.builtins[offset_for_builtin("object_bytes")] = Arc::new(BfObjectBytes {});
-        self.builtins[offset_for_builtin("value_hash")] = Arc::new(BfValueHash {});
-        self.builtins[offset_for_builtin("length")] = Arc::new(BfLength {});
-    }
+pub(crate) fn register_bf_values(builtins: &mut [Arc<dyn BuiltinFunction>]) {
+    builtins[offset_for_builtin("typeof")] = Arc::new(BfTypeof {});
+    builtins[offset_for_builtin("tostr")] = Arc::new(BfTostr {});
+    builtins[offset_for_builtin("toliteral")] = Arc::new(BfToliteral {});
+    builtins[offset_for_builtin("toint")] = Arc::new(BfToint {});
+    builtins[offset_for_builtin("tonum")] = Arc::new(BfToint {});
+    builtins[offset_for_builtin("tonum")] = Arc::new(BfToint {});
+    builtins[offset_for_builtin("toobj")] = Arc::new(BfToobj {});
+    builtins[offset_for_builtin("tofloat")] = Arc::new(BfTofloat {});
+    builtins[offset_for_builtin("equal")] = Arc::new(BfEqual {});
+    builtins[offset_for_builtin("value_bytes")] = Arc::new(BfValueBytes {});
+    builtins[offset_for_builtin("object_bytes")] = Arc::new(BfObjectBytes {});
+    builtins[offset_for_builtin("value_hash")] = Arc::new(BfValueHash {});
+    builtins[offset_for_builtin("length")] = Arc::new(BfLength {});
 }

--- a/crates/kernel/src/builtins/bf_values.rs
+++ b/crates/kernel/src/builtins/bf_values.rs
@@ -14,7 +14,6 @@
 
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
-use std::sync::Arc;
 
 use moor_compiler::offset_for_builtin;
 use moor_values::var::Error::{E_ARGS, E_INVARG, E_TYPE};
@@ -187,18 +186,18 @@ fn bf_object_bytes(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
 }
 bf_declare!(object_bytes, bf_object_bytes);
 
-pub(crate) fn register_bf_values(builtins: &mut [Arc<dyn BuiltinFunction>]) {
-    builtins[offset_for_builtin("typeof")] = Arc::new(BfTypeof {});
-    builtins[offset_for_builtin("tostr")] = Arc::new(BfTostr {});
-    builtins[offset_for_builtin("toliteral")] = Arc::new(BfToliteral {});
-    builtins[offset_for_builtin("toint")] = Arc::new(BfToint {});
-    builtins[offset_for_builtin("tonum")] = Arc::new(BfToint {});
-    builtins[offset_for_builtin("tonum")] = Arc::new(BfToint {});
-    builtins[offset_for_builtin("toobj")] = Arc::new(BfToobj {});
-    builtins[offset_for_builtin("tofloat")] = Arc::new(BfTofloat {});
-    builtins[offset_for_builtin("equal")] = Arc::new(BfEqual {});
-    builtins[offset_for_builtin("value_bytes")] = Arc::new(BfValueBytes {});
-    builtins[offset_for_builtin("object_bytes")] = Arc::new(BfObjectBytes {});
-    builtins[offset_for_builtin("value_hash")] = Arc::new(BfValueHash {});
-    builtins[offset_for_builtin("length")] = Arc::new(BfLength {});
+pub(crate) fn register_bf_values(builtins: &mut [Box<dyn BuiltinFunction>]) {
+    builtins[offset_for_builtin("typeof")] = Box::new(BfTypeof {});
+    builtins[offset_for_builtin("tostr")] = Box::new(BfTostr {});
+    builtins[offset_for_builtin("toliteral")] = Box::new(BfToliteral {});
+    builtins[offset_for_builtin("toint")] = Box::new(BfToint {});
+    builtins[offset_for_builtin("tonum")] = Box::new(BfToint {});
+    builtins[offset_for_builtin("tonum")] = Box::new(BfToint {});
+    builtins[offset_for_builtin("toobj")] = Box::new(BfToobj {});
+    builtins[offset_for_builtin("tofloat")] = Box::new(BfTofloat {});
+    builtins[offset_for_builtin("equal")] = Box::new(BfEqual {});
+    builtins[offset_for_builtin("value_bytes")] = Box::new(BfValueBytes {});
+    builtins[offset_for_builtin("object_bytes")] = Box::new(BfObjectBytes {});
+    builtins[offset_for_builtin("value_hash")] = Box::new(BfValueHash {});
+    builtins[offset_for_builtin("length")] = Box::new(BfLength {});
 }

--- a/crates/kernel/src/builtins/bf_verbs.rs
+++ b/crates/kernel/src/builtins/bf_verbs.rs
@@ -12,8 +12,6 @@
 // this program. If not, see <https://www.gnu.org/licenses/>.
 //
 
-use std::sync::Arc;
-
 use strum::EnumCount;
 use tracing::{error, warn};
 
@@ -33,15 +31,15 @@ use moor_values::util::BitEnum;
 use moor_values::var::Error::{E_ARGS, E_INVARG, E_INVIND, E_PERM, E_TYPE, E_VERBNF};
 use moor_values::var::List;
 use moor_values::var::Objid;
+use moor_values::var::Symbol;
 use moor_values::var::Variant;
 use moor_values::var::{v_empty_list, v_list, v_none, v_objid, v_str, v_string, Var};
-use moor_values::var::{Error, v_listv};
+use moor_values::var::{v_listv, Error};
 use moor_values::AsByteBuffer;
-use moor_values::var::Symbol;
 
 use crate::bf_declare;
 use crate::builtins::BfRet::Ret;
-use crate::builtins::{BfCallState, BfErr, BfRet, BuiltinFunction, world_state_bf_err};
+use crate::builtins::{world_state_bf_err, BfCallState, BfErr, BfRet, BuiltinFunction};
 use crate::tasks::command_parse::{parse_preposition_spec, preposition_to_string};
 
 // verb_info (obj <object>, str <verb-desc>) ->  {<owner>, <perms>, <names>}
@@ -64,7 +62,11 @@ fn bf_verb_info(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
     let verb_info = match bf_args.args[1].variant() {
         Variant::Str(verb_desc) => bf_args
             .world_state
-            .get_verb(bf_args.task_perms_who(), *obj, Symbol::mk_case_insensitive(verb_desc.as_str()))
+            .get_verb(
+                bf_args.task_perms_who(),
+                *obj,
+                Symbol::mk_case_insensitive(verb_desc.as_str()),
+            )
             .map_err(world_state_bf_err)?,
         Variant::Int(verb_index) => {
             let verb_index = *verb_index;
@@ -699,14 +701,14 @@ fn bf_disassemble(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
 }
 bf_declare!(disassemble, bf_disassemble);
 
-    pub(crate) fn register_bf_verbs(builtins: &mut [Arc<dyn BuiltinFunction>]) {
-        builtins[offset_for_builtin("verb_info")] = Arc::new(BfVerbInfo {});
-        builtins[offset_for_builtin("set_verb_info")] = Arc::new(BfSetVerbInfo {});
-        builtins[offset_for_builtin("verb_args")] = Arc::new(BfVerbArgs {});
-        builtins[offset_for_builtin("set_verb_args")] = Arc::new(BfSetVerbArgs {});
-        builtins[offset_for_builtin("verb_code")] = Arc::new(BfVerbCode {});
-        builtins[offset_for_builtin("set_verb_code")] = Arc::new(BfSetVerbCode {});
-        builtins[offset_for_builtin("add_verb")] = Arc::new(BfAddVerb {});
-        builtins[offset_for_builtin("delete_verb")] = Arc::new(BfDeleteVerb {});
-        builtins[offset_for_builtin("disassemble")] = Arc::new(BfDisassemble {});
-    }
+pub(crate) fn register_bf_verbs(builtins: &mut [Box<dyn BuiltinFunction>]) {
+    builtins[offset_for_builtin("verb_info")] = Box::new(BfVerbInfo {});
+    builtins[offset_for_builtin("set_verb_info")] = Box::new(BfSetVerbInfo {});
+    builtins[offset_for_builtin("verb_args")] = Box::new(BfVerbArgs {});
+    builtins[offset_for_builtin("set_verb_args")] = Box::new(BfSetVerbArgs {});
+    builtins[offset_for_builtin("verb_code")] = Box::new(BfVerbCode {});
+    builtins[offset_for_builtin("set_verb_code")] = Box::new(BfSetVerbCode {});
+    builtins[offset_for_builtin("add_verb")] = Box::new(BfAddVerb {});
+    builtins[offset_for_builtin("delete_verb")] = Box::new(BfDeleteVerb {});
+    builtins[offset_for_builtin("disassemble")] = Box::new(BfDisassemble {});
+}

--- a/crates/kernel/src/builtins/bf_verbs.rs
+++ b/crates/kernel/src/builtins/bf_verbs.rs
@@ -43,7 +43,6 @@ use crate::bf_declare;
 use crate::builtins::BfRet::Ret;
 use crate::builtins::{BfCallState, BfErr, BfRet, BuiltinFunction, world_state_bf_err};
 use crate::tasks::command_parse::{parse_preposition_spec, preposition_to_string};
-use crate::vm::VM;
 
 // verb_info (obj <object>, str <verb-desc>) ->  {<owner>, <perms>, <names>}
 fn bf_verb_info(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
@@ -700,16 +699,14 @@ fn bf_disassemble(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
 }
 bf_declare!(disassemble, bf_disassemble);
 
-impl VM {
-    pub(crate) fn register_bf_verbs(&mut self) {
-        self.builtins[offset_for_builtin("verb_info")] = Arc::new(BfVerbInfo {});
-        self.builtins[offset_for_builtin("set_verb_info")] = Arc::new(BfSetVerbInfo {});
-        self.builtins[offset_for_builtin("verb_args")] = Arc::new(BfVerbArgs {});
-        self.builtins[offset_for_builtin("set_verb_args")] = Arc::new(BfSetVerbArgs {});
-        self.builtins[offset_for_builtin("verb_code")] = Arc::new(BfVerbCode {});
-        self.builtins[offset_for_builtin("set_verb_code")] = Arc::new(BfSetVerbCode {});
-        self.builtins[offset_for_builtin("add_verb")] = Arc::new(BfAddVerb {});
-        self.builtins[offset_for_builtin("delete_verb")] = Arc::new(BfDeleteVerb {});
-        self.builtins[offset_for_builtin("disassemble")] = Arc::new(BfDisassemble {});
+    pub(crate) fn register_bf_verbs(builtins: &mut [Arc<dyn BuiltinFunction>]) {
+        builtins[offset_for_builtin("verb_info")] = Arc::new(BfVerbInfo {});
+        builtins[offset_for_builtin("set_verb_info")] = Arc::new(BfSetVerbInfo {});
+        builtins[offset_for_builtin("verb_args")] = Arc::new(BfVerbArgs {});
+        builtins[offset_for_builtin("set_verb_args")] = Arc::new(BfSetVerbArgs {});
+        builtins[offset_for_builtin("verb_code")] = Arc::new(BfVerbCode {});
+        builtins[offset_for_builtin("set_verb_code")] = Arc::new(BfSetVerbCode {});
+        builtins[offset_for_builtin("add_verb")] = Arc::new(BfAddVerb {});
+        builtins[offset_for_builtin("delete_verb")] = Arc::new(BfDeleteVerb {});
+        builtins[offset_for_builtin("disassemble")] = Arc::new(BfDisassemble {});
     }
-}

--- a/crates/kernel/src/builtins/mod.rs
+++ b/crates/kernel/src/builtins/mod.rs
@@ -26,6 +26,7 @@ use moor_values::var::Var;
 
 use crate::tasks::sessions::Session;
 use crate::tasks::task_scheduler_client::TaskSchedulerClient;
+use crate::vm::activation::{BfFrame, VmStackFrame};
 use crate::vm::{ExecutionResult, VMExecState};
 
 mod bf_list_sets;
@@ -66,6 +67,22 @@ impl BfCallState<'_> {
         let who = self.task_perms_who();
         let flags = self.world_state.flags_of(who)?;
         Ok(Perms { who, flags })
+    }
+
+    pub fn bf_frame(&self) -> &BfFrame {
+        let VmStackFrame::Bf(frame) = &self.exec_state.top().frame else {
+            panic!("Expected a BF frame at the top of the stack");
+        };
+
+        frame
+    }
+
+    pub fn bf_frame_mut(&mut self) -> &mut BfFrame {
+        let VmStackFrame::Bf(frame) = &mut self.exec_state.top_mut().frame else {
+            panic!("Expected a BF frame at the top of the stack");
+        };
+
+        frame
     }
 }
 

--- a/crates/kernel/src/builtins/mod.rs
+++ b/crates/kernel/src/builtins/mod.rs
@@ -14,8 +14,17 @@
 
 use std::sync::Arc;
 
+use moor_compiler::BUILTIN_DESCRIPTORS;
 use thiserror::Error;
 
+use crate::builtins::bf_list_sets::register_bf_list_sets;
+use crate::builtins::bf_num::register_bf_num;
+use crate::builtins::bf_objects::register_bf_objects;
+use crate::builtins::bf_properties::register_bf_properties;
+use crate::builtins::bf_server::{register_bf_server, BfNoop};
+use crate::builtins::bf_strings::register_bf_strings;
+use crate::builtins::bf_values::register_bf_values;
+use crate::builtins::bf_verbs::register_bf_verbs;
 use moor_values::model::Perms;
 use moor_values::model::WorldState;
 use moor_values::model::WorldStateError;
@@ -38,6 +47,40 @@ mod bf_strings;
 mod bf_values;
 mod bf_verbs;
 
+/// The bundle of builtins are stored here, and passed around globally.
+pub struct BuiltinRegistry {
+    // The set of built-in functions, indexed by their Name offset in the variable stack.
+    pub(crate) builtins: Arc<Vec<Arc<dyn BuiltinFunction>>>,
+}
+
+impl Default for BuiltinRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl BuiltinRegistry {
+    pub fn new() -> Self {
+        let mut builtins: Vec<Arc<dyn BuiltinFunction>> =
+            Vec::with_capacity(BUILTIN_DESCRIPTORS.len());
+        for _ in 0..BUILTIN_DESCRIPTORS.len() {
+            builtins.push(Arc::new(BfNoop {}))
+        }
+
+        register_bf_server(&mut builtins);
+        register_bf_num(&mut builtins);
+        register_bf_values(&mut builtins);
+        register_bf_strings(&mut builtins);
+        register_bf_list_sets(&mut builtins);
+        register_bf_objects(&mut builtins);
+        register_bf_verbs(&mut builtins);
+        register_bf_properties(&mut builtins);
+
+        BuiltinRegistry {
+            builtins: Arc::new(builtins),
+        }
+    }
+}
 /// The arguments and other state passed to a built-in function.
 pub struct BfCallState<'a> {
     /// The name of the invoked function.

--- a/crates/kernel/src/lib.rs
+++ b/crates/kernel/src/lib.rs
@@ -12,14 +12,14 @@
 // this program. If not, see <https://www.gnu.org/licenses/>.
 //
 
+pub use crate::tasks::scheduler_client::SchedulerClient;
+pub use crate::tasks::suspension::{SuspendedTask, WakeCondition};
+pub use crate::tasks::task::Task;
+pub use crate::tasks::{ServerOptions, TaskId};
+
 pub mod builtins;
 pub mod config;
 pub mod matching;
 pub mod tasks;
 pub mod textdump;
 pub mod vm;
-
-pub use crate::tasks::scheduler_client::SchedulerClient;
-pub use crate::tasks::suspension::{SuspendedTask, WakeCondition};
-pub use crate::tasks::task::Task;
-pub use crate::tasks::{ServerOptions, TaskId};

--- a/crates/kernel/src/matching/match_env.rs
+++ b/crates/kernel/src/matching/match_env.rs
@@ -12,11 +12,10 @@
 // this program. If not, see <https://www.gnu.org/licenses/>.
 //
 
-use moor_values::model::{ObjSet, ValSet};
-use moor_values::{AMBIGUOUS, FAILED_MATCH, NOTHING};
-
 use moor_values::model::WorldStateError;
+use moor_values::model::{ObjSet, ValSet};
 use moor_values::var::Objid;
+use moor_values::{AMBIGUOUS, FAILED_MATCH, NOTHING};
 
 use crate::tasks::command_parse::ParseMatcher;
 

--- a/crates/kernel/src/matching/mock_matching_env.rs
+++ b/crates/kernel/src/matching/mock_matching_env.rs
@@ -16,10 +16,10 @@ use std::collections::{HashMap, HashSet};
 
 use moor_values::model::WorldStateError;
 use moor_values::model::{ObjSet, ValSet};
+use moor_values::var::Objid;
 use moor_values::NOTHING;
 
 use crate::matching::match_env::MatchEnvironment;
-use moor_values::var::Objid;
 
 pub const MOCK_PLAYER: Objid = Objid(3);
 pub const MOCK_ROOM1: Objid = Objid(1);

--- a/crates/kernel/src/matching/ws_match_env.rs
+++ b/crates/kernel/src/matching/ws_match_env.rs
@@ -13,7 +13,6 @@
 //
 
 use moor_values::model::ObjSet;
-
 use moor_values::model::WorldState;
 use moor_values::model::WorldStateError;
 use moor_values::var::Objid;

--- a/crates/kernel/src/tasks/mod.rs
+++ b/crates/kernel/src/tasks/mod.rs
@@ -12,16 +12,18 @@
 // this program. If not, see <https://www.gnu.org/licenses/>.
 //
 
-use crate::tasks::scheduler::TaskResult;
-use crate::vm::Fork;
-use bincode::{Decode, Encode};
-use moor_compiler::Program;
-use moor_values::var::Symbol;
-use moor_values::var::{List, Objid};
 use std::fmt::Debug;
 use std::time::SystemTime;
 
+use bincode::{Decode, Encode};
+
+use moor_compiler::Program;
+use moor_values::var::Symbol;
+use moor_values::var::{List, Objid};
+
+use crate::tasks::scheduler::TaskResult;
 pub use crate::tasks::tasks_db::{NoopTasksDb, TasksDb, TasksDbError};
+use crate::vm::Fork;
 
 pub mod command_parse;
 pub mod scheduler;
@@ -115,19 +117,20 @@ impl ServerOptions {
 }
 
 pub mod vm_test_utils {
-    use crate::builtins::BuiltinRegistry;
-    use crate::tasks::sessions::Session;
-    use crate::tasks::vm_host::{VMHostResponse, VmHost};
-    use crate::tasks::VerbCall;
-    use crate::vm::UncaughtException;
-    
+    use std::sync::Arc;
+    use std::time::Duration;
+
     use moor_compiler::Program;
     use moor_values::model::WorldState;
     use moor_values::var::Symbol;
     use moor_values::var::{List, Objid, Var};
     use moor_values::SYSTEM_OBJECT;
-    use std::sync::Arc;
-    use std::time::Duration;
+
+    use crate::builtins::BuiltinRegistry;
+    use crate::tasks::sessions::Session;
+    use crate::tasks::vm_host::{VMHostResponse, VmHost};
+    use crate::tasks::VerbCall;
+    use crate::vm::UncaughtException;
 
     pub type ExecResult = Result<Var, UncaughtException>;
 
@@ -231,19 +234,21 @@ pub mod vm_test_utils {
 }
 
 pub mod scheduler_test_utils {
-    use crate::tasks::scheduler_client::SchedulerClient;
-    use crate::tasks::sessions::Session;
-    use crate::vm::UncaughtException;
-    use moor_values::model::CommandError;
-    use moor_values::var::{Error::E_VERBNF, Objid, Var};
     use std::sync::Arc;
     use std::time::Duration;
 
-    use super::scheduler::{SchedulerError, TaskResult};
-    use super::TaskHandle;
+    use moor_values::model::CommandError;
+    use moor_values::var::{Error::E_VERBNF, Objid, Var};
+
+    use crate::tasks::scheduler_client::SchedulerClient;
     use crate::tasks::scheduler_test_utils::SchedulerError::{
         CommandExecutionError, TaskAbortedException,
     };
+    use crate::tasks::sessions::Session;
+    use crate::vm::UncaughtException;
+
+    use super::scheduler::{SchedulerError, TaskResult};
+    use super::TaskHandle;
 
     pub type ExecResult = Result<Var, UncaughtException>;
 

--- a/crates/kernel/src/tasks/scheduler.rs
+++ b/crates/kernel/src/tasks/scheduler.rs
@@ -16,20 +16,17 @@ use std::collections::HashMap;
 use std::fs::File;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
+use std::thread::yield_now;
 use std::time::{Duration, Instant};
 
 use bincode::{Decode, Encode};
+use crossbeam_channel::Receiver;
 use crossbeam_channel::Sender;
-
+use lazy_static::lazy_static;
 use thiserror::Error;
 use tracing::{debug, error, info, instrument, trace, warn};
 use uuid::Uuid;
 
-use crossbeam_channel::Receiver;
-use lazy_static::lazy_static;
-use std::thread::yield_now;
-
-use crate::builtins::BuiltinRegistry;
 use moor_compiler::compile;
 use moor_compiler::CompileError;
 use moor_db::Database;
@@ -46,6 +43,7 @@ use SchedulerError::{
     TaskAbortedException, TaskAbortedLimit,
 };
 
+use crate::builtins::BuiltinRegistry;
 use crate::config::Config;
 use crate::matching::match_env::MatchEnvironmentParseMatcher;
 use crate::matching::ws_match_env::WsMatchEnv;

--- a/crates/kernel/src/tasks/scheduler_client.rs
+++ b/crates/kernel/src/tasks/scheduler_client.rs
@@ -12,18 +12,21 @@
 // this program. If not, see <https://www.gnu.org/licenses/>.
 //
 
+use std::sync::Arc;
+use std::time::Duration;
+
+use crossbeam_channel::Sender;
+use tracing::{instrument, trace};
+use uuid::Uuid;
+
+use moor_compiler::{compile, Program};
+use moor_values::var::Symbol;
+use moor_values::var::{Objid, Var};
+
 use crate::tasks::scheduler::SchedulerError;
 use crate::tasks::scheduler::SchedulerError::CompilationError;
 use crate::tasks::sessions::Session;
 use crate::tasks::TaskHandle;
-use crossbeam_channel::Sender;
-use moor_compiler::{compile, Program};
-use moor_values::var::Symbol;
-use moor_values::var::{Objid, Var};
-use std::sync::Arc;
-use std::time::Duration;
-use tracing::{instrument, trace};
-use uuid::Uuid;
 
 /// A handle for talking to the scheduler from the outside world.
 /// This is not meant to be used by running tasks, but by the rpc daemon, tests, etc.

--- a/crates/kernel/src/tasks/sessions.rs
+++ b/crates/kernel/src/tasks/sessions.rs
@@ -12,11 +12,13 @@
 // this program. If not, see <https://www.gnu.org/licenses/>.
 //
 
-use moor_values::model::NarrativeEvent;
-use moor_values::var::Objid;
 use std::sync::{Arc, RwLock};
+
 use thiserror::Error;
 use uuid::Uuid;
+
+use moor_values::model::NarrativeEvent;
+use moor_values::var::Objid;
 
 /// The interface for managing the user I/O connection side of state, exposed by the scheduler to
 /// the VM during execution and by the host server to the scheduler.

--- a/crates/kernel/src/tasks/suspension.rs
+++ b/crates/kernel/src/tasks/suspension.rs
@@ -12,20 +12,23 @@
 // this program. If not, see <https://www.gnu.org/licenses/>.
 //
 
-use crate::tasks::scheduler::TaskResult;
-use crate::tasks::sessions::{NoopClientSession, Session, SessionFactory};
-use crate::tasks::task::Task;
-use crate::tasks::{TaskDescription, TaskId, TasksDb};
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
 use bincode::de::{BorrowDecoder, Decoder};
 use bincode::enc::Encoder;
 use bincode::error::{DecodeError, EncodeError};
 use bincode::{BorrowDecode, Decode, Encode};
-use moor_values::var::Objid;
-use std::collections::HashMap;
-use std::sync::Arc;
-use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use tracing::{debug, error, info, warn};
 use uuid::Uuid;
+
+use moor_values::var::Objid;
+
+use crate::tasks::scheduler::TaskResult;
+use crate::tasks::sessions::{NoopClientSession, Session, SessionFactory};
+use crate::tasks::task::Task;
+use crate::tasks::{TaskDescription, TaskId, TasksDb};
 
 /// State a suspended task sits in inside the `suspended` side of the task queue.
 /// When tasks are not running they are moved into these.

--- a/crates/kernel/src/tasks/task.rs
+++ b/crates/kernel/src/tasks/task.rs
@@ -591,6 +591,7 @@ mod tests {
     use crate::tasks::task::Task;
     use crate::tasks::task_scheduler_client::{TaskControlMsg, TaskSchedulerClient};
     use crate::tasks::{ServerOptions, TaskId, TaskStart};
+    use crate::vm::activation::VmStackFrame;
     use crossbeam_channel::{unbounded, Receiver};
     use moor_compiler::compile;
     use moor_db_wiredtiger::WiredTigerDB;
@@ -820,7 +821,14 @@ mod tests {
         };
         assert_eq!(fork_request.task_id, None);
         assert_eq!(fork_request.parent_task_id, 1);
-        assert_eq!(fork_request.activation.frame.program, *program);
+
+        let VmStackFrame::Moo(moo_frame) = &fork_request.activation.frame else {
+            panic!(
+                "Expected Moo frame, got {:?}",
+                fork_request.activation.frame
+            );
+        };
+        assert_eq!(moo_frame.program, *program);
 
         // Reply back with the new task id.
         reply_channel.send(2).unwrap();

--- a/crates/kernel/src/tasks/task_scheduler_client.rs
+++ b/crates/kernel/src/tasks/task_scheduler_client.rs
@@ -12,19 +12,21 @@
 // this program. If not, see <https://www.gnu.org/licenses/>.
 //
 
-use crate::tasks::scheduler::AbortLimitReason;
-use crate::tasks::{TaskDescription, TaskId};
-use crate::vm::vm_unwind::UncaughtException;
-use crate::vm::Fork;
+use std::time::Instant;
 
-use crate::tasks::task::Task;
 use crossbeam_channel::Sender;
+
 use moor_values::model::Perms;
 use moor_values::model::{CommandError, NarrativeEvent};
 use moor_values::var::Objid;
 use moor_values::var::Symbol;
 use moor_values::var::Var;
-use std::time::Instant;
+
+use crate::tasks::scheduler::AbortLimitReason;
+use crate::tasks::task::Task;
+use crate::tasks::{TaskDescription, TaskId};
+use crate::vm::vm_unwind::UncaughtException;
+use crate::vm::Fork;
 
 /// A handle for talking to the scheduler from within a task.
 #[derive(Clone)]

--- a/crates/kernel/src/tasks/vm_host.rs
+++ b/crates/kernel/src/tasks/vm_host.rs
@@ -376,7 +376,7 @@ impl VmHost {
         if !self.vm_exec_state.stack.is_empty() {
             // coming back from any suspend, we need a return value to feed back to `bf_suspend` or
             // `bf_read()`
-            self.vm_exec_state.top_mut().frame.push(value);
+            self.vm_exec_state.set_return_value(value);
         }
 
         debug!(task_id = self.vm_exec_state.task_id, "Resuming VMHost");
@@ -403,9 +403,10 @@ impl VmHost {
         self.vm_exec_state
             .top_mut()
             .frame
-            .set_var_offset(task_id_var, value)
+            .set_variable(task_id_var, value)
             .expect("Could not set forked task id");
     }
+
     pub fn permissions(&self) -> Objid {
         self.vm_exec_state.top().permissions
     }
@@ -419,11 +420,7 @@ impl VmHost {
         self.vm_exec_state.top().this
     }
     pub fn line_number(&self) -> usize {
-        self.vm_exec_state
-            .top()
-            .frame
-            .find_line_no(self.vm_exec_state.top().frame.pc)
-            .unwrap_or(0)
+        self.vm_exec_state.top().frame.find_line_no().unwrap_or(0)
     }
 
     pub fn reset_ticks(&mut self) {

--- a/crates/kernel/src/tasks/vm_host.rs
+++ b/crates/kernel/src/tasks/vm_host.rs
@@ -265,13 +265,8 @@ impl VmHost {
                     resolved_verb,
                     call,
                     command,
-                    trampoline,
-                    trampoline_arg,
                 } => {
                     trace!(task_id, call = ?call, "Task continue, call into verb");
-
-                    self.vm_exec_state.top_mut().bf_trampoline_arg = trampoline_arg;
-                    self.vm_exec_state.top_mut().bf_trampoline = trampoline;
 
                     let program = Self::decode_program(
                         resolved_verb.verbdef().binary_type(),

--- a/crates/kernel/src/textdump/read.rs
+++ b/crates/kernel/src/textdump/read.rs
@@ -15,17 +15,17 @@
 use std::collections::BTreeMap;
 use std::io::{BufRead, BufReader, Read};
 
-use moor_values::model::WorldStateError;
 use text_io::scan;
 use tracing::info;
 
 use moor_compiler::CompileError;
+use moor_compiler::Label;
+use moor_values::model::WorldStateError;
 use moor_values::var::Objid;
 use moor_values::var::{v_err, v_float, v_int, v_none, v_objid, v_str, Var, VarType};
 use moor_values::var::{v_listv, Error};
 
 use crate::textdump::{Object, Propval, Textdump, Verb, Verbdef};
-use moor_compiler::Label;
 
 pub const TYPE_CLEAR: i64 = 5;
 

--- a/crates/kernel/src/vm/activation.rs
+++ b/crates/kernel/src/vm/activation.rs
@@ -145,10 +145,7 @@ fn set_constants(f: &mut VmStackFrame) {
 
 impl Activation {
     pub fn is_builtin_frame(&self) -> bool {
-        match self.frame {
-            VmStackFrame::Bf(_) => true,
-            _ => false,
-        }
+        matches!(self.frame, VmStackFrame::Bf(_))
     }
 
     pub fn for_call(verb_call_request: VerbExecutionRequest) -> Self {

--- a/crates/kernel/src/vm/activation.rs
+++ b/crates/kernel/src/vm/activation.rs
@@ -30,6 +30,7 @@ use moor_values::var::{v_empty_list, v_int, v_objid, v_str, v_string, Var, VarTy
 
 use crate::tasks::command_parse::ParsedCommand;
 use crate::vm::frame::Frame;
+use crate::vm::vm_call::VerbProgram;
 use crate::vm::VerbExecutionRequest;
 use moor_compiler::Program;
 use moor_values::var::Symbol;
@@ -148,9 +149,14 @@ impl Activation {
         matches!(self.frame, VmStackFrame::Bf(_))
     }
 
+    #[allow(irrefutable_let_patterns)] // We know this is a Moo frame. We're just making room
     pub fn for_call(verb_call_request: VerbExecutionRequest) -> Self {
         let program = verb_call_request.program;
         let verb_owner = verb_call_request.resolved_verb.verbdef().owner();
+
+        let VerbProgram::MOO(program) = program else {
+            unimplemented!("Only MOO programs are supported")
+        };
         let frame = Frame::new(program);
         let mut frame = VmStackFrame::Moo(frame);
         set_constants(&mut frame);

--- a/crates/kernel/src/vm/exec_state.rs
+++ b/crates/kernel/src/vm/exec_state.rs
@@ -12,14 +12,17 @@
 // this program. If not, see <https://www.gnu.org/licenses/>.
 //
 
-use crate::tasks::TaskId;
-use crate::vm::activation::{Activation, VmStackFrame};
+use std::time::{Duration, SystemTime};
+
 use bincode::{Decode, Encode};
 use daumtils::PhantomUnsync;
+
 use moor_values::var::Var;
 use moor_values::var::{Objid, Symbol};
 use moor_values::NOTHING;
-use std::time::{Duration, SystemTime};
+
+use crate::tasks::TaskId;
+use crate::vm::activation::{Activation, Frame};
 
 // {this, verb-name, programmer, verb-loc, player, line-number}
 #[derive(Clone)]
@@ -88,7 +91,7 @@ impl VMExecState {
             let this = activation.this;
             let perms = activation.permissions;
             let programmer = match activation.frame {
-                VmStackFrame::Bf(_) => NOTHING,
+                Frame::Bf(_) => NOTHING,
                 _ => perms,
             };
             callers.push(Caller {
@@ -119,7 +122,7 @@ impl VMExecState {
 
         // Skip builtin-frames (for now?)
         for activation in stack_iter {
-            if let VmStackFrame::Bf(_) = activation.frame {
+            if let Frame::Bf(_) = activation.frame {
                 continue;
             }
             return activation.this;

--- a/crates/kernel/src/vm/exec_state.rs
+++ b/crates/kernel/src/vm/exec_state.rs
@@ -13,13 +13,24 @@
 //
 
 use crate::tasks::TaskId;
-use crate::vm::activation::{Activation, Caller};
+use crate::vm::activation::Activation;
 use bincode::{Decode, Encode};
 use daumtils::PhantomUnsync;
-use moor_values::var::Objid;
 use moor_values::var::Var;
+use moor_values::var::{Objid, Symbol};
 use moor_values::NOTHING;
 use std::time::{Duration, SystemTime};
+
+// {this, verb-name, programmer, verb-loc, player, line-number}
+#[derive(Clone)]
+pub struct Caller {
+    pub this: Objid,
+    pub verb_name: Symbol,
+    pub programmer: Objid,
+    pub definer: Objid,
+    pub player: Objid,
+    pub line_number: usize,
+}
 
 /// Represents the state of VM execution.
 /// The actual "VM" remains stateless and could be potentially re-used for multiple tasks,

--- a/crates/kernel/src/vm/exec_state.rs
+++ b/crates/kernel/src/vm/exec_state.rs
@@ -157,16 +157,10 @@ impl VMExecState {
         self.top_mut().permissions = perms;
     }
 
-    /// Pop a value off the value stack.
-    #[inline]
-    pub(crate) fn pop(&mut self) -> Var {
-        self.top_mut().frame.pop()
-    }
-
     /// Push a value onto the value stack
     #[inline]
-    pub(crate) fn push(&mut self, v: Var) {
-        self.top_mut().frame.push(v)
+    pub(crate) fn set_return_value(&mut self, v: Var) {
+        self.top_mut().frame.set_return_value(v);
     }
 
     pub(crate) fn time_left(&self) -> Option<Duration> {

--- a/crates/kernel/src/vm/frame.rs
+++ b/crates/kernel/src/vm/frame.rs
@@ -1,0 +1,278 @@
+// Copyright (C) 2024 Ryan Daum <ryan.daum@gmail.com>
+//
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free Software
+// Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program. If not, see <https://www.gnu.org/licenses/>.
+//
+
+use bincode::de::{BorrowDecoder, Decoder};
+use bincode::enc::Encoder;
+use bincode::error::{DecodeError, EncodeError};
+use bincode::{BorrowDecode, Decode, Encode};
+use daumtils::{BitArray, Bitset16};
+use moor_compiler::{GlobalName, Label, Name, Op, Program};
+use moor_values::var::Error::E_VARNF;
+use moor_values::var::{v_none, Error, Var};
+
+/// The MOO stack-frame specific portions of the activation:
+///   the value stack, local variables, program, program counter, handler stack, etc.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct Frame {
+    /// The program of the verb that is currently being executed.
+    pub(crate) program: Program,
+    /// The program counter.
+    pub(crate) pc: usize,
+    // TODO: Language enhancement: Introduce lexical scopes to the MOO language:
+    //      add a 'with' keyword to the language which introduces a new scope, similar to ML's "let":
+    //              with x = 1 in
+    //                     ...
+    //              endlet
+    //      Multiple variables can be introduced at once:
+    //              with x = 1, y = 2 in ...
+    //      Variables not declared with 'with' are verb-scoped as they are now
+    //      'with' variables that shadow already-known verb-scoped variables override the verb-scope
+    //      Add LetBegin and LetEnd opcodes to the language.
+    //      Make the environment have a width, and expand and contract as scopes are entered and exited.
+    //      Likewise, Names in Program should be scope delimited somehow
+    /// The values of the variables currently in scope, by their offset.
+    pub(crate) environment: BitArray<Var, 256, Bitset16<16>>,
+    /// The value stack.
+    pub(crate) valstack: Vec<Var>,
+    /// A stack of active error handlers, each relative to a position in the valstack.
+    pub(crate) handler_stack: Vec<HandlerLabel>,
+    /// Scratch space for PushTemp and PutTemp opcodes.
+    pub(crate) temp: Var,
+}
+
+// A Label that exists in a separate stack but is *relevant* only for the `valstack_pos`
+// That is:
+//   when created, the stack's current size is stored in `valstack_pos`
+//   when popped off in unwind, the valstack's size is eaten back to pos.
+#[derive(Debug, Clone, PartialEq, Eq, Encode, Decode)]
+pub(crate) enum HandlerType {
+    Catch(usize),
+    CatchLabel(Label),
+    Finally(Label),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Encode, Decode)]
+pub(crate) struct HandlerLabel {
+    pub(crate) handler_type: HandlerType,
+    pub(crate) valstack_pos: usize,
+}
+
+impl Encode for Frame {
+    fn encode<E: Encoder>(&self, encoder: &mut E) -> Result<(), EncodeError> {
+        self.program.encode(encoder)?;
+        self.pc.encode(encoder)?;
+
+        // Environment is custom, is not bincodable, so we need to encode it manually, but we just
+        // do it as an array of Option<Var>
+        let mut env = vec![None; self.environment.len()];
+        let env_iter = self.environment.iter();
+        for (i, v) in env_iter {
+            env[i] = Some(v.clone())
+        }
+        env.encode(encoder)?;
+        self.valstack.encode(encoder)?;
+        self.handler_stack.encode(encoder)?;
+        self.temp.encode(encoder)
+    }
+}
+
+impl Decode for Frame {
+    fn decode<D: Decoder>(decoder: &mut D) -> Result<Self, DecodeError> {
+        let program = Program::decode(decoder)?;
+        let pc = usize::decode(decoder)?;
+
+        let env: Vec<Option<Var>> = Vec::decode(decoder)?;
+        let mut environment = BitArray::new();
+        for (i, v) in env.iter().enumerate() {
+            if let Some(v) = v {
+                environment.set(i, v.clone());
+            }
+        }
+
+        let valstack = Vec::decode(decoder)?;
+        let handler_stack = Vec::decode(decoder)?;
+        let temp = Var::decode(decoder)?;
+
+        Ok(Self {
+            program,
+            pc,
+            environment,
+            valstack,
+            handler_stack,
+            temp,
+        })
+    }
+}
+
+impl<'de> BorrowDecode<'de> for Frame {
+    fn borrow_decode<D: BorrowDecoder<'de>>(decoder: &mut D) -> Result<Self, DecodeError> {
+        let program = Program::borrow_decode(decoder)?;
+        let pc = usize::borrow_decode(decoder)?;
+
+        let env: Vec<Option<Var>> = Vec::borrow_decode(decoder)?;
+        let mut environment = BitArray::new();
+        for (i, v) in env.iter().enumerate() {
+            if let Some(v) = v {
+                environment.set(i, v.clone());
+            }
+        }
+
+        let valstack = Vec::borrow_decode(decoder)?;
+        let handler_stack = Vec::borrow_decode(decoder)?;
+        let temp = Var::borrow_decode(decoder)?;
+
+        Ok(Self {
+            program,
+            pc,
+            environment,
+            valstack,
+            handler_stack,
+            temp,
+        })
+    }
+}
+
+impl Frame {
+    pub(crate) fn new(program: Program) -> Self {
+        let environment = BitArray::new();
+
+        Self {
+            program,
+            environment,
+            valstack: vec![],
+            handler_stack: vec![],
+            pc: 0,
+            temp: v_none(),
+        }
+    }
+    pub(crate) fn find_line_no(&self, pc: usize) -> Option<usize> {
+        if self.program.line_number_spans.is_empty() {
+            return None;
+        }
+        // Seek through the line # spans looking for the first offset (first part of tuple) which is
+        // equal to or higher than `pc`. If we don't find one, return the last one.
+        let mut last_line_num = 1;
+        for (offset, line_no) in &self.program.line_number_spans {
+            if *offset >= pc {
+                return Some(last_line_num);
+            }
+            last_line_num = *line_no
+        }
+        Some(last_line_num)
+    }
+
+    #[inline]
+    pub fn set_gvar(&mut self, gname: GlobalName, value: Var) {
+        self.environment.set(gname as usize, value);
+    }
+
+    #[inline]
+    pub fn set_env(&mut self, id: &Name, v: Var) {
+        self.environment.set(id.0 as usize, v);
+    }
+
+    /// Return the value of a local variable.
+    #[inline]
+    pub(crate) fn get_env(&self, id: &Name) -> Option<&Var> {
+        self.environment.get(id.0 as usize)
+    }
+
+    #[inline]
+    pub fn set_var_offset(&mut self, offset: &Name, value: Var) -> Result<(), Error> {
+        if offset.0 as usize >= self.environment.len() {
+            return Err(E_VARNF);
+        }
+        self.environment.set(offset.0 as usize, value);
+        Ok(())
+    }
+
+    #[inline]
+    pub fn lookahead(&self) -> Option<Op> {
+        self.program.main_vector.get(self.pc).cloned()
+    }
+
+    #[inline]
+    pub fn skip(&mut self) {
+        self.pc += 1;
+    }
+
+    #[inline]
+    pub fn pop(&mut self) -> Var {
+        self.valstack
+            .pop()
+            .unwrap_or_else(|| panic!("stack underflow @ PC: {}", self.pc))
+    }
+
+    #[inline]
+    pub fn push(&mut self, v: Var) {
+        self.valstack.push(v)
+    }
+
+    #[inline]
+    pub fn peek_top(&self) -> &Var {
+        self.valstack.last().expect("stack underflow")
+    }
+
+    #[inline]
+    pub fn peek_top_mut(&mut self) -> &mut Var {
+        self.valstack.last_mut().expect("stack underflow")
+    }
+
+    #[inline]
+    pub fn peek_range(&self, width: usize) -> Vec<Var> {
+        let l = self.valstack.len();
+        Vec::from(&self.valstack[l - width..])
+    }
+
+    #[inline]
+    pub(crate) fn peek_abs(&self, amt: usize) -> &Var {
+        &self.valstack[amt]
+    }
+
+    #[inline]
+    pub fn peek2(&self) -> (&Var, &Var) {
+        let l = self.valstack.len();
+        let (a, b) = (&self.valstack[l - 1], &self.valstack[l - 2]);
+        (a, b)
+    }
+
+    #[inline]
+    pub fn poke(&mut self, amt: usize, v: Var) {
+        let l = self.valstack.len();
+        self.valstack[l - amt - 1] = v;
+    }
+
+    #[inline]
+    pub fn jump(&mut self, label_id: &Label) {
+        let label = &self.program.jump_labels[label_id.0 as usize];
+        self.pc = label.position.0 as usize;
+    }
+
+    pub fn push_handler_label(&mut self, handler_type: HandlerType) {
+        self.handler_stack.push(HandlerLabel {
+            handler_type,
+            valstack_pos: self.valstack.len(),
+        });
+    }
+
+    pub fn pop_applicable_handler(&mut self) -> Option<HandlerLabel> {
+        if self.handler_stack.is_empty() {
+            return None;
+        }
+        if self.handler_stack[self.handler_stack.len() - 1].valstack_pos != self.valstack.len() {
+            return None;
+        }
+        self.handler_stack.pop()
+    }
+}

--- a/crates/kernel/src/vm/mod.rs
+++ b/crates/kernel/src/vm/mod.rs
@@ -17,11 +17,17 @@
 //! Aims to be semantically identical, so as to be able to run existing LambdaMOO compatible cores
 //! without blocking issues.
 
-pub(crate) mod activation;
-pub(crate) mod exec_state;
-pub(crate) mod vm_call;
-pub(crate) mod vm_execute;
-pub(crate) mod vm_unwind;
+use std::sync::Arc;
+use std::time::Duration;
+
+use bincode::{Decode, Encode};
+
+pub use exec_state::VMExecState;
+use moor_compiler::{Name, Offset, Program};
+use moor_values::model::VerbInfo;
+use moor_values::var::{Objid, Var};
+pub use vm_call::VerbExecutionRequest;
+pub use vm_unwind::{FinallyReason, UncaughtException};
 
 // Exports to the rest of the kernel
 use crate::builtins::BuiltinRegistry;
@@ -29,17 +35,14 @@ use crate::tasks::command_parse::ParsedCommand;
 use crate::tasks::task_scheduler_client::TaskSchedulerClient;
 use crate::tasks::VerbCall;
 use crate::vm::activation::Activation;
-use bincode::{Decode, Encode};
-pub use exec_state::VMExecState;
-use moor_compiler::{Name, Offset, Program};
-use moor_values::model::VerbInfo;
-use moor_values::var::{Objid, Var};
-use std::sync::Arc;
-use std::time::Duration;
-pub use vm_call::VerbExecutionRequest;
-pub use vm_unwind::{FinallyReason, UncaughtException};
 
-mod frame;
+pub(crate) mod activation;
+pub(crate) mod exec_state;
+pub(crate) mod moo_execute;
+pub(crate) mod vm_call;
+pub(crate) mod vm_unwind;
+
+mod moo_frame;
 #[cfg(test)]
 mod vm_test;
 

--- a/crates/kernel/src/vm/mod.rs
+++ b/crates/kernel/src/vm/mod.rs
@@ -37,7 +37,6 @@ use moor_values::var::{Objid, Var};
 use std::sync::Arc;
 use std::time::Duration;
 pub use vm_call::VerbExecutionRequest;
-pub use vm_execute::VM;
 pub use vm_unwind::{FinallyReason, UncaughtException};
 
 mod frame;

--- a/crates/kernel/src/vm/mod.rs
+++ b/crates/kernel/src/vm/mod.rs
@@ -36,6 +36,7 @@ pub use vm_call::VerbExecutionRequest;
 pub use vm_execute::{ExecutionResult, Fork, VmExecParams};
 pub use vm_unwind::{FinallyReason, UncaughtException};
 
+mod frame;
 #[cfg(test)]
 mod vm_test;
 

--- a/crates/kernel/src/vm/moo_execute.rs
+++ b/crates/kernel/src/vm/moo_execute.rs
@@ -479,15 +479,6 @@ pub fn moo_frame_execute(
                     }
                 }
             }
-            Op::GPut { id } => {
-                f.set_env(id, f.peek_top().clone());
-            }
-            Op::GPush { id } => {
-                let Some(v) = f.get_env(id) else {
-                    return state.push_error(E_VARNF);
-                };
-                f.push(v.clone());
-            }
             Op::Length(offset) => {
                 let v = f.peek_abs(offset.0 as usize);
                 match v.len() {

--- a/crates/kernel/src/vm/moo_frame.rs
+++ b/crates/kernel/src/vm/moo_frame.rs
@@ -17,6 +17,7 @@ use bincode::enc::Encoder;
 use bincode::error::{DecodeError, EncodeError};
 use bincode::{BorrowDecode, Decode, Encode};
 use daumtils::{BitArray, Bitset16};
+
 use moor_compiler::{GlobalName, Label, Name, Op, Program};
 use moor_values::var::Error::E_VARNF;
 use moor_values::var::{v_none, Error, Var};
@@ -24,7 +25,7 @@ use moor_values::var::{v_none, Error, Var};
 /// The MOO stack-frame specific portions of the activation:
 ///   the value stack, local variables, program, program counter, handler stack, etc.
 #[derive(Debug, Clone, PartialEq)]
-pub(crate) struct Frame {
+pub(crate) struct MooStackFrame {
     /// The program of the verb that is currently being executed.
     pub(crate) program: Program,
     /// The program counter.
@@ -68,7 +69,7 @@ pub(crate) struct HandlerLabel {
     pub(crate) valstack_pos: usize,
 }
 
-impl Encode for Frame {
+impl Encode for MooStackFrame {
     fn encode<E: Encoder>(&self, encoder: &mut E) -> Result<(), EncodeError> {
         self.program.encode(encoder)?;
         self.pc.encode(encoder)?;
@@ -87,7 +88,7 @@ impl Encode for Frame {
     }
 }
 
-impl Decode for Frame {
+impl Decode for MooStackFrame {
     fn decode<D: Decoder>(decoder: &mut D) -> Result<Self, DecodeError> {
         let program = Program::decode(decoder)?;
         let pc = usize::decode(decoder)?;
@@ -115,7 +116,7 @@ impl Decode for Frame {
     }
 }
 
-impl<'de> BorrowDecode<'de> for Frame {
+impl<'de> BorrowDecode<'de> for MooStackFrame {
     fn borrow_decode<D: BorrowDecoder<'de>>(decoder: &mut D) -> Result<Self, DecodeError> {
         let program = Program::borrow_decode(decoder)?;
         let pc = usize::borrow_decode(decoder)?;
@@ -143,7 +144,7 @@ impl<'de> BorrowDecode<'de> for Frame {
     }
 }
 
-impl Frame {
+impl MooStackFrame {
     pub(crate) fn new(program: Program) -> Self {
         let environment = BitArray::new();
 

--- a/crates/kernel/src/vm/vm_call.rs
+++ b/crates/kernel/src/vm/vm_call.rs
@@ -53,7 +53,12 @@ pub struct VerbExecutionRequest {
     /// The parsed user command that led to this verb dispatch, if any.
     pub command: Option<ParsedCommand>,
     /// The decoded MOO Binary that contains the verb to be executed.
-    pub program: Program,
+    pub program: VerbProgram,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum VerbProgram {
+    MOO(Program),
 }
 
 impl VMExecState {

--- a/crates/kernel/src/vm/vm_execute.rs
+++ b/crates/kernel/src/vm/vm_execute.rs
@@ -36,12 +36,13 @@ use moor_values::var::{v_bool, v_empty_list, v_err, v_int, v_list, v_none, v_obj
 use moor_values::var::{v_float, Objid};
 use moor_values::var::{v_listv, Error};
 
-use crate::vm::activation::{Activation, HandlerType};
+use crate::vm::activation::Activation;
+use crate::vm::frame::HandlerType;
 use crate::vm::vm_unwind::{FinallyReason, UncaughtException};
 use crate::vm::{VMExecState, VM};
 
 /// The set of parameters for a VM-requested fork.
-#[derive(Debug, Clone, PartialEq, Encode, Decode)]
+#[derive(Debug, Clone, Encode, Decode)]
 pub struct Fork {
     /// The player. This is in the activation as well, but it's nicer to have it up here and
     /// explicit
@@ -68,7 +69,7 @@ pub struct VmExecParams {
     pub task_scheduler_client: TaskSchedulerClient,
     pub max_stack_depth: usize,
 }
-#[derive(PartialEq, Debug, Clone)]
+#[derive(Debug, Clone)]
 pub enum ExecutionResult {
     /// Execution of this call stack is complete.
     Complete(Var),

--- a/crates/kernel/src/vm/vm_test.rs
+++ b/crates/kernel/src/vm/vm_test.rs
@@ -32,6 +32,7 @@ mod tests {
     use moor_values::NOTHING;
     use moor_values::{AsByteBuffer, SYSTEM_OBJECT};
 
+    use crate::builtins::BuiltinRegistry;
     use crate::tasks::sessions::NoopClientSession;
     use crate::tasks::vm_test_utils::call_verb;
     use moor_compiler::compile;
@@ -108,7 +109,13 @@ mod tests {
         let state_source = test_db_with_verb("test", &program);
         let mut state = state_source.new_world_state().unwrap();
         let session = Arc::new(NoopClientSession::new());
-        let result = call_verb(state.as_mut(), session, "test", vec![]);
+        let result = call_verb(
+            state.as_mut(),
+            session,
+            Arc::new(BuiltinRegistry::new()),
+            "test",
+            vec![],
+        );
         assert_eq!(result, Ok(v_none()));
     }
 
@@ -124,7 +131,13 @@ mod tests {
         );
         let mut state = state_source.new_world_state().unwrap();
         let session = Arc::new(NoopClientSession::new());
-        let result = call_verb(state.as_mut(), session, "test", vec![]);
+        let result = call_verb(
+            state.as_mut(),
+            session,
+            Arc::new(BuiltinRegistry::new()),
+            "test",
+            vec![],
+        );
 
         assert_eq!(result, Ok(v_str("e")));
     }
@@ -149,7 +162,13 @@ mod tests {
         .new_world_state()
         .unwrap();
         let session = Arc::new(NoopClientSession::new());
-        let result = call_verb(state.as_mut(), session, "test", vec![]);
+        let result = call_verb(
+            state.as_mut(),
+            session,
+            Arc::new(BuiltinRegistry::new()),
+            "test",
+            vec![],
+        );
 
         assert_eq!(result, Ok(v_str("ell")));
     }
@@ -167,7 +186,13 @@ mod tests {
         .new_world_state()
         .unwrap();
         let session = Arc::new(NoopClientSession::new());
-        let result = call_verb(state.as_mut(), session, "test", vec![]);
+        let result = call_verb(
+            state.as_mut(),
+            session,
+            Arc::new(BuiltinRegistry::new()),
+            "test",
+            vec![],
+        );
 
         assert_eq!(result, Ok(v_int(222)));
     }
@@ -196,7 +221,13 @@ mod tests {
         .new_world_state()
         .unwrap();
         let session = Arc::new(NoopClientSession::new());
-        let result = call_verb(state.as_mut(), session, "test", vec![]);
+        let result = call_verb(
+            state.as_mut(),
+            session,
+            Arc::new(BuiltinRegistry::new()),
+            "test",
+            vec![],
+        );
         assert_eq!(result, Ok(v_list(&[222.into(), 333.into()])));
     }
 
@@ -237,7 +268,13 @@ mod tests {
         .new_world_state()
         .unwrap();
         let session = Arc::new(NoopClientSession::new());
-        let result = call_verb(state.as_mut(), session, "test", vec![]);
+        let result = call_verb(
+            state.as_mut(),
+            session,
+            Arc::new(BuiltinRegistry::new()),
+            "test",
+            vec![],
+        );
         assert_eq!(result, Ok(v_list(&[111.into(), 321.into(), 123.into()])));
     }
 
@@ -249,7 +286,13 @@ mod tests {
             .new_world_state()
             .unwrap();
         let session = Arc::new(NoopClientSession::new());
-        let result = call_verb(state.as_mut(), session, "test", vec![]);
+        let result = call_verb(
+            state.as_mut(),
+            session,
+            Arc::new(BuiltinRegistry::new()),
+            "test",
+            vec![],
+        );
         assert_eq!(result, Ok(v_list(&[2.into(), 3.into(), 4.into()])));
     }
 
@@ -260,7 +303,13 @@ mod tests {
             .new_world_state()
             .unwrap();
         let session = Arc::new(NoopClientSession::new());
-        let result = call_verb(state.as_mut(), session, "test", vec![]);
+        let result = call_verb(
+            state.as_mut(),
+            session,
+            Arc::new(BuiltinRegistry::new()),
+            "test",
+            vec![],
+        );
         assert_eq!(result, Ok(v_int(1)));
     }
 
@@ -297,7 +346,14 @@ mod tests {
         .new_world_state()
         .unwrap();
         let session = Arc::new(NoopClientSession::new());
-        let result = call_verb(state.as_mut(), session, "test", vec![]);
+
+        let result = call_verb(
+            state.as_mut(),
+            session,
+            Arc::new(BuiltinRegistry::new()),
+            "test",
+            vec![],
+        );
         assert_eq!(result, Ok(v_str("manbozorian")));
     }
 
@@ -327,7 +383,13 @@ mod tests {
                 .unwrap();
         }
         let session = Arc::new(NoopClientSession::new());
-        let result = call_verb(state.as_mut(), session, "test", vec![]);
+        let result = call_verb(
+            state.as_mut(),
+            session,
+            Arc::new(BuiltinRegistry::new()),
+            "test",
+            vec![],
+        );
         assert_eq!(result, Ok(v_int(666)));
     }
 
@@ -362,7 +424,13 @@ mod tests {
         .new_world_state()
         .unwrap();
         let session = Arc::new(NoopClientSession::new());
-        let result = call_verb(state.as_mut(), session, "test_call_verb", vec![]);
+        let result = call_verb(
+            state.as_mut(),
+            session,
+            Arc::new(BuiltinRegistry::new()),
+            "test_call_verb",
+            vec![],
+        );
 
         assert_eq!(result, Ok(v_int(666)));
     }
@@ -378,7 +446,13 @@ mod tests {
         let program = "x = 1; y = {1,2,3}; x = x + y[2]; return x;";
         let mut state = world_with_test_program(program);
         let session = Arc::new(NoopClientSession::new());
-        let result = call_verb(state.as_mut(), session, "test", vec![]);
+        let result = call_verb(
+            state.as_mut(),
+            session,
+            Arc::new(BuiltinRegistry::new()),
+            "test",
+            vec![],
+        );
         assert_eq!(result, Ok(v_int(3)));
     }
 
@@ -388,7 +462,13 @@ mod tests {
             "x = 0; while (x<100) x = x + 1; if (x == 75) break; endif endwhile return x;";
         let mut state = world_with_test_program(program);
         let session = Arc::new(NoopClientSession::new());
-        let result = call_verb(state.as_mut(), session, "test", vec![]);
+        let result = call_verb(
+            state.as_mut(),
+            session,
+            Arc::new(BuiltinRegistry::new()),
+            "test",
+            vec![],
+        );
         assert_eq!(result, Ok(v_int(75)));
     }
 
@@ -398,7 +478,13 @@ mod tests {
         let mut state = world_with_test_program(program);
 
         let session = Arc::new(NoopClientSession::new());
-        let result = call_verb(state.as_mut(), session, "test", vec![]);
+        let result = call_verb(
+            state.as_mut(),
+            session,
+            Arc::new(BuiltinRegistry::new()),
+            "test",
+            vec![],
+        );
 
         assert_eq!(result, Ok(v_int(50)));
     }
@@ -408,7 +494,13 @@ mod tests {
         let program = "x = 0; while (1) x = x + 1; if (x == 50) break; endif endwhile return x;";
         let mut state = world_with_test_program(program);
         let session = Arc::new(NoopClientSession::new());
-        let result = call_verb(state.as_mut(), session, "test", vec![]);
+        let result = call_verb(
+            state.as_mut(),
+            session,
+            Arc::new(BuiltinRegistry::new()),
+            "test",
+            vec![],
+        );
 
         assert_eq!(result, Ok(v_int(50)));
     }
@@ -431,7 +523,13 @@ mod tests {
         "#;
         let mut state = world_with_test_program(program);
         let session = Arc::new(NoopClientSession::new());
-        let result = call_verb(state.as_mut(), session, "test", vec![]);
+        let result = call_verb(
+            state.as_mut(),
+            session,
+            Arc::new(BuiltinRegistry::new()),
+            "test",
+            vec![],
+        );
 
         assert_eq!(result, Ok(v_int(50)));
     }
@@ -453,7 +551,13 @@ mod tests {
         "#;
         let mut state = world_with_test_program(program);
         let session = Arc::new(NoopClientSession::new());
-        let result = call_verb(state.as_mut(), session, "test", vec![]);
+        let result = call_verb(
+            state.as_mut(),
+            session,
+            Arc::new(BuiltinRegistry::new()),
+            "test",
+            vec![],
+        );
 
         assert_eq!(result, Ok(v_list(&[v_int(3), v_int(2), v_int(1)])));
     }
@@ -473,7 +577,13 @@ mod tests {
         "#;
         let mut state = world_with_test_program(program);
         let session = Arc::new(NoopClientSession::new());
-        let result = call_verb(state.as_mut(), session, "test", vec![]);
+        let result = call_verb(
+            state.as_mut(),
+            session,
+            Arc::new(BuiltinRegistry::new()),
+            "test",
+            vec![],
+        );
 
         assert_eq!(result, Ok(v_int(6)));
     }
@@ -494,9 +604,11 @@ mod tests {
                          endtry"#;
         let mut state = world_with_test_program(program);
         let session = Arc::new(NoopClientSession::new());
+        let builtin_registry = Arc::new(BuiltinRegistry::new());
         let result = call_verb(
             state.as_mut(),
             session,
+            builtin_registry,
             "test",
             vec![v_objid(SYSTEM_OBJECT), v_obj(32)],
         );
@@ -511,7 +623,15 @@ mod tests {
             r#"try 5; except error (E_RANGE) return 1; endtry for x in [1..1] return 5; endfor"#;
         let mut state = world_with_test_program(program);
         let session = Arc::new(NoopClientSession::new());
-        let result = call_verb(state.as_mut(), session.clone(), "test", vec![]);
+        let builtin_registry = Arc::new(BuiltinRegistry::new());
+
+        let result = call_verb(
+            state.as_mut(),
+            session.clone(),
+            builtin_registry,
+            "test",
+            vec![],
+        );
         assert_eq!(result, Ok(v_int(5)));
     }
 
@@ -530,7 +650,15 @@ mod tests {
             .new_world_state()
             .unwrap();
         let session = Arc::new(NoopClientSession::new());
-        let result = call_verb(state.as_mut(), session.clone(), "test", vec![]);
+        let builtin_registry = Arc::new(BuiltinRegistry::new());
+
+        let result = call_verb(
+            state.as_mut(),
+            session.clone(),
+            builtin_registry,
+            "test",
+            vec![],
+        );
         assert_eq!(result, Ok(v_none()));
     }
 
@@ -628,7 +756,13 @@ mod tests {
     fn test_run(program: &str, expected_result: Var) {
         let mut state = world_with_test_program(program);
         let session = Arc::new(NoopClientSession::new());
-        let result = call_verb(state.as_mut(), session, "test", vec![]);
+        let result = call_verb(
+            state.as_mut(),
+            session,
+            Arc::new(BuiltinRegistry::new()),
+            "test",
+            vec![],
+        );
         assert_eq!(result, Ok(expected_result));
     }
 }

--- a/crates/kernel/src/vm/vm_test.rs
+++ b/crates/kernel/src/vm/vm_test.rs
@@ -14,8 +14,6 @@
 
 #[cfg(test)]
 mod tests {
-
-    use pretty_assertions::assert_eq;
     use std::sync::Arc;
 
     use moor_values::model::PropFlag;

--- a/crates/kernel/src/vm/vm_unwind.rs
+++ b/crates/kernel/src/vm/vm_unwind.rs
@@ -23,7 +23,8 @@ use moor_values::var::{v_listv, Variant};
 use moor_values::var::{Error, ErrorPack};
 use moor_values::NOTHING;
 
-use crate::vm::activation::{Activation, HandlerType};
+use crate::vm::activation::Activation;
+use crate::vm::frame::HandlerType;
 use crate::vm::{ExecutionResult, VMExecState, VM};
 use moor_compiler::BUILTIN_DESCRIPTORS;
 use moor_compiler::{Label, Offset};

--- a/crates/kernel/tests/textdump.rs
+++ b/crates/kernel/tests/textdump.rs
@@ -14,6 +14,14 @@
 
 #[cfg(test)]
 mod test {
+    use std::collections::BTreeSet;
+    use std::fs::File;
+    use std::io::{BufReader, Read};
+    use std::path::PathBuf;
+    use std::sync::Arc;
+
+    use text_diff::assert_diff;
+
     use moor_compiler::Program;
     use moor_db::loader::LoaderInterface;
     use moor_db::Database;
@@ -25,15 +33,8 @@ mod test {
     use moor_values::model::{CommitResult, ValSet};
     use moor_values::model::{HasUuid, Named};
     use moor_values::var::Objid;
-    use moor_values::{AsByteBuffer, SYSTEM_OBJECT};
-    use std::collections::BTreeSet;
-    use std::fs::File;
-    use std::io::{BufReader, Read};
-    use std::path::PathBuf;
-
     use moor_values::var::Symbol;
-    use std::sync::Arc;
-    use text_diff::assert_diff;
+    use moor_values::{AsByteBuffer, SYSTEM_OBJECT};
 
     fn get_minimal_db() -> File {
         let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));

--- a/crates/kernel/testsuite/common/mod.rs
+++ b/crates/kernel/testsuite/common/mod.rs
@@ -12,11 +12,19 @@
 // this program. If not, see <https://www.gnu.org/licenses/>.
 //
 
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use pretty_assertions::assert_eq;
+use uuid::Uuid;
+
 use moor_compiler::compile;
 use moor_compiler::Program;
 use moor_db::Database;
-
+#[cfg(feature = "relbox")]
+use moor_db_relbox::RelBoxWorldState;
 use moor_db_wiredtiger::WiredTigerDB;
+use moor_kernel::builtins::BuiltinRegistry;
 use moor_kernel::tasks::sessions::NoopClientSession;
 use moor_kernel::tasks::sessions::Session;
 use moor_kernel::tasks::vm_test_utils;
@@ -29,16 +37,8 @@ use moor_values::model::VerbArgsSpec;
 use moor_values::model::WorldStateSource;
 use moor_values::model::{BinaryType, VerbFlag};
 use moor_values::var::Objid;
-use moor_values::{AsByteBuffer, SYSTEM_OBJECT};
-use pretty_assertions::assert_eq;
-use std::path::{Path, PathBuf};
-use std::sync::Arc;
-use uuid::Uuid;
-
-#[cfg(feature = "relbox")]
-use moor_db_relbox::RelBoxWorldState;
-use moor_kernel::builtins::BuiltinRegistry;
 use moor_values::var::Symbol;
+use moor_values::{AsByteBuffer, SYSTEM_OBJECT};
 
 #[allow(dead_code)]
 pub fn testsuite_dir() -> PathBuf {

--- a/crates/kernel/testsuite/moot_suite.rs
+++ b/crates/kernel/testsuite/moot_suite.rs
@@ -16,12 +16,16 @@
 //!
 //! See example.moot for a full-fledged example
 
-mod common;
 use std::{path::Path, sync::Arc};
 
-use common::{create_wiredtiger_db, testsuite_dir};
 use eyre::Context;
+
+#[cfg(feature = "relbox")]
+use common::create_relbox_db;
+use common::{create_wiredtiger_db, testsuite_dir};
 use moor_db::Database;
+use moor_kernel::tasks::sessions::{SessionError, SessionFactory};
+use moor_kernel::tasks::NoopTasksDb;
 use moor_kernel::{
     config::Config,
     tasks::{
@@ -34,10 +38,7 @@ use moor_kernel::{
 use moor_moot::{execute_moot_test, MootRunner};
 use moor_values::var::{v_none, Objid, Var};
 
-#[cfg(feature = "relbox")]
-use common::create_relbox_db;
-use moor_kernel::tasks::sessions::{SessionError, SessionFactory};
-use moor_kernel::tasks::NoopTasksDb;
+mod common;
 
 #[derive(Clone)]
 struct SchedulerMootRunner {

--- a/crates/kernel/testsuite/regression_suite.rs
+++ b/crates/kernel/testsuite/regression_suite.rs
@@ -12,11 +12,12 @@
 // this program. If not, see <https://www.gnu.org/licenses/>.
 //
 
-mod common;
 use common::{create_wiredtiger_db, AssertRunAsVerb};
 
 #[cfg(feature = "relbox")]
 use crate::common::create_relbox_db;
+
+mod common;
 
 #[cfg(feature = "relbox")]
 #[test]

--- a/crates/values/src/model/defset.rs
+++ b/crates/values/src/model/defset.rs
@@ -154,9 +154,7 @@ impl<T: AsByteBuffer + Clone + HasUuid + Named> Defs<T> {
     }
     #[must_use]
     pub fn find_named(&self, name: Symbol) -> Vec<T> {
-        self.iter()
-            .filter(|p| p.matches_name(name))
-            .collect()
+        self.iter().filter(|p| p.matches_name(name)).collect()
     }
     #[must_use]
     pub fn find_first_named(&self, name: Symbol) -> Option<T> {


### PR DESCRIPTION
This is a series of commits which are part of some long overdue reworking of the verb dispatch and execution happens for both the MOO virtual machine and for builtins.

One part of this is about making things more consistent in interface for builtins vs MOO execution, and cleaning up the builtin execution so they happen in their own frame type.

Another part is moving the bulk of execution logic off of the MOO "VM" and onto the VMExecState, and then isolating the MOO specific portions to their own routine, which operates on MooFrames only.

All of this has the eventual goal of making it easier to support other language runtimes inside the `moor` system.