### PR TITLE
test: migrated `test_properties_and_inheritance`

### DIFF
--- a/crates/db/src/db_transaction.rs
+++ b/crates/db/src/db_transaction.rs
@@ -968,15 +968,13 @@ impl WorldStateTransaction for DbTransaction {
         let locations = ObjSet::from_items(&[obj.clone()]).with_concatenated(descendants);
         for location in locations.iter() {
             let props: PropDefs = self.get_properties(&location)?;
-            let props = props
-                .with_removed(uuid)
-                .expect("Unable to remove property definition");
-
-            self.object_propdefs
-                .upsert(location.clone(), props)
-                .map_err(|e| {
-                    WorldStateError::DatabaseError(format!("Error deleting property: {:?}", e))
-                })?;
+            if let Some(props) = props.with_removed(uuid) {
+                self.object_propdefs
+                    .upsert(location.clone(), props)
+                    .map_err(|e| {
+                        WorldStateError::DatabaseError(format!("Error deleting property: {:?}", e))
+                    })?;
+            }
         }
         Ok(())
     }

--- a/crates/kernel/testsuite/moot/objects/test_properties_and_inheritance.moot
+++ b/crates/kernel/testsuite/moot/objects/test_properties_and_inheritance.moot
@@ -1,0 +1,257 @@
+// Adapted from https://github.com/toddsundsted/stunt/blob/e83e946/test/test_objects.rb
+//   def test_properties_and_inheritance
+
+@wizard
+; add_property($system, "e", create($nothing), {player, "wrc"});
+; add_property($system, "b", create($nothing), {player, "wrc"});
+; add_property($system, "c", create($nothing), {player, "wrc"});
+
+; add_property($system, "m", create($e), {player, "wrc"});
+; add_property($system, "n", create($e), {player, "wrc"});
+
+; add_property($e, "e1", "e1", {player, ""});
+; add_property($e, "e", "e", {player, ""});
+; add_property($b, "b1", {"b1"}, {player, "r"});
+; add_property($b, "b", {"b"}, {player, "r"});
+; add_property($c, "c", player.location, {player, "w"});
+
+; return property_info($e, "e");
+{player, ""}
+; return property_info($e, "e1");
+{player, ""}
+; return property_info($e, "b");
+E_PROPNF
+; return property_info($e, "b1");
+E_PROPNF
+; return property_info($e, "c");
+E_PROPNF
+; return property_info($m, "e1");
+{player, ""}
+; return property_info($m, "e");
+{player, ""}
+; return property_info($n, "b1");
+E_PROPNF
+; return property_info($n, "b");
+E_PROPNF
+
+; return $e.e;
+"e"
+; return $e.e1;
+"e1"
+; return $e.b;
+E_PROPNF
+; return $e.b1;
+E_PROPNF
+; return $e.c;
+E_PROPNF
+; return $m.e;
+"e"
+; return $m.e1;
+"e1"
+; return $n.e;
+"e"
+; return $n.e1;
+"e1"
+
+; return $e.e = "ee";
+"ee"
+; return $e.b = "bb";
+E_PROPNF
+; return $e.c = "cc";
+E_PROPNF
+; return $m.e = "11";
+"11"
+; return $n.e = "ee";
+"ee"
+
+; return $e.e;
+"ee"
+; return $e.b;
+E_PROPNF
+; return $e.c;
+E_PROPNF
+; return $m.e;
+"11"
+; return $n.e;
+"ee"
+
+; return $e.e = "e";
+"e"
+
+; return $e.e;
+"e"
+; return $e.b;
+E_PROPNF
+; return $e.c;
+E_PROPNF
+; return $m.e;
+"11"
+; return $n.e;
+"ee"
+
+; clear_property($m, "e");
+; clear_property($n, "e");
+
+; chparent($e, $b);
+
+; return property_info($e, "e");
+{player, ""}
+; return property_info($e, "e1");
+{player, ""}
+; return property_info($e, "b");
+{player, "r"}
+; return property_info($e, "b1");
+{player, "r"}
+; return property_info($e, "c");
+E_PROPNF
+; return property_info($m, "e1");
+{player, ""}
+; return property_info($m, "e");
+{player, ""}
+; return property_info($n, "b1");
+{player, "r"}
+; return property_info($n, "b");
+{player, "r"}
+
+; return $e.e;
+"e"
+; return $e.e1;
+"e1"
+; return $e.b;
+{"b"}
+; return $e.b1;
+{"b1"}
+; return $e.c;
+E_PROPNF
+; return $m.e;
+"e"
+; return $m.e1;
+"e1"
+; return $n.e;
+"e"
+; return $n.e1;
+"e1"
+
+; chparent($e, $c);
+
+; return property_info($e, "e");
+{player, ""}
+; return property_info($e, "e1");
+{player, ""}
+; return property_info($e, "b");
+E_PROPNF
+; return property_info($e, "b1");
+E_PROPNF
+; return property_info($e, "c");
+{player, "w"}
+; return property_info($m, "e1");
+{player, ""}
+; return property_info($m, "e");
+{player, ""}
+; return property_info($n, "b1");
+E_PROPNF
+; return property_info($n, "b");
+E_PROPNF
+; return property_info($m, "c");
+{player, "w"}
+; return property_info($n, "c");
+{player, "w"}
+
+; return $e.e;
+"e"
+; return $e.e1;
+"e1"
+; return $e.b;
+E_PROPNF
+; return $e.b1;
+E_PROPNF
+; return $e.c;
+player.location
+; return $m.e;
+"e"
+; return $m.e1;
+"e1"
+; return $n.e;
+"e"
+; return $n.e1;
+"e1"
+; return $m.c;
+player.location
+; return $n.c;
+player.location
+
+; delete_property($c, "c");
+; add_property($c, "c", "c", {player, "c"});
+
+; return property_info($e, "e");
+{player, ""}
+; return property_info($e, "e1");
+{player, ""}
+; return property_info($e, "b");
+E_PROPNF
+; return property_info($e, "b1");
+E_PROPNF
+; return property_info($e, "c");
+{player, "c"}
+; return property_info($m, "e1");
+{player, ""}
+; return property_info($m, "e");
+{player, ""}
+; return property_info($n, "b1");
+E_PROPNF
+; return property_info($n, "b");
+E_PROPNF
+; return property_info($m, "c");
+{player, "c"}
+; return property_info($n, "c");
+{player, "c"}
+
+; return $e.e;
+"e"
+; return $e.e1;
+"e1"
+; return $e.b;
+E_PROPNF
+; return $e.b1;
+E_PROPNF
+; return $e.c;
+"c"
+; return $m.e;
+"e"
+; return $m.e1;
+"e1"
+; return $n.e;
+"e"
+; return $n.e1;
+"e1"
+; return $m.c;
+"c"
+; return $n.c;
+"c"
+
+; return delete_property($m, "e");
+E_PROPNF
+; return delete_property($n, "e");
+E_PROPNF
+
+; delete_property($c, "c");
+
+; return $e.e;
+"e"
+; return $e.b;
+E_PROPNF
+; return $e.c;
+E_PROPNF
+; return $m.e;
+"e"
+; return $n.e;
+"e"
+
+; add_property($c, "c", player.location, {player, "w"});
+; clear_property($m, "e");
+; clear_property($n, "e");
+
+; return delete_property($m, "e");
+E_PROPNF
+; return delete_property($n, "e");
+E_PROPNF

