### PR TITLE
fix(telnet,rpc_server): fix default `huh` message

### DIFF
--- a/crates/telnet-host/src/telnet.rs
+++ b/crates/telnet-host/src/telnet.rs
@@ -331,7 +331,7 @@ impl TelnetConnection {
         match task_error {
             SchedulerError::CommandExecutionError(CommandError::CouldNotParseCommand) => {
                 self.write
-                    .send("I don't understand that.".to_string())
+                    .send("I couldn't understand that.".to_string())
                     .await?;
             }
             SchedulerError::CommandExecutionError(CommandError::NoObjectMatch) => {
@@ -341,7 +341,7 @@ impl TelnetConnection {
             }
             SchedulerError::CommandExecutionError(CommandError::NoCommandMatch) => {
                 self.write
-                    .send("I don't understand that.".to_string())
+                    .send("I couldn't understand that.".to_string())
                     .await?;
             }
             SchedulerError::CommandExecutionError(CommandError::PermissionDenied) => {

--- a/crates/telnet-host/tests/integration_test.rs
+++ b/crates/telnet-host/tests/integration_test.rs
@@ -155,3 +155,10 @@ fn test_echo() {
 fn test_suspend_read_notify() {
     test_moot_with_telnet_host("suspend_read_notify");
 }
+
+#[cfg(target_os = "linux")]
+#[test]
+#[serial(telnet_host)]
+fn test_huh() {
+    test_moot_with_telnet_host("huh");
+}

--- a/crates/telnet-host/tests/moot/huh.moot
+++ b/crates/telnet-host/tests/moot/huh.moot
@@ -1,0 +1,4 @@
+// The test core doesn't define a `huh` verb.
+// Test that we get the correct default `huh` message.
+% discombobulate
+=I couldn't understand that.


### PR DESCRIPTION
I couldn't understand that.

Fixes #340 