### PR TITLE
Support let/const bindings for scatter-assign

### DIFF
--- a/crates/compiler/src/decompile.rs
+++ b/crates/compiler/src/decompile.rs
@@ -1179,4 +1179,13 @@ return 0 && "Automatically Added Return";
         let (parse, decompiled) = parse_decompile(program);
         assert_trees_match_recursive(&parse.stmts, &decompiled.stmts);
     }
+
+    #[test]
+    fn test_local_scatter() {
+        let program = r#"begin
+            let {things, ?nothingstr = "nothing", ?andstr = " and ", ?commastr = ", ", ?finalcommastr = ","} = args;
+        end"#;
+        let (parse, decompiled) = parse_decompile(program);
+        assert_trees_match_recursive(&parse.stmts, &decompiled.stmts);
+    }
 }

--- a/crates/compiler/src/moo.pest
+++ b/crates/compiler/src/moo.pest
@@ -59,8 +59,13 @@ unlabelled_except     = { "(" ~ codes ~ ")" }
 
 begin_statement       = { ^"begin" ~ statements ~ ^"end" }
 
-local_assignment = { ^"let" ~ ident ~ (ASSIGN ~ expr)? ~ ";" }
-const_assignment = { ^"const" ~ ident ~ (ASSIGN ~ expr)? ~ ";" }
+local_assignment = { ^"let" ~ (local_assign_scatter | local_assign_single) ~ ";" }
+local_assign_single = { ident ~ (ASSIGN ~ expr)? }
+local_assign_scatter = { scatter_assign ~ expr }
+
+const_assignment = { ^"const" ~ (const_assign_scatter | const_assign_single) ~ ";" }
+const_assign_single = { ident ~ (ASSIGN ~ expr)? }
+const_assign_scatter = { scatter_assign ~ expr }
 
 // globally scoped (same as default in MOO) adds explicitly to global scope.
 global_assignment = { ^"global" ~ ident ~ (ASSIGN ~ expr)? ~ ";" }

--- a/crates/compiler/src/names.rs
+++ b/crates/compiler/src/names.rs
@@ -114,6 +114,21 @@ impl UnboundNames {
         Ok(unbound_name)
     }
 
+    pub fn declare(
+        &mut self,
+        name: &str,
+        constant: bool,
+        global: bool,
+    ) -> Result<UnboundName, CompileError> {
+        if global {
+            return self.find_or_add_name_global(name);
+        }
+        if constant {
+            return self.declare_const(name);
+        }
+        self.declare_name(name)
+    }
+
     /// If the same named variable exists in multiple scopes, return them all as a vector.
     pub fn find_named(&self, name: &str) -> Vec<UnboundName> {
         let name = Symbol::mk_case_insensitive(name);

--- a/crates/kernel/src/vm/vm_test.rs
+++ b/crates/kernel/src/vm/vm_test.rs
@@ -1011,6 +1011,28 @@ mod tests {
         assert_eq!(result, Ok(v_int(42)));
     }
 
+    #[test]
+    fn test_local_scatter_assign() {
+        let program = r#"a = 1;
+        begin
+            let {a, b} = {2, 3};
+            return {a, b};
+        end
+        "#;
+        let compiled = compile(program, CompileOptions::default()).unwrap();
+        let mut state = world_with_test_programs(&[("test", &compiled)]);
+        let session = Arc::new(NoopClientSession::new());
+        let builtin_registry = Arc::new(BuiltinRegistry::new());
+        let result = call_verb(
+            state.as_mut(),
+            session.clone(),
+            builtin_registry,
+            "test",
+            vec![],
+        );
+        assert_eq!(result, Ok(v_list(&[v_int(2), v_int(3)])));
+    }
+
     #[test_case("return 1;", v_int(1); "simple return")]
     #[test_case(
         r#"rest = "me:words"; rest[1..0] = ""; return rest;"#,


### PR DESCRIPTION
Lets scatter assigns take part in lexical scoping.

https://github.com/rdaum/moor/issues/281