### PR TITLE
Add ARIA live region to output window so text is auto-spoken by screen readers

### DIFF
--- a/crates/web-host/src/client/narrative.ts
+++ b/crates/web-host/src/client/narrative.ts
@@ -401,6 +401,9 @@ const OutputWindow = (player: State<Player>) => {
     return div({
         id: "output_window",
         class: "output_window",
+        role: "log",
+        "aria-live": "polite",
+        "aria-atomic": "false",
     });
 };
 


### PR DESCRIPTION
This PR adds basic support for automatically speaking text as it arrives in the output window of the web host.
Note that the user's typed text is announced as well (as it appears in the output); this seems ok to me for a first attempt, perhaps we make this more complex later with some client setting to choose not to announce input.
The role here is set to log, and atomic is false to only announce added text, rather than speaking the entire window each time.