### PR TITLE
Permit sending "rich" content via `notify`

### DIFF
--- a/crates/kernel/src/tasks/task.rs
+++ b/crates/kernel/src/tasks/task.rs
@@ -744,7 +744,10 @@ mod tests {
         };
         assert_eq!(player, SYSTEM_OBJECT);
         assert_eq!(event.author(), SYSTEM_OBJECT);
-        assert_eq!(event.event, Event::TextNotify("12345".to_string()));
+        assert_eq!(
+            event.event,
+            Event::Notify(v_str("12345"), "text/plain".to_string())
+        );
 
         // Also scheduler should have received a TaskSuccess message.
         let (task_id, msg) = control_receiver.recv().unwrap();

--- a/crates/values/src/model/mod.rs
+++ b/crates/values/src/model/mod.rs
@@ -31,9 +31,9 @@ pub use crate::model::world_state::{WorldState, WorldStateSource};
 use crate::AsByteBuffer;
 use thiserror::Error;
 
-use crate::var::Error;
 use crate::var::Objid;
 use crate::var::Symbol;
+use crate::var::{Error, Var};
 
 mod defset;
 mod r#match;
@@ -167,7 +167,12 @@ pub struct NarrativeEvent {
 #[derive(Debug, Clone, PartialEq, Eq, Encode, Decode)]
 pub enum Event {
     /// The typical "something happened" descriptive event.
-    TextNotify(String),
+    /// Text +content-type
+    ///  - "text/plain" for plain text
+    ///  - "text/html" for HTML
+    ///  - "text/markdown" for Markdown
+    /// etc.
+    Notify(Var, String),
     // TODO: Other Event types on Session stream
     //   other events that might happen here would be things like (local) "object moved" or "object
     //   created."
@@ -175,11 +180,11 @@ pub enum Event {
 
 impl NarrativeEvent {
     #[must_use]
-    pub fn notify_text(author: Objid, event: String) -> Self {
+    pub fn notify(author: Objid, event: Var, content_type: Option<String>) -> Self {
         Self {
             timestamp: SystemTime::now(),
             author,
-            event: Event::TextNotify(event),
+            event: Event::Notify(event, content_type.unwrap_or("text/plain".to_string())),
         }
     }
 


### PR DESCRIPTION
Changes the RPC "Notify" event to carry a full MOO "Var" instead of a string, along with a content-type.

The builtin function "notify" is now modified to take an optional third argument, which is a content / mime-type. The intent here is to allow cores & clients connected to them to do smarter things with richer content.

For default (no argument), or for any content-type which starts with "text/" the 2nd argument is expected to be a MOO string, same as usual, and E_TYPE is raised for any other value types.

For any other content type, the value is allowed to be passed through without modification and is up to the client to interpret it.

The existing telnet client just turns everything into strings, relying on the default .to_string functionality on Var.