### PR TITLE
Support for sending a content-type via notify

### DIFF
--- a/crates/console-host/src/main.rs
+++ b/crates/console-host/src/main.rs
@@ -252,7 +252,7 @@ fn console_loop(
                     printer
                         .print(
                             (match msg.event() {
-                                moor_values::tasks::Event::Notify(s) => s,
+                                moor_values::tasks::Event::Notify(s, _content_type) => s,
                             })
                             .to_string(),
                         )

--- a/crates/kernel/src/tasks/task.rs
+++ b/crates/kernel/src/tasks/task.rs
@@ -857,7 +857,7 @@ mod tests {
         };
         assert_eq!(player, SYSTEM_OBJECT);
         assert_eq!(event.author(), SYSTEM_OBJECT);
-        assert_eq!(event.event, Event::Notify(v_str("12345")));
+        assert_eq!(event.event, Event::Notify(v_str("12345"), None));
 
         // Also scheduler should have received a TaskSuccess message.
         let (task_id, msg) = control_receiver.recv().unwrap();

--- a/crates/telnet-host/src/telnet.rs
+++ b/crates/telnet-host/src/telnet.rs
@@ -142,10 +142,11 @@ impl TelnetConnection {
                         }
                         ConnectionEvent::Narrative(_author, event) => {
                             let msg = event.event();
-                            let Event::Notify(msg) = msg;
+                            let Event::Notify(msg, _content_type) = msg;
 
                             // Strings output as text lines to the client, otherwise send the
                             // literal form (for e.g. lists, objrefs, etc)
+                            // TODO: content-type conversions for non-text/plain (e.g. markdown, html)
                             if let Variant::Str(msg_text) = msg.variant() {
                                 self.write.send(msg_text.to_string()).await.with_context(|| "Unable to send message to client")?;
                             } else {
@@ -314,7 +315,7 @@ impl TelnetConnection {
                         }
                         ConnectionEvent::Narrative(_author, event) => {
                             let msg = event.event();
-                            let Event::Notify(msg) = msg;
+                            let Event::Notify(msg, _content_type) = msg;
 
                             // Strings output as text lines to the client, otherwise send the
                             // literal form (for e.g. lists, objrefs, etc)

--- a/crates/values/src/tasks/events.rs
+++ b/crates/values/src/tasks/events.rs
@@ -12,7 +12,7 @@
 // this program. If not, see <https://www.gnu.org/licenses/>.
 //
 
-use crate::var::{Objid, Var};
+use crate::var::{Objid, Symbol, Var};
 use bincode::{Decode, Encode};
 use std::time::SystemTime;
 
@@ -32,7 +32,8 @@ pub struct NarrativeEvent {
 #[derive(Debug, Clone, PartialEq, Eq, Encode, Decode)]
 pub enum Event {
     /// The typical "something happened" descriptive event.
-    Notify(Var),
+    /// Value & Content-Type
+    Notify(Var, Option<Symbol>),
     // TODO: Other Event types on Session stream
     //   other events that might happen here would be things like (local) "object moved" or "object
     //   created."
@@ -40,11 +41,11 @@ pub enum Event {
 
 impl NarrativeEvent {
     #[must_use]
-    pub fn notify(author: Objid, value: Var) -> Self {
+    pub fn notify(author: Objid, value: Var, content_type: Option<Symbol>) -> Self {
         Self {
             timestamp: SystemTime::now(),
             author,
-            event: Event::Notify(value),
+            event: Event::Notify(value, content_type),
         }
     }
 


### PR DESCRIPTION
Adds an extra optional argument to `notify` that can identify the content-type to the host.