### PR TITLE
feat(moot): optional colored output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2238,6 +2238,8 @@ dependencies = [
 name = "moor-kernel"
 version = "0.9.0-alpha"
 dependencies = [
+ "anstream",
+ "anstyle",
  "argon2",
  "bincode",
  "byteview",
@@ -2303,6 +2305,8 @@ dependencies = [
 name = "moor-moot"
 version = "0.9.0-alpha"
 dependencies = [
+ "anstream",
+ "anstyle",
  "eyre",
  "moor-var",
  "pest",

--- a/crates/kernel/Cargo.toml
+++ b/crates/kernel/Cargo.toml
@@ -25,6 +25,13 @@ test-case.workspace = true
 test_each_file.workspace = true
 tracing.workspace = true
 
+# SOURCE OF TRUTH FOR VERSIONS: crates/testing/moot/Cargo.toml
+# Optional dependencies are not supported for workspace-inherited dependencies.
+# Alternative to optional color support is enforced color support; then we can move `anstream`
+# and `anstyle` to the top level as usual.
+anstream = { version = "0.6.18", features = ["test"] }
+anstyle = { version = "1.0.10" }
+
 [[test]]
 name = "regression-suite"
 path = "testsuite/regression_suite.rs"
@@ -39,10 +46,10 @@ harness = false
 
 [dependencies]
 ## Own
+moor-common = { path = "../common" }
 moor-compiler = { path = "../compiler" }
 moor-db = { path = "../db" }
-moor-moot = { path = "../testing/moot" }
-moor-common = { path = "../common" }
+moor-moot = { path = "../testing/moot", features = ["colors"] }
 moor-var = { path = "../var" }
 
 ## General usefulness

--- a/crates/kernel/testsuite/moot_suite.rs
+++ b/crates/kernel/testsuite/moot_suite.rs
@@ -17,6 +17,7 @@
 
 use std::{path::Path, sync::Arc};
 
+use anstream::eprintln;
 use eyre::Context;
 
 use common::{create_db, testsuite_dir};
@@ -33,6 +34,7 @@ use moor_kernel::{
         sessions::{NoopClientSession, Session},
     },
 };
+use moor_moot::stylesheet::MOOT_STYLESHEET;
 use moor_moot::{MootOptions, MootRunner, execute_moot_test};
 use moor_var::{Obj, Var, v_none};
 
@@ -58,7 +60,15 @@ impl MootRunner for SchedulerMootRunner {
 
     fn eval<S: Into<String>>(&mut self, player: &Obj, command: S) -> eyre::Result<()> {
         let command = command.into();
-        eprintln!("{player} >> ; {command}");
+        eprintln!(
+            "{}{player}{:#} {}>>{:#} {}; {command}{:#}",
+            MOOT_STYLESHEET.remote,
+            MOOT_STYLESHEET.remote,
+            MOOT_STYLESHEET.arrows,
+            MOOT_STYLESHEET.arrows,
+            MOOT_STYLESHEET.request,
+            MOOT_STYLESHEET.request
+        );
         self.eval_result = Some(
             scheduler_test_utils::call_eval(
                 self.scheduler.clone(),
@@ -76,7 +86,15 @@ impl MootRunner for SchedulerMootRunner {
 
     fn command<S: AsRef<str>>(&mut self, player: &Obj, command: S) -> eyre::Result<()> {
         let command: &str = command.as_ref();
-        eprintln!("{player} >> {}", command);
+        eprintln!(
+            "{}{player}{:#} {}>>{:#} {}{command}{:#}",
+            MOOT_STYLESHEET.remote,
+            MOOT_STYLESHEET.remote,
+            MOOT_STYLESHEET.arrows,
+            MOOT_STYLESHEET.arrows,
+            MOOT_STYLESHEET.request,
+            MOOT_STYLESHEET.request
+        );
         self.eval_result = Some(
             scheduler_test_utils::call_command(
                 self.scheduler.clone(),
@@ -101,10 +119,18 @@ impl MootRunner for SchedulerMootRunner {
     }
 
     fn read_eval_result(&mut self, player: &Obj) -> eyre::Result<Option<Var>> {
-        Ok(self
-            .eval_result
-            .take()
-            .inspect(|var| eprintln!("{player} << {}", to_literal(var))))
+        Ok(self.eval_result.take().inspect(|var| {
+            eprintln!(
+                "{}{player}{:#} {}<<{:#} {}{}{:#}",
+                MOOT_STYLESHEET.remote,
+                MOOT_STYLESHEET.remote,
+                MOOT_STYLESHEET.arrows,
+                MOOT_STYLESHEET.arrows,
+                MOOT_STYLESHEET.response,
+                to_literal(var),
+                MOOT_STYLESHEET.response,
+            )
+        }))
     }
 
     fn read_command_result(&mut self, player: &Obj) -> eyre::Result<Option<Self::Value>> {

--- a/crates/telnet-host/Cargo.toml
+++ b/crates/telnet-host/Cargo.toml
@@ -12,10 +12,10 @@ rust-version.workspace = true
 description = "A server which presents a classic LambdaMOO-style line-based TCP interface for interacting with a moor daemon."
 
 [dependencies]
-moor-var = { path = "../var" }
-moor-compiler = { path = "../compiler" }
-moor-moot = { path = "../testing/moot" }
 moor-common = { path = "../common" }
+moor-compiler = { path = "../compiler" }
+moor-moot = { path = "../testing/moot", features = ["colors"] }
+moor-var = { path = "../var" }
 rpc-async-client = { path = "../rpc/rpc-async-client" }
 rpc-common = { path = "../rpc/rpc-common" }
 

--- a/crates/testing/moot/Cargo.toml
+++ b/crates/testing/moot/Cargo.toml
@@ -12,11 +12,18 @@ rust-version.workspace = true
 description = "Execute MOO interaction tests described in simple text files."
 
 [dependencies]
+# Optional dependencies are not supported for workspace-inherited dependencies.
+# Alternative to optional color support is enforced color support; then we can move `anstream`
+# and `anstyle` to the top level as usual.
+anstream = { version = "0.6.18", optional = true, features = ["test"] }
+anstyle = { version = "1.0.10", optional = true }
 eyre.workspace = true
+moor-var = { path = "../../var" }
 pest.workspace = true
 pest_derive.workspace = true
 pretty_assertions.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
 
-moor-var = { path = "../../var" }
+[features]
+colors = ["dep:anstream", "dep:anstyle"]

--- a/crates/testing/moot/src/lib.rs
+++ b/crates/testing/moot/src/lib.rs
@@ -12,7 +12,12 @@
 //
 
 mod parser;
+pub mod stylesheet;
 pub mod telnet;
+
+#[cfg(feature = "colors")]
+use anstream::eprintln;
+use stylesheet::MOOT_STYLESHEET;
 
 use std::{
     path::{Path, PathBuf},
@@ -123,7 +128,12 @@ pub fn execute_moot_test<R: MootRunner, F: Fn() -> eyre::Result<()>>(
     validate_state: F,
 ) {
     init_logging(options);
-    eprintln!("Test definition: {}", path.display());
+    eprintln!(
+        "{}Test definition: {}{:#}",
+        MOOT_STYLESHEET.test_header,
+        path.display(),
+        MOOT_STYLESHEET.test_header
+    );
 
     let test = std::fs::read_to_string(path)
         .wrap_err(format!("{}", path.display()))
@@ -131,7 +141,10 @@ pub fn execute_moot_test<R: MootRunner, F: Fn() -> eyre::Result<()>>(
 
     let mut player = options.wizard_object.clone();
     for span in parser::parse(&test).context("parse").unwrap() {
-        eprintln!("{:?}", span);
+        eprintln!(
+            "{}{:?}{:#}",
+            MOOT_STYLESHEET.block_header, span, MOOT_STYLESHEET.block_header
+        );
         match &span.expr {
             MootBlock::ChangePlayer(change) => {
                 player = handle_change_player(options, change.name)

--- a/crates/testing/moot/src/stylesheet.rs
+++ b/crates/testing/moot/src/stylesheet.rs
@@ -1,0 +1,45 @@
+// Copyright (C) 2025 Ryan Daum <ryan.daum@gmail.com> This program is free
+// software: you can redistribute it and/or modify it under the terms of the GNU
+// General Public License as published by the Free Software Foundation, version
+// 3.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program. If not, see <https://www.gnu.org/licenses/>.
+//
+
+pub struct MootStylesheet<S: std::fmt::Display> {
+    pub test_header: S,
+    pub block_header: S,
+    pub remote: S,
+    pub arrows: S,
+    pub request: S,
+    pub response: S,
+}
+
+#[cfg(feature = "colors")]
+pub const MOOT_STYLESHEET: MootStylesheet<anstyle::Style> = MootStylesheet {
+    test_header: anstyle::Style::new()
+        .bold()
+        .fg_color(Some(anstyle::Color::Ansi(anstyle::AnsiColor::BrightWhite))),
+    block_header: anstyle::Style::new().dimmed(),
+    remote: anstyle::Style::new()
+        .dimmed()
+        .fg_color(Some(anstyle::Color::Ansi(anstyle::AnsiColor::Cyan))),
+    arrows: anstyle::Style::new().dimmed(),
+    request: anstyle::Style::new().fg_color(Some(anstyle::Color::Ansi(anstyle::AnsiColor::Yellow))),
+    response: anstyle::Style::new().fg_color(Some(anstyle::Color::Ansi(anstyle::AnsiColor::White))),
+};
+
+#[cfg(not(feature = "colors"))]
+pub const MOOT_STYLESHEET: MootStylesheet<&str> = MootStylesheet {
+    test_header: "",
+    block_header: "",
+    remote: "",
+    arrows: "",
+    request: "",
+    response: "",
+};

--- a/crates/testing/moot/src/telnet.rs
+++ b/crates/testing/moot/src/telnet.rs
@@ -11,6 +11,8 @@
 // this program. If not, see <https://www.gnu.org/licenses/>.
 //
 
+#[cfg(feature = "colors")]
+use anstream::eprintln;
 use eyre::{WrapErr, eyre};
 use moor_var::Obj;
 use std::{
@@ -22,7 +24,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use crate::MootRunner;
+use crate::{MootRunner, stylesheet::MOOT_STYLESHEET};
 
 pub struct ManagedChild {
     name: &'static str,
@@ -105,7 +107,16 @@ impl MootClient {
             .write_all(s.as_ref().as_bytes())
             .and_then(|_| writer.write_all(b"\n"))
             .wrap_err_with(|| format!("writing port={port}"));
-        eprintln!("{} >> {}", port, s.as_ref());
+        let s = s.as_ref();
+        eprintln!(
+            "{}{port}{:#} {}>>{:#} {}{s}{:#}",
+            MOOT_STYLESHEET.remote,
+            MOOT_STYLESHEET.remote,
+            MOOT_STYLESHEET.arrows,
+            MOOT_STYLESHEET.arrows,
+            MOOT_STYLESHEET.request,
+            MOOT_STYLESHEET.request,
+        );
         result
     }
 
@@ -113,7 +124,14 @@ impl MootClient {
         let mut buf = String::new();
         match BufReader::new(&self.stream).read_line(&mut buf) {
             Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
-                eprintln!("{} read timeout", self.port());
+                let port = self.port();
+                eprintln!(
+                    "{}{port}{:#} {}(no response){:#}",
+                    MOOT_STYLESHEET.remote,
+                    MOOT_STYLESHEET.remote,
+                    MOOT_STYLESHEET.response,
+                    MOOT_STYLESHEET.response
+                );
                 Ok(None)
             }
             Err(e) => {
@@ -122,7 +140,16 @@ impl MootClient {
             Ok(0) => Ok(None),
             Ok(_) => {
                 let line = buf.trim_end_matches(['\r', '\n']).to_string();
-                eprintln!("{} << {}", self.port(), line);
+                let port = self.port();
+                eprintln!(
+                    "{}{port}{:#} {}<<{:#} {}{line}{:#}",
+                    MOOT_STYLESHEET.remote,
+                    MOOT_STYLESHEET.remote,
+                    MOOT_STYLESHEET.arrows,
+                    MOOT_STYLESHEET.arrows,
+                    MOOT_STYLESHEET.response,
+                    MOOT_STYLESHEET.response,
+                );
                 Ok(Some(line))
             }
         }


### PR DESCRIPTION
This should make it much easier to skim `moot` test output. Does for me, anyway!

# `kernel` tests

![image](https://github.com/user-attachments/assets/7af65837-e70e-4dc0-bd4b-e17e3d505418)

# `telnet` tests

Against real LambdaMOO, with LambdaMOO logs interspersed (`crates/testing/moot/tests/moot_lmoo.rs`)

![image](https://github.com/user-attachments/assets/a81395c6-eb87-42db-8035-6fe0e5e543fc)

Against mooR, with mooR server logs interspersed (`crates/telnet-host/tests/integration_test.rs`)

![image](https://github.com/user-attachments/assets/337574ea-1c6b-41bb-8717-ea3fb75c225b)

