### PR TITLE
chore: delete disabled test that *shouldn't* work

### DIFF
--- a/crates/telnet-host/tests/moot/suspend_read_notify.moot
+++ b/crates/telnet-host/tests/moot/suspend_read_notify.moot
@@ -10,11 +10,5 @@
 =read: hi
 ="retval"
 
-// TODO disabled for now: this consistently fails
-// ; suspend(0.1); notify(player, "read 2: " + read()); return "retval 2";
-// %hello
-// =read2: hello
-// ="retval2"
-
 ; suspend(0.1); return 42;
 =42


### PR DESCRIPTION
The test as written *should* fail; we don't currently have a way in `moot` to send input after some delay. Doesn't seem worth adding that feature at the moment (or maybe ever), so: delete the commented-out test.