### PR TITLE
[moot] Rebuild custom parser in `pest`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2273,6 +2273,8 @@ version = "0.9.0-alpha"
 dependencies = [
  "eyre",
  "moor-values",
+ "pest",
+ "pest_derive",
  "pretty_assertions",
  "tracing",
  "tracing-subscriber",

--- a/crates/kernel/testsuite/moot/create.moot
+++ b/crates/kernel/testsuite/moot/create.moot
@@ -38,9 +38,9 @@ E_PERM
 ; player.f = 1;
 ; return player.f;
 1
-@wizard
 
 // test_that_a_wizard_can_create_even_if_the_fertile_flag_is_not_set
+@wizard
 ; return $system.f;
 0
 ; create($system);
@@ -57,7 +57,10 @@ E_PERM
 @programmer
 ; return $object.f;
 1
+; create($object);
+@wizard
 ; $tmp = create($nothing);
+@programmer
 ; return $tmp.f;
 0
 ; create($tmp);

--- a/crates/kernel/testsuite/moot_suite.rs
+++ b/crates/kernel/testsuite/moot_suite.rs
@@ -162,5 +162,5 @@ fn test(db: Box<dyn Database>, path: &Path) {
 fn test_single() {
     // cargo test -p moor-kernel --test moot-suite test_single -- --ignored
     // CARGO_PROFILE_RELEASE_DEBUG=true cargo flamegraph --test moot-suite -- test_single --ignored
-    test_with_db(&testsuite_dir().join("moot/truthiness.moot"));
+    test_with_db(&testsuite_dir().join("moot/create.moot"));
 }

--- a/crates/telnet-host/tests/moot/suspend_read_notify.moot
+++ b/crates/telnet-host/tests/moot/suspend_read_notify.moot
@@ -1,11 +1,11 @@
 ; return 200;
 =200
 
-; return read();
+& return read();
 %201
 ="201"
 
-; notify(player, "read: " + read()); return "retval";
+& notify(player, "read: " + read()); return "retval";
 %hi
 =read: hi
 ="retval"

--- a/crates/testing/moot/Cargo.toml
+++ b/crates/testing/moot/Cargo.toml
@@ -13,6 +13,8 @@ description = "Execute MOO interaction tests described in simple text files."
 
 [dependencies]
 eyre.workspace = true
+pest.workspace = true
+pest_derive.workspace = true
 pretty_assertions.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true

--- a/crates/testing/moot/README.md
+++ b/crates/testing/moot/README.md
@@ -7,6 +7,7 @@
 | <pre>; return<br>> 42;</pre> | Multi-line `eval`                                                                  |
 | <pre>% look<br>> here</pre>  | Multi-line command                                                                 |
 | `% look`                     | Execute `look` as a command                                                        |
+| `& return read();`           | `eval("return read();")`, but don't expect any output                              |
 | `42`, `< 42`                 | Assert that we receive `42` from the server as a response to the `eval` or command |
 | `=foobar`                    | Assert that we received a line containing exactly the string `foobar`              |
 | `// comment`                 | It's a comment!                                                                    |

--- a/crates/testing/moot/src/moot.pest
+++ b/crates/testing/moot/src/moot.pest
@@ -1,0 +1,48 @@
+// Copyright (C) 2025 Ryan Daum <ryan.daum@gmail.com> This program is free
+// software: you can redistribute it and/or modify it under the terms of the GNU
+// General Public License as published by the Free Software Foundation, version
+// 3.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program. If not, see <https://www.gnu.org/licenses/>.
+//
+
+file = _{
+    SOI ~
+    skip ~
+    (block ~ skip)* ~
+    EOI
+}
+
+block = _{ 
+    change_player |
+    eval |
+    cmd
+}
+
+skip = _{ (
+    (" "* ~ NEWLINE) |
+    "//" ~ (!NEWLINE ~ ANY)* ~ eol
+)* }
+
+change_player = _{ "@" ~ change_player_name ~ eol }
+change_player_name = { ASCII_ALPHA_LOWER+ }
+
+eval = { ";" ~ test }
+cmd = { "%" ~ test }
+test = _{ " "* ~ test_input ~ skip ~ expect? }
+test_input = _{ test_line ~ eol ~ (">" ~ test_line ~ eol)* }
+test_line = { (!NEWLINE ~ ANY)* }
+
+expect = _{ expect_verbatim | expect_eval }
+expect_verbatim = _{ "=" ~ expect_verbatim_line ~ eol }
+expect_verbatim_line = { (!NEWLINE ~ ANY)* }
+
+expect_eval = _{ ("<" | !(";" | "@" | "%" | "//")) ~ " "* ~ expect_eval_line ~ eol }
+expect_eval_line = { (!NEWLINE ~ ANY)+ }
+
+eol = _{ NEWLINE | EOI }

--- a/crates/testing/moot/src/moot.pest
+++ b/crates/testing/moot/src/moot.pest
@@ -21,7 +21,8 @@ file = _{
 block = _{ 
     change_player |
     eval |
-    cmd
+    cmd |
+    eval_bg
 }
 
 skip = _{ (
@@ -34,7 +35,8 @@ change_player_name = { ASCII_ALPHA_LOWER+ }
 
 eval = { ";" ~ test }
 cmd = { "%" ~ test }
-test = _{ " "* ~ test_input ~ skip ~ expect? }
+eval_bg = { "&" ~ test }
+test = _{ " "* ~ test_input ~ skip ~ expect* }
 test_input = _{ test_line ~ eol ~ (">" ~ test_line ~ eol)* }
 test_line = { (!NEWLINE ~ ANY)* }
 
@@ -42,7 +44,7 @@ expect = _{ expect_verbatim | expect_eval }
 expect_verbatim = _{ "=" ~ expect_verbatim_line ~ eol }
 expect_verbatim_line = { (!NEWLINE ~ ANY)* }
 
-expect_eval = _{ ("<" | !(";" | "@" | "%" | "//")) ~ " "* ~ expect_eval_line ~ eol }
+expect_eval = _{ ("<" | !(";" | "@" | "%" | "//" | "&")) ~ " "* ~ expect_eval_line ~ eol }
 expect_eval_line = { (!NEWLINE ~ ANY)+ }
 
 eol = _{ NEWLINE | EOI }

--- a/crates/testing/moot/src/parser.rs
+++ b/crates/testing/moot/src/parser.rs
@@ -1,0 +1,192 @@
+// Copyright (C) 2025 Ryan Daum <ryan.daum@gmail.com> This program is free
+// software: you can redistribute it and/or modify it under the terms of the GNU
+// General Public License as published by the Free Software Foundation, version
+// 3.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program. If not, see <https://www.gnu.org/licenses/>.
+//
+
+use pest::Parser;
+use pest_derive::Parser;
+
+#[derive(Parser)]
+#[grammar = "moot.pest"]
+struct MootParser;
+
+#[derive(Debug, PartialEq)]
+pub struct MootBlockSpan<'a> {
+    pub line_no: usize,
+    pub expr: MootBlock<'a>,
+}
+
+#[derive(Debug, PartialEq)]
+pub enum MootBlock<'a> {
+    ChangePlayer(MootBlockChangePlayer<'a>),
+    Test(MootBlockTest<'a>),
+}
+
+#[derive(Debug, PartialEq)]
+pub struct MootBlockChangePlayer<'a> {
+    pub name: &'a str,
+}
+
+#[derive(Debug, PartialEq)]
+pub struct MootBlockTest<'a> {
+    pub kind: MootBlockTestKind,
+    pub prog_lines: Vec<&'a str>,
+    pub expected_output: Option<MootBlockTestExpectedOutput<'a>>,
+}
+impl MootBlockTest<'_> {
+    pub fn prog(&self) -> String {
+        self.prog_lines.join("\n")
+    }
+
+    pub fn verbatim(&self) -> bool {
+        self.expected_output.as_ref().map_or(false, |e| e.verbatim)
+    }
+
+    pub fn expected_output_str(&self) -> Option<&str> {
+        self.expected_output.as_ref().map(|e| e.expected_output)
+    }
+}
+
+#[derive(Debug, PartialEq)]
+pub struct MootBlockTestExpectedOutput<'a> {
+    pub expected_output: &'a str,
+    pub verbatim: bool,
+    pub line_no: usize,
+}
+
+#[derive(Debug, PartialEq)]
+pub enum MootBlockTestKind {
+    Eval,
+    Command,
+}
+
+pub fn parse(input: &str) -> eyre::Result<Vec<MootBlockSpan>> {
+    let mut expressions = vec![];
+    for pair in MootParser::parse(Rule::file, input)? {
+        let line_no = pair.as_span().start_pos().line_col().0;
+
+        let content = match pair.as_rule() {
+            Rule::block => None,
+            Rule::change_player_name => Some(MootBlock::ChangePlayer(MootBlockChangePlayer {
+                name: pair.as_str(),
+            })),
+
+            Rule::eval | Rule::cmd => {
+                let kind = match pair.as_rule() {
+                    Rule::eval => MootBlockTestKind::Eval,
+                    Rule::cmd => MootBlockTestKind::Command,
+                    r => unreachable!("{:?}", r),
+                };
+                let mut test = MootBlockTest {
+                    kind,
+                    prog_lines: vec![],
+                    expected_output: None,
+                };
+                for pair in pair.into_inner() {
+                    match pair.as_rule() {
+                        Rule::test_line => {
+                            test.prog_lines.push(pair.as_str());
+                        }
+                        Rule::expect_eval_line | Rule::expect_verbatim_line => {
+                            test.expected_output = Some(MootBlockTestExpectedOutput {
+                                expected_output: pair.as_str(),
+                                verbatim: pair.as_rule() == Rule::expect_verbatim_line,
+                                line_no: pair.as_span().start_pos().line_col().0,
+                            });
+                        }
+                        Rule::EOI => {}
+                        r => unreachable!("{:?}", r),
+                    }
+                }
+                Some(MootBlock::Test(test))
+            }
+
+            Rule::EOI => None,
+            r => unreachable!("{:?}", r),
+        };
+
+        if let Some(expr) = content {
+            expressions.push(MootBlockSpan { line_no, expr });
+        }
+    }
+
+    Ok(expressions)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_change_player() {
+        assert_eq!(
+            parse("  \n//comment\n\n@wizard\n\n//comment\n@programmer").unwrap(),
+            vec![
+                MootBlockSpan {
+                    line_no: 4,
+                    expr: MootBlock::ChangePlayer(MootBlockChangePlayer { name: "wizard" })
+                },
+                MootBlockSpan {
+                    line_no: 7,
+                    expr: MootBlock::ChangePlayer(MootBlockChangePlayer { name: "programmer" })
+                }
+            ]
+        );
+    }
+
+    #[test]
+    fn test_eval() {
+        assert_eq!(
+            parse("; 1 + \n> 2;\n//comment\n=3\n\n").unwrap(),
+            vec![MootBlockSpan {
+                line_no: 1,
+                expr: MootBlock::Test(MootBlockTest {
+                    kind: MootBlockTestKind::Eval,
+                    prog_lines: vec!["1 + ", " 2;"],
+                    expected_output: Some(MootBlockTestExpectedOutput {
+                        expected_output: "3",
+                        verbatim: true,
+                        line_no: 4,
+                    }),
+                })
+            }]
+        );
+    }
+
+    #[test]
+    fn test_eval_multiple_statements() {
+        assert_eq!(
+            parse("; 1; 2; 3;\n; 4;\n4").unwrap(),
+            vec![
+                MootBlockSpan {
+                    line_no: 1,
+                    expr: MootBlock::Test(MootBlockTest {
+                        kind: MootBlockTestKind::Eval,
+                        prog_lines: vec!["1; 2; 3;"],
+                        expected_output: None
+                    })
+                },
+                MootBlockSpan {
+                    line_no: 2,
+                    expr: MootBlock::Test(MootBlockTest {
+                        kind: MootBlockTestKind::Eval,
+                        prog_lines: vec!["4;"],
+                        expected_output: Some(MootBlockTestExpectedOutput {
+                            expected_output: "4",
+                            verbatim: false,
+                            line_no: 3,
+                        }),
+                    })
+                }
+            ]
+        )
+    }
+}

--- a/tools/moot-lang/syntaxes/moot.tmLanguage.json
+++ b/tools/moot-lang/syntaxes/moot.tmLanguage.json
@@ -30,7 +30,7 @@
         },
         {
           "name": "variable.language.moo",
-          "match": "\\b(INT|NUM|FLOAT|LIST|MAP|STR|ANON|OBJ|ERR|player|this|caller|verb|args|argstr|dobj|dobjstr|prepstr|iobj|iobjstr)\\b"
+          "match": "\\b(INT|NUM|FLOAT|LIST|MAP|STR|ANON|OBJ|ERR|false|true|player|this|caller|verb|args|argstr|dobj|dobjstr|prepstr|iobj|iobjstr)\\b"
         },
         {
           "name": "constant.language.moo.error",
@@ -62,7 +62,7 @@
         },
         {
           "name": "markup.inserted.moot.input",
-          "match": "^[;%>]"
+          "match": "^[;%>&]"
         },
         {
           "name": "markup.inline.raw.moot.output",


### PR DESCRIPTION
The original hand-built parser had a bunch of weird behaviors around comments and missing / present empty lines & line endings, and was kinda fragile in general. This should make everything better (?)