### PR TITLE
Allow "rich" host/client output

### DIFF
--- a/crates/console-host/src/main.rs
+++ b/crates/console-host/src/main.rs
@@ -252,7 +252,7 @@ fn console_loop(
                     printer
                         .print(
                             (match msg.event() {
-                                moor_values::tasks::Event::TextNotify(s) => s,
+                                moor_values::tasks::Event::Notify(s) => s,
                             })
                             .to_string(),
                         )

--- a/crates/daemon/src/main.rs
+++ b/crates/daemon/src/main.rs
@@ -190,6 +190,13 @@ struct Args {
 
     #[arg(long, help = "Enable debug logging", default_value = "false")]
     debug: bool,
+
+    #[arg(
+        long,
+        help = "Enable strict mode, which constraints behaviours to original LambdaMOO",
+        default_value = "false"
+    )]
+    strict_mode: bool,
 }
 
 fn main() -> Result<(), Report> {
@@ -295,6 +302,7 @@ fn main() -> Result<(), Report> {
     let config = Config {
         textdump_output: args.textdump_out,
         textdump_encoding: args.textdump_encoding,
+        strict_mode: args.strict_mode,
     };
 
     let tasks_db: Box<dyn TasksDb> = match args.db_flavour {

--- a/crates/daemon/src/main.rs
+++ b/crates/daemon/src/main.rs
@@ -80,7 +80,7 @@ struct Args {
     #[arg(
         long,
         value_name = "textdump-encoding",
-        help = "Encoding to use for reading textdump files. utf8 or iso8859-1. \
+        help = "Encoding to use for reading and writing textdump files. utf8 or iso8859-1. \
           LambdaMOO textdumps that contain 8-bit strings are written using iso8859-1, so for full compatibility, \
           choose iso8859-1.
           If you know your textdump contains no such strings, or if your textdump is from moor choose utf8,
@@ -294,6 +294,7 @@ fn main() -> Result<(), Report> {
 
     let config = Config {
         textdump_output: args.textdump_out,
+        textdump_encoding: args.textdump_encoding,
     };
 
     let tasks_db: Box<dyn TasksDb> = match args.db_flavour {

--- a/crates/kernel/benches/vm_benches.rs
+++ b/crates/kernel/benches/vm_benches.rs
@@ -24,6 +24,7 @@ use criterion::{criterion_group, criterion_main, Criterion};
 use moor_compiler::compile;
 use moor_db_wiredtiger::WiredTigerDB;
 use moor_kernel::builtins::BuiltinRegistry;
+use moor_kernel::config::Config;
 use moor_kernel::tasks::sessions::{NoopClientSession, Session};
 use moor_kernel::tasks::task_scheduler_client::TaskSchedulerClient;
 use moor_kernel::tasks::vm_host::{VMHostResponse, VmHost};
@@ -109,6 +110,8 @@ fn execute(
     vm_host.reset_ticks();
     vm_host.reset_time();
 
+    let config = Arc::new(Config::default());
+
     // Call repeatedly into exec until we ge either an error or Complete.
     loop {
         match vm_host.exec_interpreter(
@@ -117,6 +120,7 @@ fn execute(
             task_scheduler_client.clone(),
             session.clone(),
             Arc::new(BuiltinRegistry::new()),
+            config.clone(),
         ) {
             VMHostResponse::ContinueOk => {
                 continue;

--- a/crates/kernel/src/builtins/mod.rs
+++ b/crates/kernel/src/builtins/mod.rs
@@ -33,6 +33,7 @@ use crate::builtins::bf_server::{register_bf_server, BfNoop};
 use crate::builtins::bf_strings::register_bf_strings;
 use crate::builtins::bf_values::register_bf_values;
 use crate::builtins::bf_verbs::register_bf_verbs;
+use crate::config::Config;
 use crate::tasks::sessions::Session;
 use crate::tasks::task_scheduler_client::TaskSchedulerClient;
 use crate::vm::activation::{BfFrame, Frame};
@@ -96,6 +97,8 @@ pub struct BfCallState<'a> {
     pub(crate) session: Arc<dyn Session>,
     /// For sending messages up to the scheduler
     pub(crate) task_scheduler_client: TaskSchedulerClient,
+    /// Config
+    pub(crate) config: Arc<Config>,
 }
 
 impl BfCallState<'_> {

--- a/crates/kernel/src/config.rs
+++ b/crates/kernel/src/config.rs
@@ -15,9 +15,11 @@
 //! Config is created by the host daemon, and passed through the scheduler, whereupon it is
 //! available to all components. Used to hold things typically configured by CLI flags, etc.
 
+use crate::textdump::EncodingMode;
 use std::path::PathBuf;
 
 #[derive(Debug, Default)]
 pub struct Config {
     pub textdump_output: Option<PathBuf>,
+    pub textdump_encoding: EncodingMode,
 }

--- a/crates/kernel/src/config.rs
+++ b/crates/kernel/src/config.rs
@@ -20,6 +20,11 @@ use std::path::PathBuf;
 
 #[derive(Debug, Default)]
 pub struct Config {
+    /// Whether to run in a strict mode which ties the server to the original LambdaMOO behaviour,
+    /// or to allow for more modern features.
+    pub strict_mode: bool,
+    /// Where to write periodic textdumps of the database.
     pub textdump_output: Option<PathBuf>,
+    /// What encoding to use for textdumps (ISO-8859-1 or UTF-8).
     pub textdump_encoding: EncodingMode,
 }

--- a/crates/kernel/src/config.rs
+++ b/crates/kernel/src/config.rs
@@ -18,7 +18,7 @@
 use crate::textdump::EncodingMode;
 use std::path::PathBuf;
 
-#[derive(Debug, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct Config {
     /// Whether to run in a strict mode which ties the server to the original LambdaMOO behaviour,
     /// or to allow for more modern features.

--- a/crates/kernel/src/tasks/mod.rs
+++ b/crates/kernel/src/tasks/mod.rs
@@ -129,6 +129,7 @@ pub mod vm_test_utils {
     use moor_values::SYSTEM_OBJECT;
 
     use crate::builtins::BuiltinRegistry;
+    use crate::config::Config;
     use crate::tasks::sessions::Session;
     use crate::tasks::vm_host::{VMHostResponse, VmHost};
     use crate::tasks::VerbCall;
@@ -152,6 +153,8 @@ pub mod vm_test_utils {
 
         fun(world_state, &mut vm_host);
 
+        let config = Arc::new(Config::default());
+
         // Call repeatedly into exec until we ge either an error or Complete.
         loop {
             match vm_host.exec_interpreter(
@@ -160,6 +163,7 @@ pub mod vm_test_utils {
                 task_scheduler_client.clone(),
                 session.clone(),
                 builtins.clone(),
+                config.clone(),
             ) {
                 VMHostResponse::ContinueOk => {
                     continue;

--- a/crates/kernel/src/tasks/scheduler.rs
+++ b/crates/kernel/src/tasks/scheduler.rs
@@ -55,7 +55,7 @@ use crate::tasks::{
     ServerOptions, TaskHandle, TaskStart, DEFAULT_BG_SECONDS, DEFAULT_BG_TICKS, DEFAULT_FG_SECONDS,
     DEFAULT_FG_TICKS, DEFAULT_MAX_STACK_DEPTH,
 };
-use crate::textdump::{make_textdump, EncodingMode, TextdumpWriter};
+use crate::textdump::{make_textdump, TextdumpWriter};
 use crate::vm::Fork;
 use moor_values::tasks::SchedulerError::{
     CommandExecutionError, InputRequestNotFound, TaskAbortedCancelled, TaskAbortedError,
@@ -844,6 +844,8 @@ impl Scheduler {
             return Err(SchedulerError::CouldNotStartTask);
         };
 
+        let encoding_mode = self.config.textdump_encoding;
+
         let loader_client = {
             match self.database.loader_client() {
                 Ok(tx) => tx,
@@ -870,7 +872,7 @@ impl Scheduler {
                 );
 
                 debug!(?textdump_path, "Writing textdump..");
-                let mut writer = TextdumpWriter::new(&mut output, EncodingMode::UTF8);
+                let mut writer = TextdumpWriter::new(&mut output, encoding_mode);
                 if let Err(e) = writer.write_textdump(&textdump) {
                     error!(?e, "Could not write textdump");
                     return;

--- a/crates/kernel/src/tasks/task.rs
+++ b/crates/kernel/src/tasks/task.rs
@@ -857,7 +857,7 @@ mod tests {
         };
         assert_eq!(player, SYSTEM_OBJECT);
         assert_eq!(event.author(), SYSTEM_OBJECT);
-        assert_eq!(event.event, Event::TextNotify("12345".to_string()));
+        assert_eq!(event.event, Event::Notify(v_str("12345")));
 
         // Also scheduler should have received a TaskSuccess message.
         let (task_id, msg) = control_receiver.recv().unwrap();

--- a/crates/kernel/src/tasks/task.rs
+++ b/crates/kernel/src/tasks/task.rs
@@ -46,6 +46,7 @@ use moor_values::var::{List, Objid};
 use moor_values::{NOTHING, SYSTEM_OBJECT};
 
 use crate::builtins::BuiltinRegistry;
+use crate::config::Config;
 use crate::matching::match_env::MatchEnvironmentParseMatcher;
 use crate::matching::ws_match_env::WsMatchEnv;
 use crate::tasks::command_parse::{parse_command, ParseCommandError, ParsedCommand};
@@ -114,6 +115,7 @@ impl Task {
         session: Arc<dyn Session>,
         mut world_state: Box<dyn WorldState>,
         builtin_registry: Arc<BuiltinRegistry>,
+        config: Arc<Config>,
     ) {
         while task.vm_host.is_running() {
             // Check kill switch.
@@ -127,6 +129,7 @@ impl Task {
                 session.clone(),
                 world_state.as_mut(),
                 builtin_registry.clone(),
+                config.clone(),
             ) {
                 task = continuation_task;
             } else {
@@ -149,6 +152,7 @@ impl Task {
         session: Arc<dyn Session>,
         world_state: &mut dyn WorldState,
         builtin_registry: Arc<BuiltinRegistry>,
+        config: Arc<Config>,
     ) -> Option<Self> {
         // Call the VM
         let vm_exec_result = self.vm_host.exec_interpreter(
@@ -157,6 +161,7 @@ impl Task {
             task_scheduler_client.clone(),
             session,
             builtin_registry,
+            config,
         );
 
         // Having done that, what should we now do?
@@ -654,6 +659,7 @@ mod tests {
     use moor_values::{AsByteBuffer, NOTHING, SYSTEM_OBJECT};
 
     use crate::builtins::BuiltinRegistry;
+    use crate::config::Config;
     use crate::tasks::sessions::NoopClientSession;
     use crate::tasks::task::Task;
     use crate::tasks::task_scheduler_client::{TaskControlMsg, TaskSchedulerClient};
@@ -790,6 +796,7 @@ mod tests {
             session,
             tx,
             Arc::new(BuiltinRegistry::new()),
+            Arc::new(Config::default()),
         );
 
         // Scheduler should have received a TaskSuccess message.
@@ -814,6 +821,7 @@ mod tests {
             session,
             tx,
             Arc::new(BuiltinRegistry::new()),
+            Arc::new(Config::default()),
         );
 
         // Scheduler should have received a TaskException message.
@@ -838,6 +846,7 @@ mod tests {
             session,
             tx,
             Arc::new(BuiltinRegistry::new()),
+            Arc::new(Config::default()),
         );
 
         // Scheduler should have received a TaskException message.
@@ -872,6 +881,7 @@ mod tests {
             session.clone(),
             tx,
             Arc::new(BuiltinRegistry::new()),
+            Arc::new(Config::default()),
         );
 
         // Scheduler should have received a TaskSuspend message.
@@ -893,6 +903,7 @@ mod tests {
             session,
             tx,
             Arc::new(BuiltinRegistry::new()),
+            Arc::new(Config::default()),
         );
         let (task_id, msg) = control_receiver.recv().unwrap();
         assert_eq!(task_id, 1);
@@ -915,6 +926,7 @@ mod tests {
             session.clone(),
             tx,
             Arc::new(BuiltinRegistry::new()),
+            Arc::new(Config::default()),
         );
 
         // Scheduler should have received a TaskRequestInput message, and it should contain the task.
@@ -936,6 +948,7 @@ mod tests {
             session,
             tx,
             Arc::new(BuiltinRegistry::new()),
+            Arc::new(Config::default()),
         );
 
         // Scheduler should have received a TaskSuccess message.
@@ -971,6 +984,7 @@ mod tests {
                 session,
                 tx,
                 Arc::new(BuiltinRegistry::new()),
+                Arc::new(Config::default()),
             );
         });
 
@@ -1019,6 +1033,7 @@ mod tests {
             session,
             tx,
             Arc::new(BuiltinRegistry::new()),
+            Arc::new(Config::default()),
         );
 
         // Scheduler should have received a NoCommandMatch
@@ -1051,6 +1066,7 @@ mod tests {
             session,
             tx,
             Arc::new(BuiltinRegistry::new()),
+            Arc::new(Config::default()),
         );
 
         // This should be a success, it got handled
@@ -1081,6 +1097,7 @@ mod tests {
             session,
             tx,
             Arc::new(BuiltinRegistry::new()),
+            Arc::new(Config::default()),
         );
 
         // This should be a success, it got handled
@@ -1112,6 +1129,7 @@ mod tests {
             session,
             tx,
             Arc::new(BuiltinRegistry::new()),
+            Arc::new(Config::default()),
         );
 
         // This should be a success, it got handled
@@ -1151,6 +1169,7 @@ mod tests {
             session,
             tx,
             Arc::new(BuiltinRegistry::new()),
+            Arc::new(Config::default()),
         );
 
         // This should be a success, it got handled

--- a/crates/kernel/src/tasks/vm_host.rs
+++ b/crates/kernel/src/tasks/vm_host.rs
@@ -38,6 +38,7 @@ use moor_values::var::{List, Objid};
 use moor_values::AsByteBuffer;
 
 use crate::builtins::BuiltinRegistry;
+use crate::config::Config;
 use crate::tasks::command_parse::ParsedCommand;
 use crate::tasks::sessions::Session;
 use crate::tasks::task_scheduler_client::TaskSchedulerClient;
@@ -223,6 +224,7 @@ impl VmHost {
         task_scheduler_client: TaskSchedulerClient,
         session: Arc<dyn Session>,
         builtin_registry: Arc<BuiltinRegistry>,
+        config: Arc<Config>,
     ) -> VMHostResponse {
         self.vm_exec_state.task_id = task_id;
 
@@ -230,6 +232,7 @@ impl VmHost {
             task_scheduler_client: task_scheduler_client.clone(),
             builtin_registry,
             max_stack_depth: self.max_stack_depth,
+            config,
         };
 
         // Check existing ticks and seconds, and abort the task if we've exceeded the limits.

--- a/crates/kernel/src/textdump/mod.rs
+++ b/crates/kernel/src/textdump/mod.rs
@@ -47,10 +47,11 @@ const VF_ASPEC_THIS: u16 = 2;
 /// Note that LambdaMOO imports are always in ISO-8859-1, but exports can be in UTF-8.
 /// To make things backwards compatible to LambdaMOO servers, choose ISO-8859-1.
 /// The default is UTF-8.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Default)]
 pub enum EncodingMode {
     // windows-1252 / ISO-8859-1
     ISO8859_1,
+    #[default]
     UTF8,
 }
 

--- a/crates/kernel/src/vm/mod.rs
+++ b/crates/kernel/src/vm/mod.rs
@@ -32,6 +32,7 @@ pub use vm_unwind::FinallyReason;
 
 // Exports to the rest of the kernel
 use crate::builtins::BuiltinRegistry;
+use crate::config::Config;
 use crate::tasks::command_parse::ParsedCommand;
 use crate::tasks::task_scheduler_client::TaskSchedulerClient;
 use crate::tasks::VerbCall;
@@ -75,6 +76,7 @@ pub struct VmExecParams {
     pub task_scheduler_client: TaskSchedulerClient,
     pub builtin_registry: Arc<BuiltinRegistry>,
     pub max_stack_depth: usize,
+    pub config: Arc<Config>,
 }
 
 #[derive(Debug, Clone)]

--- a/crates/kernel/src/vm/vm_call.rs
+++ b/crates/kernel/src/vm/vm_call.rs
@@ -260,6 +260,7 @@ impl VMExecState {
             // TODO: avoid copy here by using List inside BfCallState
             args: args.iter().collect(),
             task_scheduler_client: exec_args.task_scheduler_client.clone(),
+            config: exec_args.config.clone(),
         };
 
         let call_results = match bf.call(&mut bf_args) {
@@ -308,6 +309,7 @@ impl VMExecState {
             // TODO: avoid copy here by using List inside BfCallState
             args: args.iter().collect(),
             task_scheduler_client: exec_args.task_scheduler_client.clone(),
+            config: exec_args.config.clone(),
         };
 
         match bf.call(&mut bf_args) {

--- a/crates/values/src/tasks/events.rs
+++ b/crates/values/src/tasks/events.rs
@@ -12,7 +12,7 @@
 // this program. If not, see <https://www.gnu.org/licenses/>.
 //
 
-use crate::var::Objid;
+use crate::var::{Objid, Var};
 use bincode::{Decode, Encode};
 use std::time::SystemTime;
 
@@ -32,7 +32,7 @@ pub struct NarrativeEvent {
 #[derive(Debug, Clone, PartialEq, Eq, Encode, Decode)]
 pub enum Event {
     /// The typical "something happened" descriptive event.
-    TextNotify(String),
+    Notify(Var),
     // TODO: Other Event types on Session stream
     //   other events that might happen here would be things like (local) "object moved" or "object
     //   created."
@@ -40,11 +40,11 @@ pub enum Event {
 
 impl NarrativeEvent {
     #[must_use]
-    pub fn notify_text(author: Objid, event: String) -> Self {
+    pub fn notify(author: Objid, value: Var) -> Self {
         Self {
             timestamp: SystemTime::now(),
             author,
-            event: Event::TextNotify(event),
+            event: Event::Notify(value),
         }
     }
 

--- a/crates/web-host/src/host/ws_connection.rs
+++ b/crates/web-host/src/host/ws_connection.rs
@@ -12,7 +12,7 @@
 // this program. If not, see <https://www.gnu.org/licenses/>.
 //
 
-use crate::host::serialize_var;
+use crate::host::{serialize_var, var_as_json};
 use axum::extract::ws::{Message, WebSocket};
 use futures_util::stream::SplitSink;
 use futures_util::{SinkExt, StreamExt};
@@ -26,6 +26,7 @@ use rpc_common::ConnectionEvent;
 use rpc_common::{
     AuthToken, ClientToken, ConnectType, RpcRequest, RpcRequestError, RpcResponse, RpcResult,
 };
+use serde_json::Value;
 use std::net::SocketAddr;
 use std::time::SystemTime;
 use tmq::subscribe::Subscribe;
@@ -51,7 +52,7 @@ pub struct NarrativeOutput {
     #[serde(skip_serializing_if = "Option::is_none")]
     system_message: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    message: Option<String>,
+    message: Option<Value>,
     server_time: SystemTime,
 }
 
@@ -124,7 +125,7 @@ impl WebSocketConnection {
                                 origin_player: author.0,
                                 system_message: None,
                                 message: Some(match msg {
-                                    Event::TextNotify(msg) => msg,
+                                    Event::Notify(msg) => var_as_json(&msg),
                                 }),
                                 server_time: event.timestamp(),
                             }).await;


### PR DESCRIPTION
Makes room for sending things other than just text to the client by allowing (in non-strict-compat mode) the `notify` builtin to send _any_ MOO value to the client, not just a string.

For the existing old-school telnet host if this is a string, it outputs as usual. Otherwise it gets printed in its literal representation.

For the web host, everything is turned into its JSON equivalent.