### PR TITLE
Fix the resume() builtin so the second arg is optional

### DIFF
--- a/crates/kernel/src/builtins/bf_server.rs
+++ b/crates/kernel/src/builtins/bf_server.rs
@@ -680,7 +680,9 @@ fn bf_kill_task(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
 bf_declare!(kill_task, bf_kill_task);
 
 fn bf_resume(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
-    if bf_args.args.len() < 2 {
+    // Syntax: resume(INT task-ID[, ANY value])
+    // Resumes a previously suspended task, optionally with a value to pass back to the suspend() call
+    if bf_args.args.len() > 2 {
         return Err(BfErr::Code(E_ARGS));
     }
 


### PR DESCRIPTION
Surely the smallest PR ever.
Makes the value (second arg to resume) optional as intended, and adds a syntax comment.
I'd also like to write a moot test to show a pass after the fix but don't understand enough to yet. Happy to add with another commit.