--- a/crates/kernel/testsuite/moot_suite.rs
+++ b/crates/kernel/testsuite/moot_suite.rs
@@ -168,5 +168,5 @@ fn test(db: Box<dyn Database>, path: &Path) {
 fn test_single() {
     // cargo test -p moor-kernel --test moot-suite test_single -- --ignored
     // CARGO_PROFILE_RELEASE_DEBUG=true cargo flamegraph --test moot-suite -- test_single --ignored
-    test_with_db(&testsuite_dir().join("moot/objects/test_command_verbs_and_inheritance.moot"));
+    test_with_db(&testsuite_dir().join("moot/objects/test_properties_and_inheritance.moot"));
 }

--- a/crates/testing/moot/tests/moot_lmoo.rs
+++ b/crates/testing/moot/tests/moot_lmoo.rs
@@ -85,6 +85,6 @@ fn test_moo(path: &Path) {
 fn test_single() {
     test_moo(
         &PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-            .join("../../kernel/testsuite/moot/objects/test_command_verbs_and_inheritance.moot"),
+            .join("../../kernel/testsuite/moot/objects/test_properties_and_inheritance.moot"),
     );
 }

--- a/tools/moot-translate.awk
+++ b/tools/moot-translate.awk
@@ -72,6 +72,9 @@
     # set(obj, field, value)
     s = gensub(/^set\((.*), ['"](.*)['"], (.*)\)/, "; $\\1.\\2 = \\3;", "g", s);
 
+    # return set(obj, field, value)
+    s = gensub(/^return set\((.*), ['"](.*)['"], (.*)\)/, "; return \\1.\\2 = \\3;", "g", s);
+
     # get(obj, field)
     s = gensub(/^get\((.*), ['"](.*)['"]\)/, "; return $\\1.\\2;", "g", s);
 


### PR DESCRIPTION
# !!! WATCH OUT

**Look at the `fix` commit very very carefully.** This fix makes the assumption that propdefs only exist on the objects that actually had the property directly added to them (and so inheritance resolution takes place at read time). If this is *not* the case, then this "fix" hides the real problem (the real problem being that the propdef is not pushed to somewhere it *should* be). In this case it's also concerning that this is not caught by anything else in the added tests.

FTR, failure before the `fix` commit:

```
MootBlockSpan { line_no: 180, expr: Test(MootBlockTest { kind: Eval, prog_lines: ["return $n.c;"], expected_output: [MootBlockTestExpectedOutput { expected_output: "player.location", verbatim: false, line_no: 181 }] }) }
#3 >> ; return $n.c; "moot-line:180";
#3 << #2
#3 >> ; return player.location; "moot-expect-line:181";
#3 << #2
MootBlockSpan { line_no: 183, expr: Test(MootBlockTest { kind: Eval, prog_lines: ["delete_property($c, \"c\");"], expected_output: [] }) }
#3 >> ; delete_property($c, "c"); "moot-line:183";

thread 'moor-task-162-player-#3' panicked at crates/db/src/db_transaction.rs:973:18:
Unable to remove property definition
```