### PR TITLE
A couple more cleanups

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1677,6 +1677,7 @@ dependencies = [
  "rpc-common",
  "rpc-sync-client",
  "rustyline",
+ "signal-hook",
  "tracing",
  "tracing-subscriber",
  "uuid",

--- a/crates/console-host/Cargo.toml
+++ b/crates/console-host/Cargo.toml
@@ -35,3 +35,4 @@ zmq.workspace = true
 ## For console
 owo-colors.workspace = true
 rustyline.workspace = true
+signal-hook.workspace = true

--- a/crates/daemon/src/rpc_server.rs
+++ b/crates/daemon/src/rpc_server.rs
@@ -463,7 +463,7 @@ impl RpcServer {
                     return make_response(Err(RpcRequestError::PermissionDenied));
                 };
 
-                info!("Detaching client: {}", client_id);
+                debug!(?client_id, "Detaching client");
 
                 // Detach this client id from the player/connection object.
                 let Ok(_) = self.connections.remove_client_connection(client_id) else {

--- a/crates/kernel/src/tasks/scheduler.rs
+++ b/crates/kernel/src/tasks/scheduler.rs
@@ -669,7 +669,7 @@ impl Scheduler {
                 task_q.send_task_result(task_id, Err(TaskAbortedLimit(limit_reason)));
             }
             TaskControlMsg::TaskException(exception) => {
-                warn!(?task_id, finally_reason = ?exception, "Task threw exception");
+                debug!(?task_id, finally_reason = ?exception, "Task threw exception");
 
                 let Some(task) = task_q.tasks.get_mut(&task_id) else {
                     warn!(task_id, "Task not found for abort");
@@ -862,21 +862,20 @@ impl Scheduler {
                     return;
                 };
 
-                info!("Creating textdump...");
+                trace!("Creating textdump...");
                 let textdump = make_textdump(
                     loader_client.as_ref(),
                     // just to be compatible with LambdaMOO import for now, hopefully.
                     Some("** LambdaMOO Database, Format Version 4 **"),
                 );
 
-                info!("Writing textdump to {}", textdump_path.display());
-
+                debug!(?textdump_path, "Writing textdump..");
                 let mut writer = TextdumpWriter::new(&mut output);
                 if let Err(e) = writer.write_textdump(&textdump) {
                     error!(?e, "Could not write textdump");
                     return;
                 }
-                info!("Textdump written to {}", textdump_path.display());
+                trace!(?textdump_path, "Textdump written.");
             });
         if let Err(e) = tr {
             error!(?e, "Could not start textdump thread");

--- a/crates/kernel/src/tasks/suspension.rs
+++ b/crates/kernel/src/tasks/suspension.rs
@@ -23,12 +23,12 @@ use bincode::{BorrowDecode, Decode, Encode};
 use tracing::{debug, error, info, warn};
 use uuid::Uuid;
 
-use moor_values::var::Objid;
+use moor_values::var::{Objid, Var};
 
 use crate::tasks::sessions::{NoopClientSession, Session, SessionFactory};
 use crate::tasks::task::Task;
 use crate::tasks::{TaskDescription, TasksDb};
-use moor_values::tasks::{TaskId, TaskResult};
+use moor_values::tasks::{SchedulerError, TaskId};
 
 /// State a suspended task sits in inside the `suspended` side of the task queue.
 /// When tasks are not running they are moved into these.
@@ -36,7 +36,7 @@ pub struct SuspendedTask {
     pub wake_condition: WakeCondition,
     pub task: Task,
     pub session: Arc<dyn Session>,
-    pub result_sender: Option<oneshot::Sender<TaskResult>>,
+    pub result_sender: Option<oneshot::Sender<Result<Var, SchedulerError>>>,
 }
 
 /// Possible conditions in which a suspended task can wake from suspension.
@@ -118,7 +118,7 @@ impl SuspensionQ {
         wake_condition: WakeCondition,
         task: Task,
         session: Arc<dyn Session>,
-        result_sender: Option<oneshot::Sender<TaskResult>>,
+        result_sender: Option<oneshot::Sender<Result<Var, SchedulerError>>>,
     ) {
         let task_id = task.task_id;
         let sr = SuspendedTask {

--- a/crates/kernel/src/vm/moo_execute.rs
+++ b/crates/kernel/src/vm/moo_execute.rs
@@ -507,7 +507,6 @@ pub fn moo_frame_execute(
                         return ExecutionResult::RollbackRestart;
                     }
                     Err(e) => {
-                        debug!(obj = ?obj, propname = propname.as_str(), "Error resolving property");
                         return state.push_error(e.to_error_code());
                     }
                 };

--- a/crates/values/src/tasks/errors.rs
+++ b/crates/values/src/tasks/errors.rs
@@ -21,13 +21,6 @@ use std::time::Duration;
 use strum::Display;
 use thiserror::Error;
 
-/// Possible results returned to waiters on tasks to which they've subscribed.
-#[derive(Clone, Debug)]
-pub enum TaskResult {
-    Success(Var),
-    Error(SchedulerError),
-}
-
 #[derive(Debug, Clone, Error, Decode, Encode, PartialEq, Display)]
 pub enum VerbProgramError {
     NoVerbToProgram,

--- a/crates/values/src/tasks/mod.rs
+++ b/crates/values/src/tasks/mod.rs
@@ -16,7 +16,7 @@ mod errors;
 mod events;
 
 pub use errors::{
-    AbortLimitReason, CommandError, SchedulerError, TaskResult, UncaughtException, VerbProgramError,
+    AbortLimitReason, CommandError, SchedulerError, UncaughtException, VerbProgramError,
 };
 
 pub use events::{Event, NarrativeEvent};


### PR DESCRIPTION
* Signal handling for `console-host` and `telnet-host` to properly exit on `SIGTERM`/`SIGINT`
* Get rid of `TaskResult` which was a redundant vestige better expresses with `Result<Var, SchedulerError>`