### PR TITLE
Release Time Optimization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -164,3 +164,14 @@ ssh-key = "0.6"
 
 # For the consistency checker in `load-tools`
 edn-format = "3.3"
+
+[profile.release]
+# The Rust compiler splits crates into multiple codegen units to parallelize (and thus speed up) 
+# compilation. However, this might cause it to miss some potential optimizations. 
+# You may be able to improve runtime speed and reduce binary size, at the cost of increased 
+# compile times, by setting the number of units to one.
+codegen-units = 1
+
+# Link-time optimization (LTO) is a whole-program optimization technique that can improve runtime
+# speed by 10-20% or more, and also reduce binary size, at the cost of worse compile times.
+lto = "fat"

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,9 @@ COPY ./Cargo.lock ./Cargo.lock
 # We bring this over so we can get the git hash via shadow-rs. A bit bloated, but oh well.
 COPY ./.git ./.git
 
+# Set some additional build flags
+ENV RUSTFLAGS="-C target-cpu=native"
+
 RUN CARGO_PROFILE_RELEASE_DEBUG=true cargo build --all-targets --release
 COPY ./crates/web-host/src/client ./client
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ COPY ./Cargo.lock ./Cargo.lock
 COPY ./.git ./.git
 
 # Set some additional build flags
+ENV MALLOC_CONF="thp:always,metadata_thp:always"
 ENV RUSTFLAGS="-C target-cpu=native"
 
 RUN CARGO_PROFILE_RELEASE_DEBUG=true cargo build --all-targets --release

--- a/crates/daemon/Cargo.toml
+++ b/crates/daemon/Cargo.toml
@@ -25,6 +25,7 @@ moor-db = { path = "../db" }
 moor-kernel = { path = "../kernel" }
 moor-var = { path = "../var" }
 rpc-common = { path = "../rpc/rpc-common" }
+tikv-jemallocator = "0.6.0"
 
 ## Command line arguments parsing.
 clap.workspace = true

--- a/crates/daemon/src/main.rs
+++ b/crates/daemon/src/main.rs
@@ -37,6 +37,13 @@ mod rpc_session;
 mod sys_ctrl;
 mod tasks_fjall;
 
+#[cfg(not(target_env = "msvc"))]
+use tikv_jemallocator::Jemalloc;
+
+#[cfg(not(target_env = "msvc"))]
+#[global_allocator]
+static GLOBAL: Jemalloc = Jemalloc;
+
 /// Host for the moor runtime.
 ///   * Brings up the database
 ///   * Instantiates a scheduler


### PR DESCRIPTION
# Summary
This PR introduces several changes aimed at optimizing the performance and reducing the binary size of the daemon in release builds. The improvements focus on allocator performance, compilation tuning, and runtime configuration.

## Changes
### Cargo.toml (Release Profile Configuration):

Set codegen-units = 1:
Forces the Rust compiler to use a single code generation unit, which enables more aggressive optimizations across the entire crate at the cost of longer compile times.

Enabled lto = "fat":
Activates fat Link Time Optimization, which performs whole-program optimization to improve runtime performance and reduce the final binary size.

### main.rs (Memory Allocator Configuration):

Introduced tikv_jemallocator::Jemalloc as the global allocator for non-MSVC targets:
Jemalloc is a high-performance memory allocator known for better allocation/deallocation performance and reduced fragmentation compared to the system allocator, especially in multithreaded environments.

### Dockerfile (Runtime and Compile-Time Environment):

Set ENV MALLOC_CONF="thp:always,metadata_thp:always":
Configures Jemalloc to use transparent huge pages (THP) for both user and metadata allocations, which can reduce TLB misses and improve memory throughput.

Set ENV RUSTFLAGS="-C target-cpu=native":
Instructs the compiler to optimize the build for the specific CPU architecture of the build machine, enabling all supported CPU features for maximum performance.

## Motivation
These changes are driven by the need to:

* Improve runtime performance through better memory allocation and CPU-targeted compilation.
* Reduce binary size where possible.
* Ensure optimal use of system resources in production environments, especially when running inside containers.

While these changes slightly increase compile times, the tradeoff is worthwhile for release builds where runtime efficiency is critical.