### PR TITLE
test: migrate `test_parent_chparent`

### DIFF
--- a/crates/kernel/testsuite/moot/objects/test_parent_chparent.moot
+++ b/crates/kernel/testsuite/moot/objects/test_parent_chparent.moot
@@ -1,0 +1,84 @@
+// Adapted from https://github.com/toddsundsted/stunt/blob/e83e946/test/test_objects.rb
+//   def test_parent_chparent 
+
+; add_property($system, "a", create($nothing), {player, "wrc"});
+; add_property($system, "b", create($nothing), {player, "wrc"});
+; add_property($system, "c", create($nothing), {player, "wrc"});
+
+; return parent($a);
+$nothing
+; return parent($b);
+$nothing
+; return parent($c);
+$nothing
+
+; chparent($a, $b);
+; chparent($b, $c);
+
+; return parent($a);
+$b
+; return parent($b);
+$c
+; return parent($c);
+$nothing
+
+; return children($a);
+{}
+; return children($b);
+{$a}
+; return children($c);
+{$b}
+
+; chparent($a, $c);
+
+; return parent($a);
+$c
+; return parent($b);
+$c
+; return parent($c);
+$nothing
+
+; return children($a);
+{}
+; return children($b);
+{}
+; return children($c);
+{$b, $a}
+
+; chparent($a, $nothing);
+; chparent($b, $nothing);
+; chparent($c, $nothing);
+
+; return parent($a);
+$nothing
+; return parent($b);
+$nothing
+; return parent($c);
+$nothing
+
+; return children($a);
+{}
+; return children($b);
+{}
+; return children($c);
+{}
+
+// Test that if two objects define the same property by name, the
+// assigned property value (and info) is not preserved across
+// chparent.  Test both the single and multiple inheritance
+// cases.
+
+; add_property($a, "foo", "foo", {$a, "c"});
+; add_property($b, "foo", "foo", {$b, ""});
+
+; chparent($c, $a);
+; return property_info($c, "foo");
+{player, "c"}
+; $c.foo = "bar";
+; return $c.foo;
+"bar"
+; chparent($c, $b);
+; return property_info($c, "foo");
+{$b, ""}
+; return $c.foo;
+"foo"

--- a/crates/testing/moot/src/lib.rs
+++ b/crates/testing/moot/src/lib.rs
@@ -122,8 +122,19 @@ fn handle_test<R: MootRunner, F: Fn() -> eyre::Result<()>>(
     path: &Path,
 ) -> eyre::Result<()> {
     execute_test_prog(runner, player, line_no, test, &validate_state)?;
-    for expectation in &test.expected_output {
-        execute_test_expectation(runner, player, &validate_state, expectation, path)?;
+
+    if test.expected_output.is_empty() {
+        if test.kind == MootBlockTestKind::EvalBg {
+            // Discard the result of the eval
+            runner.read_eval_result(player)?;
+        } else if test.kind == MootBlockTestKind::Eval {
+            // Assert that we got the empty result
+            assert_eval_result(runner, player, None, path, line_no)?;
+        }
+    } else {
+        for expectation in &test.expected_output {
+            execute_test_expectation(runner, player, &validate_state, expectation, path)?;
+        }
     }
 
     Ok(())

--- a/crates/testing/moot/tests/moot_lmoo.rs
+++ b/crates/testing/moot/tests/moot_lmoo.rs
@@ -76,6 +76,7 @@ fn test_moo(path: &Path) {
 #[ignore = "Useful for debugging; just run a single test against 'real' MOO"]
 fn test_single() {
     test_moo(
-        &PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../kernel/testsuite/moot/truthiness.moot"),
+        &PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("../../kernel/testsuite/moot/objects/test_parent_chparent.moot"),
     );
 }

--- a/tools/moot-translate.awk
+++ b/tools/moot-translate.awk
@@ -1,0 +1,47 @@
+#!/usr/bin/env -S awk -f
+# Copyright (C) 2025 Ryan Daum <ryan.daum@gmail.com> This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 3.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+
+{
+    # Array syntax, comments, strings
+    gsub(/\[/, "{");
+    gsub(/\]/, "}");
+    gsub(/#/, "//");
+    gsub(/'/, "\"");
+
+    # Standard corified references
+    gsub("NOTHING", "$nothing");
+    gsub("AMBIGUOUS_MATCH", "$ambiguous_match");
+    gsub("FAILED_MATCH", "$failed_match");
+    gsub("INVALID_OBJECT", "$invalid_object");
+
+    # Assigment. Watch out: any variable names that are built-in MOO properties must be manually changed.
+    s = gensub(/^(.*) = (.*)/, "; add_property($system, \"\\1\", \\2, {player, \"wrc\"});", "g", $0);
+
+    # assert_equal. Heuristics: LHS is the expected value. RHS is a function call.
+    s = gensub(/^assert_equal (.*), ([a-z_]+\(.+\))/, "; return \\2;\n\\1", "g", s); 
+
+    # assert_not_equal. Same heuristics as assert_equal.
+    s = gensub(/^assert_not_equal (.*), ([a-z_]+\(.+\))/, "; return \\1 == \\2;\n0", "g", s); 
+
+    # set(obj, field, value)
+    s = gensub(/^set\((.*), ['"](.*)['"], (.*)\)/, "; \\1.\\2 = \\3;", "g", s);
+
+    # get(obj, field)
+    s = gensub(/^get\((.*), ['"](.*)['"]\)/, "; return \\1.\\2;", "g", s);
+
+    # function calls with parens
+    s = gensub(/^([a-z_]+)\((.*)\)$/, "; \\1(\\2);", "g", s);
+
+    # function calls without parens, because yay Ruby
+    s = gensub(/^([a-z_]+) (.*)$/, "; \\1(\\2);", "g", s);
+
+    # TODO: somehow rewrite common variables like `a` into `$a`, but only when used as a variable?
+    #       this might be too hard to do without a full parser
+
+    print s
+}


### PR DESCRIPTION
... and some stuff I used to do it, because as discussed, I wish stacked PRs would exist but they don't.

This new test passes against both Lambda and `moor`.