### PR TITLE
The great Error reworking of 2025

### DIFF
--- a/crates/common/src/model/objects.rs
+++ b/crates/common/src/model/objects.rs
@@ -76,7 +76,7 @@ impl ObjectRef {
 impl Display for ObjectRef {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::Id(id) => write!(f, "#{}", id),
+            Self::Id(id) => write!(f, "{}", id),
             Self::SysObj(symbols) => {
                 let mut s = String::new();
                 for sym in symbols {

--- a/crates/common/src/tasks/errors.rs
+++ b/crates/common/src/tasks/errors.rs
@@ -71,16 +71,14 @@ pub enum SchedulerError {
 
 #[derive(Clone, Eq, PartialEq, Debug, Decode, Encode)]
 pub struct Exception {
-    pub code: Error,
-    pub msg: String,
-    pub value: Var,
+    pub error: Error,
     pub stack: Vec<Var>,
     pub backtrace: Vec<Var>,
 }
 
 impl Display for Exception {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "Uncaught exception: {} ({})", self.msg, self.code)
+        write!(f, "Uncaught exception: {}", self.error)
     }
 }
 

--- a/crates/compiler/src/ast.rs
+++ b/crates/compiler/src/ast.rs
@@ -11,7 +11,7 @@
 // this program. If not, see <https://www.gnu.org/licenses/>.
 //
 
-use moor_var::{Symbol, VarType};
+use moor_var::{ErrorCode, Symbol, VarType};
 use std::fmt::Display;
 
 use moor_var::Var;
@@ -130,6 +130,7 @@ pub enum Expr {
     },
     TypeConstant(VarType),
     Value(Var),
+    Error(ErrorCode, Option<Box<Expr>>),
     Id(UnboundName),
     Binary(BinaryOp, Box<Expr>, Box<Expr>),
     And(Box<Expr>, Box<Expr>),

--- a/crates/compiler/src/builtins.rs
+++ b/crates/compiler/src/builtins.rs
@@ -18,7 +18,7 @@ use bincode::{Decode, Encode};
 use lazy_static::lazy_static;
 use moor_var::Symbol;
 use moor_var::VarType;
-use moor_var::VarType::{TYPE_BOOL, TYPE_FLYWEIGHT, TYPE_MAP, TYPE_SYMBOL};
+use moor_var::VarType::{TYPE_BOOL, TYPE_ERR, TYPE_FLYWEIGHT, TYPE_MAP, TYPE_SYMBOL};
 /// Global registry of built-in function names.
 use std::collections::HashMap;
 
@@ -1227,6 +1227,20 @@ fn mk_builtin_table() -> Vec<Builtin> {
             min_args: Q(2),
             max_args: U,
             types: vec![Typed(TYPE_SYMBOL), Any],
+            implemented: true,
+        },
+        Builtin {
+            name: Symbol::mk("error_message"),
+            min_args: Q(1),
+            max_args: Q(1),
+            types: vec![Typed(TYPE_ERR)],
+            implemented: true,
+        },
+        Builtin {
+            name: Symbol::mk("error_code"),
+            min_args: Q(1),
+            max_args: Q(1),
+            types: vec![Typed(TYPE_ERR)],
             implemented: true,
         },
     ]

--- a/crates/compiler/src/codegen.rs
+++ b/crates/compiler/src/codegen.rs
@@ -374,9 +374,6 @@ impl CodegenState {
                         Err(_) => self.emit(Op::ImmBigInt(*i)),
                     },
                     Variant::Float(f) => self.emit(Op::ImmFloat(*f)),
-                    Variant::Err(e) => {
-                        self.emit(Op::ImmErr(*e));
-                    }
                     _ => {
                         let literal = self.add_literal(v);
                         self.emit(Op::Imm(literal));

--- a/crates/compiler/src/codegen_tests.rs
+++ b/crates/compiler/src/codegen_tests.rs
@@ -20,9 +20,9 @@ mod tests {
     use crate::opcode::Op::*;
     use crate::opcode::{ForSequenceOperand, ScatterArgs, ScatterLabel};
     use moor_common::model::CompileError;
-    use moor_var::Obj;
     use moor_var::SYSTEM_OBJECT;
     use moor_var::Symbol;
+    use moor_var::{E_INVARG, E_INVIND, E_PERM, E_PROPNF, E_RANGE, Obj};
 
     #[test]
     fn test_simple_add_expr() {
@@ -867,10 +867,10 @@ mod tests {
         assert_eq!(
             *binary.main_vector.as_ref(),
             vec![
-                Imm(Label(0)),
+                ImmErr(E_INVARG),
                 MakeSingletonList,
                 PushCatchLabel(0.into()),
-                Imm(Label(1)),
+                ImmErr(E_PROPNF),
                 MakeSingletonList,
                 PushCatchLabel(1.into()),
                 TryExcept {
@@ -924,9 +924,9 @@ mod tests {
         assert_eq!(
             *binary.main_vector.as_ref(),
             vec![
-                Imm(Label(0)),
+                ImmErr(E_PROPNF),
                 MakeSingletonList,
-                Imm(Label(1)),
+                ImmErr(E_PERM),
                 ListAddTail,
                 PushCatchLabel(0.into()),
                 TryCatch {
@@ -973,7 +973,7 @@ mod tests {
                     handler_label: 0.into(),
                     end_label: 1.into(),
                 },
-                Imm(Label(0)),
+                ImmErr(E_INVARG),
                 MakeSingletonList,
                 FuncCall { id: raise },
                 EndCatch(1.into()),
@@ -1512,7 +1512,7 @@ mod tests {
         assert_eq!(
             *program.main_vector.as_ref(),
             vec![
-                Imm(Label(0)),
+                ImmErr(E_RANGE),
                 MakeSingletonList,
                 PushCatchLabel(Label(0)),
                 TryExcept {
@@ -1520,7 +1520,7 @@ mod tests {
                     environment_width: 0,
                     end_label: 1.into(),
                 },
-                Imm(Label(1)),
+                Imm(Label(0)),
                 ImmInt(2),
                 // Our offset is different because we don't count PushLabel in the stack.
                 Length(Offset(0)),
@@ -1556,7 +1556,7 @@ mod tests {
         assert_eq!(
             *binary.main_vector.as_ref(),
             vec![
-                Imm(Label(0)),
+                ImmErr(E_INVIND),
                 MakeSingletonList,
                 PushCatchLabel(0.into()),
                 TryCatch {

--- a/crates/compiler/src/codegen_tests.rs
+++ b/crates/compiler/src/codegen_tests.rs
@@ -20,7 +20,6 @@ mod tests {
     use crate::opcode::Op::*;
     use crate::opcode::{ForSequenceOperand, ScatterArgs, ScatterLabel};
     use moor_common::model::CompileError;
-    use moor_var::Error::{E_INVARG, E_INVIND, E_PERM, E_PROPNF, E_RANGE};
     use moor_var::Obj;
     use moor_var::SYSTEM_OBJECT;
     use moor_var::Symbol;
@@ -868,10 +867,10 @@ mod tests {
         assert_eq!(
             *binary.main_vector.as_ref(),
             vec![
-                ImmErr(E_INVARG),
+                Imm(Label(0)),
                 MakeSingletonList,
                 PushCatchLabel(0.into()),
-                ImmErr(E_PROPNF),
+                Imm(Label(1)),
                 MakeSingletonList,
                 PushCatchLabel(1.into()),
                 TryExcept {
@@ -925,9 +924,9 @@ mod tests {
         assert_eq!(
             *binary.main_vector.as_ref(),
             vec![
-                ImmErr(E_PROPNF),
+                Imm(Label(0)),
                 MakeSingletonList,
-                ImmErr(E_PERM),
+                Imm(Label(1)),
                 ListAddTail,
                 PushCatchLabel(0.into()),
                 TryCatch {
@@ -974,7 +973,7 @@ mod tests {
                     handler_label: 0.into(),
                     end_label: 1.into(),
                 },
-                ImmErr(E_INVARG),
+                Imm(Label(0)),
                 MakeSingletonList,
                 FuncCall { id: raise },
                 EndCatch(1.into()),
@@ -1513,7 +1512,7 @@ mod tests {
         assert_eq!(
             *program.main_vector.as_ref(),
             vec![
-                ImmErr(E_RANGE),
+                Imm(Label(0)),
                 MakeSingletonList,
                 PushCatchLabel(Label(0)),
                 TryExcept {
@@ -1521,7 +1520,7 @@ mod tests {
                     environment_width: 0,
                     end_label: 1.into(),
                 },
-                Imm(Label(0)),
+                Imm(Label(1)),
                 ImmInt(2),
                 // Our offset is different because we don't count PushLabel in the stack.
                 Length(Offset(0)),
@@ -1557,7 +1556,7 @@ mod tests {
         assert_eq!(
             *binary.main_vector.as_ref(),
             vec![
-                ImmErr(E_INVIND),
+                Imm(Label(0)),
                 MakeSingletonList,
                 PushCatchLabel(0.into()),
                 TryCatch {

--- a/crates/compiler/src/decompile.rs
+++ b/crates/compiler/src/decompile.rs
@@ -11,7 +11,7 @@
 // this program. If not, see <https://www.gnu.org/licenses/>.
 //
 
-use moor_var::{Symbol, Var, v_err, v_int, v_none, v_obj};
+use moor_var::{Symbol, Var, v_int, v_none, v_obj};
 use moor_var::{Variant, v_float};
 use std::collections::{HashMap, VecDeque};
 
@@ -656,6 +656,12 @@ impl Decompile {
                 let delegate = self.pop_expr()?;
                 self.push_expr(Expr::Flyweight(Box::new(delegate), slots, contents));
             }
+            Op::MakeError(offset) => {
+                let error_code = self.program.error_operands[offset.0 as usize];
+                // The value for the error is on the stack.
+                let value = self.pop_expr()?;
+                self.push_expr(Expr::Error(error_code, Some(Box::new(value))))
+            }
             Op::Pass => {
                 let args = self.pop_expr()?;
                 let Expr::List(args) = args else {
@@ -962,7 +968,7 @@ impl Decompile {
                 self.push_expr(Expr::Value(v_float(f)));
             }
             Op::ImmErr(e) => {
-                self.push_expr(Expr::Value(v_err(e)));
+                self.push_expr(Expr::Error(e, None));
             }
             Op::ImmObjid(oid) => {
                 self.push_expr(Expr::Value(v_obj(oid)));

--- a/crates/compiler/src/moo.pest
+++ b/crates/compiler/src/moo.pest
@@ -184,7 +184,8 @@ range_end = { "$" }
 // An unambiguous assignment operator, for use in scatter assignments where list comparison could be a false match.
 ASSIGN = _{ "=" ~ !("=") }
 
-err = @{ ^"e_" ~ ident_continue+ }
+err = { errcode ~ ("(" ~ expr ~ ")")? }
+errcode = @{ ^"e_" ~ ident_continue+  }
 
 object  = @{ "#" ~ integer }
 keyword = @{

--- a/crates/compiler/src/objdef.rs
+++ b/crates/compiler/src/objdef.rs
@@ -24,8 +24,8 @@ use moor_common::model::{
 };
 use moor_common::util::BitEnum;
 use moor_var::{
-    AsByteBuffer, Error, List, NOTHING, Obj, Symbol, Var, VarType, Variant, v_bool, v_err, v_float,
-    v_flyweight, v_int, v_list, v_map, v_obj, v_str,
+    AsByteBuffer, Error, List, NOTHING, Obj, Symbol, Var, VarType, Variant, v_bool, v_error,
+    v_float, v_flyweight, v_int, v_list, v_map, v_obj, v_str,
 };
 use pest::Parser;
 use pest::error::LineColLocation;
@@ -289,7 +289,7 @@ fn parse_literal_atom(
                     message: e.to_string(),
                 }));
             };
-            Ok(v_err(e))
+            Ok(v_error(e))
         }
         Rule::ident | Rule::variable => {
             let sym = Symbol::mk(pair.as_str());
@@ -733,8 +733,7 @@ fn parse_verb_decl(
 mod tests {
     use super::*;
     use moor_common::matching::Preposition;
-    use moor_var::Error::E_INVIND;
-    use moor_var::Variant;
+    use moor_var::{E_INVIND, Variant, v_err};
 
     /// Just a simple objdef no verbs or props
     #[test]

--- a/crates/compiler/src/objdef.rs
+++ b/crates/compiler/src/objdef.rs
@@ -24,7 +24,7 @@ use moor_common::model::{
 };
 use moor_common::util::BitEnum;
 use moor_var::{
-    AsByteBuffer, Error, List, NOTHING, Obj, Symbol, Var, VarType, Variant, v_bool, v_error,
+    AsByteBuffer, ErrorCode, List, NOTHING, Obj, Symbol, Var, VarType, Variant, v_bool, v_err,
     v_float, v_flyweight, v_int, v_list, v_map, v_obj, v_str,
 };
 use pest::Parser;
@@ -281,7 +281,7 @@ fn parse_literal_atom(
         }
         Rule::err => {
             let e = pair.as_str();
-            let Some(e) = Error::parse_str(e) else {
+            let Some(e) = ErrorCode::parse_str(e) else {
                 return Err(VerbCompileError(CompileError::ParseError {
                     error_position: CompileContext::new(pair.line_col()),
                     end_line_col: None,
@@ -289,7 +289,7 @@ fn parse_literal_atom(
                     message: e.to_string(),
                 }));
             };
-            Ok(v_error(e))
+            Ok(v_err(e))
         }
         Rule::ident | Rule::variable => {
             let sym = Symbol::mk(pair.as_str());

--- a/crates/compiler/src/opcode.rs
+++ b/crates/compiler/src/opcode.rs
@@ -73,6 +73,8 @@ pub enum Op {
     ListAddTail,
     ListAppend,
     Lt,
+    /// Operand is used because not doing so blew us over our 16-byte limit for some reason.
+    MakeError(Offset),
     MakeSingletonList,
     MakeMap,
     MapInsert,

--- a/crates/compiler/src/opcode.rs
+++ b/crates/compiler/src/opcode.rs
@@ -58,7 +58,6 @@ pub enum Op {
     ImmBigInt(i64),
     ImmFloat(f64),
     ImmEmptyList,
-    ImmErr(ErrorCode),
     ImmInt(i32),
     ImmType(VarType),
     ImmNone,
@@ -73,7 +72,10 @@ pub enum Op {
     ListAddTail,
     ListAppend,
     Lt,
+    /// Pushes just an error code, and is used when the literal has no message portion.
+    ImmErr(ErrorCode),
     /// Operand is used because not doing so blew us over our 16-byte limit for some reason.
+    /// Expects stack to contain a message portion of the error, immediately after.
     MakeError(Offset),
     MakeSingletonList,
     MakeMap,

--- a/crates/compiler/src/opcode.rs
+++ b/crates/compiler/src/opcode.rs
@@ -15,8 +15,8 @@ use crate::builtins::BuiltinId;
 use crate::labels::{Label, Offset};
 use crate::names::Name;
 use bincode::{Decode, Encode};
-use moor_var::Obj;
-use moor_var::{Error, VarType};
+use moor_var::VarType;
+use moor_var::{ErrorCode, Obj};
 
 #[derive(Clone, Debug, PartialEq, PartialOrd, Encode, Decode)]
 pub enum Op {
@@ -58,7 +58,7 @@ pub enum Op {
     ImmBigInt(i64),
     ImmFloat(f64),
     ImmEmptyList,
-    ImmErr(Error),
+    ImmErr(ErrorCode),
     ImmInt(i32),
     ImmType(VarType),
     ImmNone,

--- a/crates/compiler/src/parse.rs
+++ b/crates/compiler/src/parse.rs
@@ -19,7 +19,7 @@ use std::rc::Rc;
 use std::str::FromStr;
 
 use itertools::Itertools;
-use moor_var::{Error, SYSTEM_OBJECT, Var, VarType};
+use moor_var::{Error, ErrorCode, SYSTEM_OBJECT, Var, VarType, v_error};
 use moor_var::{Symbol, v_none};
 pub use pest::Parser as PestParser;
 use pest::error::LineColLocation;
@@ -27,7 +27,7 @@ use pest::iterators::{Pair, Pairs};
 use pest::pratt_parser::{Assoc, Op, PrattParser};
 
 use moor_var::Obj;
-use moor_var::{v_err, v_float, v_int, v_obj, v_str, v_string};
+use moor_var::{v_float, v_int, v_obj, v_str, v_string};
 
 use crate::Name;
 use crate::ast::Arg::{Normal, Splice};
@@ -186,7 +186,7 @@ impl TreeTransformer {
                 let Some(e) = Error::parse_str(e) else {
                     panic!("invalid error value: {e}");
                 };
-                if let Error::Custom(_) = &e {
+                if let ErrorCode::ErrCustom(_) = &e.err_type {
                     if !self.options.custom_errors {
                         return Err(CompileError::DisabledFeature(
                             self.compile_context(&pair),
@@ -194,7 +194,7 @@ impl TreeTransformer {
                         ));
                     }
                 }
-                Ok(Expr::Value(v_err(e)))
+                Ok(Expr::Value(v_error(e)))
             }
             _ => {
                 panic!("Unimplemented atom: {:?}", pair);
@@ -1463,8 +1463,7 @@ pub fn unquote_str(s: &str) -> Result<String, String> {
 
 #[cfg(test)]
 mod tests {
-    use moor_var::Error::{Custom, E_INVARG, E_PROPNF, E_VARNF};
-    use moor_var::{Symbol, v_none};
+    use moor_var::{E_INVARG, E_PROPNF, E_VARNF, ErrCustom, Symbol, v_none};
     use moor_var::{Var, v_err, v_float, v_int, v_objid, v_str};
 
     use crate::CompileOptions;
@@ -3116,9 +3115,9 @@ mod tests {
                 vec![
                     Normal(Value(v_err(E_INVARG))),
                     Normal(Value(v_err(E_PROPNF))),
-                    Normal(Value(v_err(Custom("e_custom".into())))),
-                    Normal(Value(v_err(Custom("e__ultra_long_custom".into())))),
-                    Normal(Value(v_err(Custom("e_unknown".into())))),
+                    Normal(Value(v_err(ErrCustom("e_custom".into())))),
+                    Normal(Value(v_err(ErrCustom("e__ultra_long_custom".into())))),
+                    Normal(Value(v_err(ErrCustom("e_unknown".into())))),
                 ]
             )))))]
         )

--- a/crates/compiler/src/program.rs
+++ b/crates/compiler/src/program.rs
@@ -18,8 +18,8 @@ use crate::unparse::to_literal;
 use bincode::{Decode, Encode};
 use byteview::ByteView;
 use lazy_static::lazy_static;
-use moor_var::Var;
 use moor_var::{AsByteBuffer, BINCODE_CONFIG, CountingWriter, DecodingError, EncodingError};
+use moor_var::{ErrorCode, Var};
 use std::fmt::{Display, Formatter};
 use std::sync::Arc;
 
@@ -44,6 +44,8 @@ pub struct Program {
     pub range_comprehensions: Vec<RangeComprehend>,
     /// List comprehensions, referenced by the list comprehension opcode.
     pub list_comprehensions: Vec<ListComprehend>,
+    /// All the error operands referenced in by MakeError in the program.
+    pub error_operands: Vec<ErrorCode>,
     /// The actual program code.
     pub main_vector: Arc<Vec<Op>>,
     /// The program code for each fork.
@@ -67,6 +69,7 @@ impl Program {
             main_vector: Arc::new(Vec::new()),
             fork_vectors: Vec::new(),
             line_number_spans: Vec::new(),
+            error_operands: vec![],
         }
     }
 

--- a/crates/compiler/src/unparse.rs
+++ b/crates/compiler/src/unparse.rs
@@ -11,14 +11,13 @@
 // this program. If not, see <https://www.gnu.org/licenses/>.
 //
 
-use moor_common::util::quote_str;
-use moor_var::{Obj, Sequence, Var, Variant};
-use std::collections::HashMap;
-
 use crate::ast::{Expr, Stmt, StmtNode};
 use crate::decompile::DecompileError;
 use crate::parse::Parse;
 use crate::{Name, ast};
+use moor_common::util::quote_str;
+use moor_var::{Obj, Sequence, Var, Variant};
+use std::collections::HashMap;
 
 use crate::names::UnboundName;
 
@@ -70,6 +69,7 @@ impl Expr {
             Expr::Index(_, _) => 2,
 
             Expr::Value(_) => 1,
+            Expr::Error(_, _) => 1,
             Expr::Id(_) => 1,
             Expr::TypeConstant(_) => 1,
             Expr::List(_) => 1,
@@ -165,6 +165,14 @@ impl<'a> Unparse<'a> {
                 buffer.push('(');
                 buffer.push_str(self.unparse_args(args).unwrap().as_str());
                 buffer.push(')');
+                Ok(buffer)
+            }
+            Expr::Error(code, value) => {
+                let mut buffer: String = (*code).into();
+                if let Some(value) = value {
+                    let value = self.unparse_expr(value).unwrap();
+                    buffer.push_str(format!("({})", value).as_str());
+                }
                 Ok(buffer)
             }
             Expr::Value(var) => Ok(self.unparse_var(var, false)),

--- a/crates/daemon/src/sys_ctrl.rs
+++ b/crates/daemon/src/sys_ctrl.rs
@@ -35,7 +35,11 @@ impl SystemControl for RpcServer {
     ) -> Result<(), moor_var::Error> {
         let host_type = match host_type {
             "tcp" => HostType::TCP,
-            _ => return Err(moor_var::E_INVARG.msg("Invalid host type")),
+            _ => {
+                return Err(
+                    moor_var::E_INVARG.with_msg(|| format!("Unhandled host type: {host_type}"))
+                );
+            }
         };
 
         let event = HostBroadcastEvent::Listen {

--- a/crates/daemon/src/sys_ctrl.rs
+++ b/crates/daemon/src/sys_ctrl.rs
@@ -35,7 +35,7 @@ impl SystemControl for RpcServer {
     ) -> Result<(), moor_var::Error> {
         let host_type = match host_type {
             "tcp" => HostType::TCP,
-            _ => return Err(moor_var::Error::E_INVARG),
+            _ => return Err(moor_var::E_INVARG.msg("Invalid host type")),
         };
 
         let event = HostBroadcastEvent::Listen {
@@ -59,7 +59,7 @@ impl SystemControl for RpcServer {
                 })
                 .map_err(|e| {
                     error!("Could not send Listen event: {}", e);
-                    moor_var::Error::E_INVARG
+                    moor_var::E_INVARG.msg("Unable to send Listen event")
                 })?;
         }
 
@@ -69,7 +69,7 @@ impl SystemControl for RpcServer {
     fn unlisten(&self, port: u16, host_type: &str) -> Result<(), moor_var::Error> {
         let host_type = match host_type {
             "tcp" => HostType::TCP,
-            _ => return Err(moor_var::Error::E_INVARG),
+            _ => return Err(moor_var::E_INVARG.msg("Invalid host type")),
         };
 
         let event = HostBroadcastEvent::Unlisten { host_type, port };
@@ -88,7 +88,7 @@ impl SystemControl for RpcServer {
                 })
                 .map_err(|e| {
                     error!("Could not send Unlisten event: {}", e);
-                    moor_var::Error::E_INVARG
+                    moor_var::E_INVARG.msg("Unable to send Unlisten event")
                 })?;
         }
         Ok(())

--- a/crates/kernel/src/builtins/bf_maps.rs
+++ b/crates/kernel/src/builtins/bf_maps.rs
@@ -19,22 +19,26 @@ use moor_var::{Var, Variant, v_list};
 /// Returns a copy of map with the value corresponding to key removed. If key is not a valid key, then E_RANGE is raised.
 fn bf_mapdelete(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
     if bf_args.args.len() != 2 {
-        return Err(BfErr::Code(E_ARGS));
+        return Err(BfErr::ErrValue(E_ARGS.msg("mapdelete() takes 2 arguments")));
     }
 
     let Variant::Map(m) = &bf_args.args[0].variant() else {
-        return Err(BfErr::Code(E_TYPE));
+        return Err(BfErr::ErrValue(
+            E_TYPE.msg("mapdelete first argument must be a map"),
+        ));
     };
 
     if matches!(
         bf_args.args[1].variant(),
         Variant::Map(_) | Variant::List(_)
     ) {
-        return Err(BfErr::Code(E_TYPE));
+        return Err(BfErr::ErrValue(
+            E_TYPE.msg("mapdelete second argument must be a scalar"),
+        ));
     }
 
     let (nm, Some(_)) = m.remove(&bf_args.args[1], false) else {
-        return Err(BfErr::Code(E_RANGE));
+        return Err(BfErr::ErrValue(E_RANGE.msg("mapdelete key not found")));
     };
 
     Ok(BfRet::Ret(nm))
@@ -43,11 +47,13 @@ bf_declare!(mapdelete, bf_mapdelete);
 
 fn bf_mapkeys(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
     if bf_args.args.len() != 1 {
-        return Err(BfErr::Code(E_ARGS));
+        return Err(BfErr::ErrValue(E_ARGS.msg("mapkeys() takes 1 argument")));
     }
 
     let Variant::Map(m) = &bf_args.args[0].variant() else {
-        return Err(BfErr::Code(E_TYPE));
+        return Err(BfErr::ErrValue(
+            E_TYPE.msg("mapkeys first argument must be a map"),
+        ));
     };
 
     let keys: Vec<Var> = m.iter().map(|kv| kv.0.clone()).collect();
@@ -58,11 +64,13 @@ bf_declare!(mapkeys, bf_mapkeys);
 
 fn bf_mapvalues(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
     if bf_args.args.len() != 1 {
-        return Err(BfErr::Code(E_ARGS));
+        return Err(BfErr::ErrValue(E_ARGS.msg("mapvalues() takes 1 argument")));
     }
 
     let Variant::Map(m) = &bf_args.args[0].variant() else {
-        return Err(BfErr::Code(E_TYPE));
+        return Err(BfErr::ErrValue(
+            E_TYPE.msg("mapvalues first argument must be a map"),
+        ));
     };
 
     let values: Vec<Var> = m.iter().map(|kv| kv.1.clone()).collect();
@@ -73,18 +81,22 @@ bf_declare!(mapvalues, bf_mapvalues);
 
 fn bf_maphaskey(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
     if bf_args.args.len() != 2 {
-        return Err(BfErr::Code(E_ARGS));
+        return Err(BfErr::ErrValue(E_ARGS.msg("maphaskey() takes 2 arguments")));
     }
 
     let Variant::Map(m) = &bf_args.args[0].variant() else {
-        return Err(BfErr::Code(E_TYPE));
+        return Err(BfErr::ErrValue(
+            E_TYPE.msg("maphaskey first argument must be a map"),
+        ));
     };
 
     if matches!(
         bf_args.args[1].variant(),
         Variant::Map(_) | Variant::List(_)
     ) {
-        return Err(BfErr::Code(E_TYPE));
+        return Err(BfErr::ErrValue(
+            E_TYPE.msg("maphaskey second argument must be a scalar"),
+        ));
     }
 
     let contains = m

--- a/crates/kernel/src/builtins/bf_maps.rs
+++ b/crates/kernel/src/builtins/bf_maps.rs
@@ -14,8 +14,7 @@
 use crate::bf_declare;
 use crate::builtins::{BfCallState, BfErr, BfRet, BuiltinFunction};
 use moor_compiler::offset_for_builtin;
-use moor_var::Error::{E_ARGS, E_RANGE, E_TYPE};
-use moor_var::{Associative, Sequence};
+use moor_var::{Associative, E_ARGS, E_RANGE, E_TYPE, Sequence};
 use moor_var::{Var, Variant, v_list};
 /// Returns a copy of map with the value corresponding to key removed. If key is not a valid key, then E_RANGE is raised.
 fn bf_mapdelete(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
@@ -90,7 +89,7 @@ fn bf_maphaskey(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
 
     let contains = m
         .contains_key(&bf_args.args[1], false)
-        .map_err(BfErr::Code)?;
+        .map_err(BfErr::ErrValue)?;
     Ok(BfRet::Ret(bf_args.v_bool(contains)))
 }
 bf_declare!(maphaskey, bf_maphaskey);

--- a/crates/kernel/src/builtins/bf_num.rs
+++ b/crates/kernel/src/builtins/bf_num.rs
@@ -14,8 +14,7 @@
 use rand::Rng;
 
 use moor_compiler::offset_for_builtin;
-use moor_var::Error::{E_ARGS, E_INVARG, E_TYPE};
-use moor_var::{Sequence, Var, Variant};
+use moor_var::{E_ARGS, E_INVARG, E_TYPE, Sequence, Var, Variant};
 use moor_var::{v_float, v_int, v_str};
 
 use crate::bf_declare;

--- a/crates/kernel/src/builtins/bf_num.rs
+++ b/crates/kernel/src/builtins/bf_num.rs
@@ -23,26 +23,28 @@ use crate::builtins::{BfCallState, BfErr, BfRet, BuiltinFunction};
 
 fn bf_abs(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
     if bf_args.args.len() != 1 {
-        return Err(BfErr::Code(E_ARGS));
+        return Err(BfErr::ErrValue(E_ARGS.msg("abs() takes 1 argument")));
     }
 
     match bf_args.args[0].variant() {
         Variant::Int(i) => Ok(Ret(v_int(i.abs()))),
         Variant::Float(f) => Ok(Ret(v_float(f.abs()))),
-        _ => Err(BfErr::Code(E_TYPE)),
+        _ => Err(BfErr::ErrValue(E_TYPE.msg("abs() takes a number"))),
     }
 }
 bf_declare!(abs, bf_abs);
 
 fn bf_min(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
     if bf_args.args.is_empty() {
-        return Err(BfErr::Code(E_ARGS));
+        return Err(BfErr::ErrValue(
+            E_ARGS.msg("min() takes at least 1 argument"),
+        ));
     }
     let expected_type = bf_args.args[0].type_code();
     let mut minimum = bf_args.args[0].clone();
     for arg in bf_args.args.iter() {
         if arg.type_code() != expected_type {
-            return Err(BfErr::Code(E_TYPE));
+            return Err(BfErr::ErrValue(E_TYPE.msg("min() takes numbers")));
         }
         if arg.lt(&minimum) {
             minimum = arg.clone();
@@ -54,13 +56,15 @@ bf_declare!(min, bf_min);
 
 fn bf_max(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
     if bf_args.args.is_empty() {
-        return Err(BfErr::Code(E_ARGS));
+        return Err(BfErr::ErrValue(
+            E_ARGS.msg("max() takes at least 1 argument"),
+        ));
     }
     let expected_type = bf_args.args[0].type_code();
     let mut maximum = bf_args.args[0].clone();
     for arg in bf_args.args.iter() {
         if arg.type_code() != expected_type {
-            return Err(BfErr::Code(E_TYPE));
+            return Err(BfErr::ErrValue(E_TYPE.msg("max() takes numbers")));
         }
         if arg.gt(&maximum) {
             maximum = arg.clone();
@@ -73,7 +77,9 @@ bf_declare!(max, bf_max);
 
 fn bf_random(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
     if bf_args.args.len() > 1 {
-        return Err(BfErr::Code(E_ARGS));
+        return Err(BfErr::ErrValue(
+            E_ARGS.msg("random() takes 0 or 1 argument"),
+        ));
     }
 
     let mut rng = rand::thread_rng();
@@ -91,17 +97,27 @@ bf_declare!(random, bf_random);
 
 fn bf_floatstr(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
     if bf_args.args.len() < 2 || bf_args.args.len() > 3 {
-        return Err(BfErr::Code(E_ARGS));
+        return Err(BfErr::ErrValue(
+            E_ARGS.msg("floatstr() takes 2 or 3 arguments"),
+        ));
     }
 
     let x = match bf_args.args[0].variant() {
         Variant::Float(f) => f,
-        _ => return Err(BfErr::Code(E_TYPE)),
+        _ => {
+            return Err(BfErr::ErrValue(
+                E_TYPE.msg("floatstr() first argument must be a float"),
+            ));
+        }
     };
 
     let precision = match &bf_args.args[1].variant() {
         Variant::Int(i) if *i > 0 => *i as usize,
-        _ => return Err(BfErr::Code(E_TYPE)),
+        _ => {
+            return Err(BfErr::ErrValue(
+                E_TYPE.msg("floatstr() second argument must be a positive integer"),
+            ));
+        }
     };
 
     let scientific = bf_args.args.len() == 3 && bf_args.args[2].is_true();
@@ -119,7 +135,7 @@ fn numeric_arg(arg: &Var) -> Result<f64, BfErr> {
     let x = match arg.variant() {
         Variant::Int(i) => *i as f64,
         Variant::Float(f) => *f,
-        _ => return Err(BfErr::Code(E_TYPE)),
+        _ => return Err(BfErr::ErrValue(E_TYPE.msg("non-numeric argument"))),
     };
 
     Ok(x)
@@ -127,7 +143,7 @@ fn numeric_arg(arg: &Var) -> Result<f64, BfErr> {
 
 fn bf_sin(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
     if bf_args.args.len() != 1 {
-        return Err(BfErr::Code(E_ARGS));
+        return Err(BfErr::ErrValue(E_ARGS.msg("sin() takes 1 argument")));
     }
 
     let x = numeric_arg(&bf_args.args[0])?;
@@ -138,7 +154,7 @@ bf_declare!(sin, bf_sin);
 
 fn bf_cos(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
     if bf_args.args.len() != 1 {
-        return Err(BfErr::Code(E_ARGS));
+        return Err(BfErr::ErrValue(E_ARGS.msg("cos() takes 1 argument")));
     }
 
     let x = numeric_arg(&bf_args.args[0])?;
@@ -149,7 +165,7 @@ bf_declare!(cos, bf_cos);
 
 fn bf_tan(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
     if bf_args.args.len() != 1 {
-        return Err(BfErr::Code(E_ARGS));
+        return Err(BfErr::ErrValue(E_ARGS.msg("tan() takes 1 argument")));
     }
 
     let x = numeric_arg(&bf_args.args[0])?;
@@ -160,13 +176,15 @@ bf_declare!(tan, bf_tan);
 
 fn bf_sqrt(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
     if bf_args.args.len() != 1 {
-        return Err(BfErr::Code(E_ARGS));
+        return Err(BfErr::ErrValue(E_ARGS.msg("sqrt() takes 1 argument")));
     }
 
     let x = numeric_arg(&bf_args.args[0])?;
 
     if x < 0.0 {
-        return Err(BfErr::Code(E_ARGS));
+        return Err(BfErr::ErrValue(
+            E_ARGS.msg("sqrt() takes a non-negative number"),
+        ));
     }
 
     Ok(Ret(v_float(x.sqrt())))
@@ -175,13 +193,15 @@ bf_declare!(sqrt, bf_sqrt);
 
 fn bf_asin(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
     if bf_args.args.len() != 1 {
-        return Err(BfErr::Code(E_ARGS));
+        return Err(BfErr::ErrValue(E_ARGS.msg("asin() takes 1 argument")));
     }
 
     let x = numeric_arg(&bf_args.args[0])?;
 
     if !(-1.0..=1.0).contains(&x) {
-        return Err(BfErr::Code(E_ARGS));
+        return Err(BfErr::ErrValue(
+            E_ARGS.msg("asin() takes a number between -1 and 1"),
+        ));
     }
 
     Ok(Ret(v_float(x.asin())))
@@ -190,13 +210,15 @@ bf_declare!(asin, bf_asin);
 
 fn bf_acos(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
     if bf_args.args.len() != 1 {
-        return Err(BfErr::Code(E_ARGS));
+        return Err(BfErr::ErrValue(E_ARGS.msg("acos() takes 1 argument")));
     }
 
     let x = numeric_arg(&bf_args.args[0])?;
 
     if !(-1.0..=1.0).contains(&x) {
-        return Err(BfErr::Code(E_ARGS));
+        return Err(BfErr::ErrValue(
+            E_ARGS.msg("acos() takes a number between -1 and 1"),
+        ));
     }
 
     Ok(Ret(v_float(x.acos())))
@@ -205,7 +227,7 @@ bf_declare!(acos, bf_acos);
 
 fn bf_atan(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
     if bf_args.args.is_empty() || bf_args.args.len() > 2 {
-        return Err(BfErr::Code(E_ARGS));
+        return Err(BfErr::ErrValue(E_ARGS.msg("atan() takes 1 or 2 arguments")));
     }
 
     let x = numeric_arg(&bf_args.args[0])?;
@@ -217,7 +239,7 @@ bf_declare!(atan, bf_atan);
 
 fn bf_sinh(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
     if bf_args.args.len() != 1 {
-        return Err(BfErr::Code(E_ARGS));
+        return Err(BfErr::ErrValue(E_ARGS.msg("sinh() takes 1 argument")));
     }
 
     let x = numeric_arg(&bf_args.args[0])?;
@@ -228,7 +250,7 @@ bf_declare!(sinh, bf_sinh);
 
 fn bf_cosh(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
     if bf_args.args.len() != 1 {
-        return Err(BfErr::Code(E_ARGS));
+        return Err(BfErr::ErrValue(E_ARGS.msg("cosh() takes 1 argument")));
     }
 
     let x = numeric_arg(&bf_args.args[0])?;
@@ -239,7 +261,7 @@ bf_declare!(cosh, bf_cosh);
 
 fn bf_tanh(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
     if bf_args.args.len() != 1 {
-        return Err(BfErr::Code(E_ARGS));
+        return Err(BfErr::ErrValue(E_ARGS.msg("tanh() takes 1 argument")));
     }
 
     let x = numeric_arg(&bf_args.args[0])?;
@@ -250,7 +272,7 @@ bf_declare!(tanh, bf_tanh);
 
 fn bf_exp(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
     if bf_args.args.len() != 1 {
-        return Err(BfErr::Code(E_ARGS));
+        return Err(BfErr::ErrValue(E_ARGS.msg("exp() takes 1 argument")));
     }
 
     let x = numeric_arg(&bf_args.args[0])?;
@@ -261,13 +283,13 @@ bf_declare!(exp, bf_exp);
 
 fn bf_log(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
     if bf_args.args.len() != 1 {
-        return Err(BfErr::Code(E_ARGS));
+        return Err(BfErr::ErrValue(E_ARGS.msg("log() takes 1 argument")));
     }
 
     let x = numeric_arg(&bf_args.args[0])?;
 
     if x <= 0.0 {
-        return Err(BfErr::Code(E_ARGS));
+        return Err(BfErr::ErrValue(E_ARGS.msg("log() takes a positive number")));
     }
 
     Ok(Ret(v_float(x.ln())))
@@ -276,13 +298,15 @@ bf_declare!(log, bf_log);
 
 fn bf_log10(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
     if bf_args.args.len() != 1 {
-        return Err(BfErr::Code(E_ARGS));
+        return Err(BfErr::ErrValue(E_ARGS.msg("log10() takes 1 argument")));
     }
 
     let x = numeric_arg(&bf_args.args[0])?;
 
     if x <= 0.0 {
-        return Err(BfErr::Code(E_ARGS));
+        return Err(BfErr::ErrValue(
+            E_ARGS.msg("log10() takes a positive number"),
+        ));
     }
 
     Ok(Ret(v_float(x.log10())))
@@ -291,7 +315,7 @@ bf_declare!(log10, bf_log10);
 
 fn bf_ceil(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
     if bf_args.args.len() != 1 {
-        return Err(BfErr::Code(E_ARGS));
+        return Err(BfErr::ErrValue(E_ARGS.msg("ceil() takes 1 argument")));
     }
 
     let x = numeric_arg(&bf_args.args[0])?;
@@ -302,7 +326,7 @@ bf_declare!(ceil, bf_ceil);
 
 fn bf_floor(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
     if bf_args.args.len() != 1 {
-        return Err(BfErr::Code(E_ARGS));
+        return Err(BfErr::ErrValue(E_ARGS.msg("floor() takes 1 argument")));
     }
 
     let x = numeric_arg(&bf_args.args[0])?;
@@ -313,7 +337,7 @@ bf_declare!(floor, bf_floor);
 
 fn bf_trunc(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
     if bf_args.args.len() != 1 {
-        return Err(BfErr::Code(E_ARGS));
+        return Err(BfErr::ErrValue(E_ARGS.msg("trunc() takes 1 argument")));
     }
 
     let x = numeric_arg(&bf_args.args[0])?;

--- a/crates/kernel/src/builtins/bf_objects.rs
+++ b/crates/kernel/src/builtins/bf_objects.rs
@@ -19,7 +19,7 @@ use moor_common::model::WorldStateError;
 use moor_common::model::{ObjFlag, ValSet};
 use moor_common::util::BitEnum;
 use moor_compiler::offset_for_builtin;
-use moor_var::Error::{E_ARGS, E_INVARG, E_NACC, E_PERM, E_TYPE};
+use moor_var::{E_ARGS, E_INVARG, E_NACC, E_PERM, E_TYPE};
 use moor_var::{List, Variant, v_bool};
 use moor_var::{NOTHING, v_list_iter};
 use moor_var::{Sequence, Symbol, v_list};

--- a/crates/kernel/src/builtins/bf_objects.rs
+++ b/crates/kernel/src/builtins/bf_objects.rs
@@ -45,10 +45,12 @@ Returns a non-zero integer (i.e., a true value) if object is a valid object (one
 */
 fn bf_valid(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
     if bf_args.args.len() != 1 {
-        return Err(BfErr::Code(E_ARGS));
+        return Err(BfErr::ErrValue(E_ARGS.msg("valid() takes 1 argument")));
     }
     let Variant::Obj(obj) = bf_args.args[0].variant() else {
-        return Err(BfErr::Code(E_TYPE));
+        return Err(BfErr::ErrValue(
+            E_TYPE.msg("valid() first argument must be an object"),
+        ));
     };
     let is_valid = bf_args.world_state.valid(obj).map_err(world_state_bf_err)?;
     Ok(Ret(bf_args.v_bool(is_valid)))
@@ -57,13 +59,17 @@ bf_declare!(valid, bf_valid);
 
 fn bf_parent(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
     if bf_args.args.len() != 1 {
-        return Err(BfErr::Code(E_ARGS));
+        return Err(BfErr::ErrValue(E_ARGS.msg("parent() takes 1 argument")));
     }
     let Variant::Obj(obj) = bf_args.args[0].variant() else {
-        return Err(BfErr::Code(E_TYPE));
+        return Err(BfErr::ErrValue(
+            E_TYPE.msg("parent() first argument must be an object"),
+        ));
     };
     if !obj.is_positive() || !bf_args.world_state.valid(obj).map_err(world_state_bf_err)? {
-        return Err(BfErr::Code(E_INVARG));
+        return Err(BfErr::ErrValue(
+            E_INVARG.msg("parent() argument must be a valid object"),
+        ));
     }
     let parent = bf_args
         .world_state
@@ -75,13 +81,17 @@ bf_declare!(parent, bf_parent);
 
 fn bf_chparent(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
     if bf_args.args.len() != 2 {
-        return Err(BfErr::Code(E_ARGS));
+        return Err(BfErr::ErrValue(E_ARGS.msg("chparent() takes 2 arguments")));
     }
     let Variant::Obj(obj) = bf_args.args[0].variant() else {
-        return Err(BfErr::Code(E_TYPE));
+        return Err(BfErr::ErrValue(
+            E_TYPE.msg("chparent() first argument must be an object"),
+        ));
     };
     let Variant::Obj(new_parent) = bf_args.args[1].variant() else {
-        return Err(BfErr::Code(E_TYPE));
+        return Err(BfErr::ErrValue(
+            E_TYPE.msg("chparent() second argument must be an object"),
+        ));
     };
     // If object is not valid, or if new-parent is neither valid nor equal to #-1, then E_INVARG is raised.
     if !bf_args.world_state.valid(obj).map_err(world_state_bf_err)?
@@ -91,7 +101,9 @@ fn bf_chparent(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
                 .valid(new_parent)
                 .map_err(world_state_bf_err)?)
     {
-        return Err(BfErr::Code(E_INVARG));
+        return Err(BfErr::ErrValue(
+            E_INVARG.msg("chparent() arguments must be valid objects"),
+        ));
     }
     bf_args
         .world_state
@@ -103,13 +115,17 @@ bf_declare!(chparent, bf_chparent);
 
 fn bf_children(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
     if bf_args.args.len() != 1 {
-        return Err(BfErr::Code(E_ARGS));
+        return Err(BfErr::ErrValue(E_ARGS.msg("children() takes 1 argument")));
     }
     let Variant::Obj(obj) = bf_args.args[0].variant() else {
-        return Err(BfErr::Code(E_TYPE));
+        return Err(BfErr::ErrValue(
+            E_TYPE.msg("children() first argument must be an object"),
+        ));
     };
     if !bf_args.world_state.valid(obj).map_err(world_state_bf_err)? {
-        return Err(BfErr::Code(E_INVARG));
+        return Err(BfErr::ErrValue(
+            E_INVARG.msg("children() argument must be a valid object"),
+        ));
     }
     let children = bf_args
         .world_state
@@ -123,13 +139,19 @@ bf_declare!(children, bf_children);
 
 fn bf_descendants(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
     if bf_args.args.len() != 1 {
-        return Err(BfErr::Code(E_ARGS));
+        return Err(BfErr::ErrValue(
+            E_ARGS.msg("descendants() takes 1 argument"),
+        ));
     }
     let Variant::Obj(obj) = bf_args.args[0].variant() else {
-        return Err(BfErr::Code(E_TYPE));
+        return Err(BfErr::ErrValue(
+            E_TYPE.msg("descendants() first argument must be an object"),
+        ));
     };
     if !bf_args.world_state.valid(obj).map_err(world_state_bf_err)? {
-        return Err(BfErr::Code(E_INVARG));
+        return Err(BfErr::ErrValue(
+            E_INVARG.msg("descendants() argument must be a valid object"),
+        ));
     }
     let descendants = bf_args
         .world_state
@@ -143,10 +165,14 @@ bf_declare!(descendants, bf_descendants);
 
 fn bf_ancestors(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
     if bf_args.args.len() > 2 {
-        return Err(BfErr::Code(E_ARGS));
+        return Err(BfErr::ErrValue(
+            E_ARGS.msg("ancestors() takes 1 or 2 arguments"),
+        ));
     }
     let Variant::Obj(obj) = bf_args.args[0].variant() else {
-        return Err(BfErr::Code(E_TYPE));
+        return Err(BfErr::ErrValue(
+            E_TYPE.msg("ancestors() first argument must be an object"),
+        ));
     };
     let add_self = if bf_args.args.len() == 2 {
         bf_args.args[1].is_true()
@@ -155,7 +181,9 @@ fn bf_ancestors(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
     };
 
     if !bf_args.world_state.valid(obj).map_err(world_state_bf_err)? {
-        return Err(BfErr::Code(E_INVARG));
+        return Err(BfErr::ErrValue(
+            E_INVARG.msg("ancestors() argument must be a valid object"),
+        ));
     }
     let ancestors = bf_args
         .world_state
@@ -172,13 +200,17 @@ Syntax: isa (obj <object>, obj <possible_ancestor>) => int
 */
 fn bf_isa(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
     if bf_args.args.len() != 2 {
-        return Err(BfErr::Code(E_ARGS));
+        return Err(BfErr::ErrValue(E_ARGS.msg("isa() takes 2 arguments")));
     }
     let Variant::Obj(obj) = bf_args.args[0].variant() else {
-        return Err(BfErr::Code(E_TYPE));
+        return Err(BfErr::ErrValue(
+            E_TYPE.msg("isa() first argument must be an object"),
+        ));
     };
     let Variant::Obj(possible_ancestor) = bf_args.args[1].variant() else {
-        return Err(BfErr::Code(E_TYPE));
+        return Err(BfErr::ErrValue(
+            E_TYPE.msg("isa() second argument must be an object"),
+        ));
     };
 
     if !bf_args.world_state.valid(obj).map_err(world_state_bf_err)?
@@ -187,7 +219,9 @@ fn bf_isa(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
             .valid(possible_ancestor)
             .map_err(world_state_bf_err)?
     {
-        return Err(BfErr::Code(E_INVARG));
+        return Err(BfErr::ErrValue(
+            E_INVARG.msg("isa() arguments must be valid objects"),
+        ));
     }
 
     let ancestors = bf_args
@@ -208,14 +242,20 @@ const BF_CREATE_OBJECT_TRAMPOLINE_DONE: usize = 1;
 
 fn bf_create(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
     if bf_args.args.is_empty() || bf_args.args.len() > 2 {
-        return Err(BfErr::Code(E_ARGS));
+        return Err(BfErr::ErrValue(
+            E_ARGS.msg("create() takes 1 or 2 arguments"),
+        ));
     }
     let Variant::Obj(parent) = bf_args.args[0].variant().clone() else {
-        return Err(BfErr::Code(E_TYPE));
+        return Err(BfErr::ErrValue(
+            E_TYPE.msg("create() first argument must be an object"),
+        ));
     };
     let owner = if bf_args.args.len() == 2 {
         let Variant::Obj(owner) = bf_args.args[1].variant().clone() else {
-            return Err(BfErr::Code(E_TYPE));
+            return Err(BfErr::ErrValue(
+                E_TYPE.msg("create() second argument must be an object"),
+            ));
         };
         owner
     } else {
@@ -290,10 +330,12 @@ const BF_RECYCLE_TRAMPOLINE_CALL_EXITFUNC: usize = 0;
 const BF_RECYCLE_TRAMPOLINE_DONE_MOVE: usize = 1;
 fn bf_recycle(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
     if bf_args.args.len() != 1 {
-        return Err(BfErr::Code(E_ARGS));
+        return Err(BfErr::ErrValue(E_ARGS.msg("recycle() takes 1 argument")));
     }
     let Variant::Obj(obj) = bf_args.args[0].variant().clone() else {
-        return Err(BfErr::Code(E_TYPE));
+        return Err(BfErr::ErrValue(
+            E_TYPE.msg("recycle() first argument must be an object"),
+        ));
     };
 
     let valid = bf_args.world_state.valid(&obj);
@@ -303,7 +345,9 @@ fn bf_recycle(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
             .map(|e| e.database_error_msg() == Some("NotFound"))
             .unwrap_or_default()
     {
-        return Err(BfErr::Code(E_INVARG));
+        return Err(BfErr::ErrValue(
+            E_INVARG.msg("recycle() argument must be a valid object"),
+        ));
     }
 
     // Check if the given task perms can control the object before continuing.
@@ -312,7 +356,7 @@ fn bf_recycle(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
         .controls(&bf_args.task_perms_who(), &obj)
         .map_err(world_state_bf_err)?
     {
-        return Err(BfErr::Code(E_PERM));
+        return Err(BfErr::ErrValue(E_PERM.msg("recycle() permission denied")));
     }
 
     // Before actually recycling the object, we need to move all its contents to #-1. While
@@ -345,7 +389,9 @@ fn bf_recycle(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
                         Err(WorldStateError::VerbNotFound(_, _)) => {}
                         Err(e) => {
                             error!("Error looking up exitfunc verb: {:?}", e);
-                            return Err(BfErr::Code(E_NACC));
+                            return Err(BfErr::ErrValue(
+                                E_NACC.msg("recycle() error looking up exitfunc"),
+                            ));
                         }
                     }
                 }
@@ -384,9 +430,10 @@ fn bf_recycle(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
                         bf_frame.bf_trampoline_arg = Some(contents);
                         // Fall through to the next case.
                     }
-                    Err(e) => {
-                        error!("Error looking up recycle verb: {:?}", e);
-                        return Err(BfErr::Code(E_NACC));
+                    Err(_) => {
+                        return Err(BfErr::ErrValue(
+                            E_NACC.msg("recycle() error looking up recycle"),
+                        ));
                     }
                 }
             }
@@ -464,7 +511,9 @@ bf_declare!(recycle, bf_recycle);
 
 fn bf_max_object(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
     if !bf_args.args.is_empty() {
-        return Err(BfErr::Code(E_ARGS));
+        return Err(BfErr::ErrValue(
+            E_ARGS.msg("max_object() takes no arguments"),
+        ));
     }
     let max_obj = bf_args
         .world_state
@@ -481,13 +530,17 @@ const BF_MOVE_TRAMPOLINE_DONE: usize = 3;
 
 fn bf_move(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
     if bf_args.args.len() != 2 {
-        return Err(BfErr::Code(E_ARGS));
+        return Err(BfErr::ErrValue(E_ARGS.msg("move() takes 2 arguments")));
     }
     let Variant::Obj(what) = bf_args.args[0].variant().clone() else {
-        return Err(BfErr::Code(E_TYPE));
+        return Err(BfErr::ErrValue(
+            E_TYPE.msg("move() first argument must be an object"),
+        ));
     };
     let Variant::Obj(whereto) = bf_args.args[1].variant().clone() else {
-        return Err(BfErr::Code(E_TYPE));
+        return Err(BfErr::ErrValue(
+            E_TYPE.msg("move() second argument must be an object"),
+        ));
     };
 
     // World state will reject this move if it's recursive.
@@ -700,10 +753,12 @@ bf_declare!(move, bf_move);
 
 fn bf_verbs(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
     if bf_args.args.len() != 1 {
-        return Err(BfErr::Code(E_ARGS));
+        return Err(BfErr::ErrValue(E_ARGS.msg("verbs() takes 1 argument")));
     }
     let Variant::Obj(obj) = bf_args.args[0].variant() else {
-        return Err(BfErr::Code(E_TYPE));
+        return Err(BfErr::ErrValue(
+            E_TYPE.msg("verbs() first argument must be an object"),
+        ));
     };
     let verbs = bf_args
         .world_state
@@ -723,10 +778,12 @@ Returns a list of the names of the properties defined directly on the given obje
  */
 fn bf_properties(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
     if bf_args.args.len() != 1 {
-        return Err(BfErr::Code(E_ARGS));
+        return Err(BfErr::ErrValue(E_ARGS.msg("properties() takes 1 argument")));
     }
     let Variant::Obj(obj) = bf_args.args[0].variant() else {
-        return Err(BfErr::Code(E_TYPE));
+        return Err(BfErr::ErrValue(
+            E_TYPE.msg("properties() first argument must be an object"),
+        ));
     };
     let props = bf_args
         .world_state
@@ -743,13 +800,17 @@ bf_declare!(properties, bf_properties);
 
 fn bf_set_player_flag(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
     if bf_args.args.len() != 2 {
-        return Err(BfErr::Code(E_ARGS));
+        return Err(BfErr::ErrValue(
+            E_ARGS.msg("set_player_flag() takes 2 arguments"),
+        ));
     }
 
     let (Variant::Obj(obj), Variant::Int(f)) =
         (bf_args.args[0].variant(), bf_args.args[1].variant())
     else {
-        return Err(BfErr::Code(E_INVARG));
+        return Err(BfErr::ErrValue(E_INVARG.msg(
+            "set_player_flag() arguments must be an object and an integer",
+        )));
     };
 
     let f = *f == 1;
@@ -789,7 +850,7 @@ bf_declare!(set_player_flag, bf_set_player_flag);
 
 fn bf_players(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
     if !bf_args.args.is_empty() {
-        return Err(BfErr::Code(E_ARGS));
+        return Err(BfErr::ErrValue(E_ARGS.msg("players() takes no arguments")));
     }
     let players = bf_args.world_state.players().map_err(world_state_bf_err)?;
 

--- a/crates/kernel/src/builtins/bf_server.rs
+++ b/crates/kernel/src/builtins/bf_server.rs
@@ -12,6 +12,7 @@
 //
 
 use std::io::Read;
+use std::ops::Deref;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use chrono::{DateTime, Local, TimeZone};
@@ -993,7 +994,7 @@ fn bf_kill_task(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
         bf_args.task_perms().map_err(world_state_bf_err)?,
     );
     if let Variant::Err(err) = result.variant() {
-        return Err(ErrValue(err.clone()));
+        return Err(ErrValue(err.deref().clone()));
     }
     Ok(Ret(result))
 }
@@ -1034,7 +1035,7 @@ fn bf_resume(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
         return_value.clone(),
     );
     if let Variant::Err(err) = result.variant() {
-        return Err(ErrValue(err.clone()));
+        return Err(ErrValue(err.deref().clone()));
     }
     Ok(Ret(result))
 }

--- a/crates/kernel/src/builtins/bf_server.rs
+++ b/crates/kernel/src/builtins/bf_server.rs
@@ -20,7 +20,7 @@ use iana_time_zone::get_timezone;
 use tracing::{error, info, warn};
 
 use crate::bf_declare;
-use crate::builtins::BfErr::Code;
+use crate::builtins::BfErr::{Code, ErrValue};
 use crate::builtins::BfRet::{Ret, VmInstr};
 use crate::builtins::{
     BfCallState, BfErr, BfRet, BuiltinFunction, bf_perf_counters, world_state_bf_err,
@@ -36,9 +36,8 @@ use moor_common::tasks::{NarrativeEvent, Presentation};
 use moor_common::util::PerfCounter;
 use moor_compiler::compile;
 use moor_compiler::{ArgCount, ArgType, BUILTINS, Builtin, offset_for_builtin};
-use moor_var::Error::{E_ARGS, E_INVARG, E_INVIND, E_PERM, E_TYPE};
 use moor_var::VarType::TYPE_STR;
-use moor_var::{Error, Symbol, v_list_iter};
+use moor_var::{E_ARGS, E_INVARG, E_INVIND, E_PERM, E_QUOTA, E_TYPE, Error, Symbol, v_list_iter};
 use moor_var::{Sequence, v_map};
 use moor_var::{Var, v_float, v_int, v_list, v_none, v_obj, v_str, v_string};
 use moor_var::{Variant, v_sym};
@@ -48,11 +47,10 @@ fn bf_noop(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
         "Builtin function {} is not implemented, called with arguments: ({:?})",
         bf_args.name, bf_args.args
     );
-    Err(BfErr::Raise(
-        E_INVIND,
-        Some(format!("Builtin {} is not implemented", bf_args.name)),
-        Some(v_str(bf_args.name.as_str())),
-    ))
+    Err(BfErr::Raise(E_INVIND.with_msg_and_value(
+        || format!("Builtin {} is not implemented", bf_args.name),
+        v_str(bf_args.name.as_str()),
+    )))
 }
 bf_declare!(noop, bf_noop);
 
@@ -61,20 +59,24 @@ fn bf_notify(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
     // Otherwise, it can send any value, and it's up to the host/client to interpret it.
     if !bf_args.config.rich_notify {
         if bf_args.args.len() != 2 {
-            return Err(BfErr::Code(E_ARGS));
+            return Err(ErrValue(E_ARGS.msg("notify() requires 2 arguments")));
         }
         if bf_args.args[1].type_code() != TYPE_STR {
-            return Err(BfErr::Code(E_TYPE));
+            return Err(ErrValue(
+                E_TYPE.msg("notify() requires a string as the second argument"),
+            ));
         }
     }
 
     if bf_args.args.len() < 2 || bf_args.args.len() > 3 {
-        return Err(BfErr::Code(E_ARGS));
+        return Err(ErrValue(E_ARGS.msg("notify() requires 2 or 3 arguments")));
     }
 
     let player = bf_args.args[0].variant();
     let Variant::Obj(player) = player else {
-        return Err(BfErr::Code(E_TYPE));
+        return Err(ErrValue(
+            E_TYPE.msg("notify() requires an object as the first argument"),
+        ));
     };
 
     // If player is not the calling task perms, or a caller is not a wizard, raise E_PERM.
@@ -84,7 +86,7 @@ fn bf_notify(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
         .map_err(world_state_bf_err)?;
 
     let content_type = if bf_args.config.rich_notify && bf_args.args.len() == 3 {
-        let content_type = bf_args.args[2].as_symbol().map_err(Code)?;
+        let content_type = bf_args.args[2].as_symbol().map_err(ErrValue)?;
         Some(content_type)
     } else {
         None
@@ -108,16 +110,21 @@ bf_declare!(notify, bf_notify);
 /// If only the first two arguments are provided, the client should "unpresent" the presentation with that ID.
 fn bf_present(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
     if !bf_args.config.rich_notify {
-        return Err(BfErr::Code(E_PERM));
+        return Err(ErrValue(E_PERM.msg("present() is not available")));
     };
 
     if bf_args.args.len() < 2 || bf_args.args.len() > 6 {
-        return Err(BfErr::Code(E_ARGS));
+        return Err(ErrValue(E_ARGS.msg("present() requires 2 to 6 arguments")));
     }
 
     let player = bf_args.args[0].variant();
     let Variant::Obj(player) = player else {
-        return Err(BfErr::Code(E_TYPE));
+        return Err(ErrValue(E_TYPE.with_msg(|| {
+            format!(
+                "present() requires an object as the first argument, got {:?}",
+                bf_args.args[0].type_code().to_literal()
+            )
+        })));
     };
 
     // If player is not the calling task perms, or a caller is not a wizard, raise E_PERM.
@@ -128,7 +135,11 @@ fn bf_present(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
 
     let id = match bf_args.args[1].variant() {
         Variant::Str(id) => id,
-        _ => return Err(BfErr::Code(E_TYPE)),
+        _ => {
+            return Err(ErrValue(
+                E_TYPE.msg("present() requires a string as the second argument"),
+            ));
+        }
     };
 
     // This is unpresent
@@ -145,19 +156,39 @@ fn bf_present(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
     }
 
     if bf_args.args.len() < 5 {
-        return Err(BfErr::Code(E_ARGS));
+        return Err(ErrValue(E_ARGS.with_msg(|| {
+            format!(
+                "present() requires at least 5 arguments, got {}",
+                bf_args.args.len()
+            )
+        })));
     }
 
     let Variant::Str(content_type) = bf_args.args[2].variant() else {
-        return Err(BfErr::Code(E_TYPE));
+        return Err(ErrValue(E_TYPE.with_msg(|| {
+            format!(
+                "present() requires a string as the third argument, got {:?}",
+                bf_args.args[2].type_code().to_literal()
+            )
+        })));
     };
 
     let Variant::Str(target) = bf_args.args[3].variant() else {
-        return Err(BfErr::Code(E_TYPE));
+        return Err(ErrValue(E_TYPE.with_msg(|| {
+            format!(
+                "present() requires a string as the fourth argument, got {:?}",
+                bf_args.args[3].type_code().to_literal()
+            )
+        })));
     };
 
     let Variant::Str(content) = bf_args.args[4].variant() else {
-        return Err(BfErr::Code(E_TYPE));
+        return Err(ErrValue(E_TYPE.with_msg(|| {
+            format!(
+                "present() requires a string as the fifth argument, got {:?}",
+                bf_args.args[4].type_code().to_literal()
+            )
+        })));
     };
 
     let mut attributes = vec![];
@@ -169,20 +200,28 @@ fn bf_present(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
                     match item.variant() {
                         Variant::List(l) => {
                             if l.len() != 2 {
-                                return Err(BfErr::Code(E_ARGS));
+                                return Err(ErrValue(E_ARGS.msg(
+                                    "present() requires a list of { string, string } pairs as the sixth argument",
+                                )));
                             }
                             let key = match l[0].variant() {
                                 Variant::Str(s) => s,
-                                _ => return Err(BfErr::Code(E_TYPE)),
+                                _ => return Err(ErrValue(E_TYPE.msg(
+                                    "present() requires a list of { string, string } pairs as the sixth argument",
+                                ))),
                             };
                             let value = match l[1].variant() {
                                 Variant::Str(s) => s,
-                                _ => return Err(BfErr::Code(E_TYPE)),
+                                _ => return Err(ErrValue(E_TYPE.msg(
+                                    "present() requires a list of { string, string } pairs as the sixth argument",
+                                ))),
                             };
                             attributes.push((key.as_str().to_string(), value.as_str().to_string()));
                         }
                         _ => {
-                            return Err(BfErr::Code(E_TYPE));
+                            return Err(ErrValue(E_TYPE.msg(
+                                "present() requires a list of { string, string } pairs as the sixth argument",
+                            )));
                         }
                     }
                 }
@@ -191,17 +230,23 @@ fn bf_present(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
                 for (key, value) in m.iter() {
                     let key = match key.variant() {
                         Variant::Str(s) => s,
-                        _ => return Err(BfErr::Code(E_TYPE)),
+                        _ => return Err(ErrValue(E_TYPE.msg(
+                            "present() requires a map of string -> string pairs as the sixth argument",
+                        ))),
                     };
                     let value = match value.variant() {
                         Variant::Str(s) => s,
-                        _ => return Err(BfErr::Code(E_TYPE)),
+                        _ => return Err(ErrValue(E_TYPE.msg(
+                            "present() requires a map of string -> string pairs as the sixth argument",
+                        ))),
                     };
                     attributes.push((key.as_str().to_string(), value.as_str().to_string()));
                 }
             }
             _ => {
-                return Err(BfErr::Code(E_TYPE));
+                return Err(ErrValue(E_TYPE.msg(
+                    "present() requires a list of { string, string } pairs or a map of string -> string pairs as the sixth argument",
+                )));
             }
         }
     }
@@ -229,7 +274,9 @@ bf_declare!(present, bf_present);
 fn bf_connected_players(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
     let include_all = if bf_args.args.len() == 1 {
         let Variant::Int(include_all) = bf_args.args[0].variant() else {
-            return Err(BfErr::Code(E_TYPE));
+            return Err(ErrValue(E_TYPE.msg(
+                "connected_players() requires an integer as the first argument",
+            )));
         };
         *include_all == 1
     } else {
@@ -252,16 +299,22 @@ bf_declare!(connected_players, bf_connected_players);
 
 fn bf_is_player(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
     if bf_args.args.len() != 1 {
-        return Err(BfErr::Code(E_ARGS));
+        return Err(ErrValue(E_ARGS.msg("is_player() requires 1 argument")));
     }
     let player = bf_args.args[0].variant();
     let Variant::Obj(player) = player else {
-        return Err(BfErr::Code(E_TYPE));
+        return Err(ErrValue(
+            E_TYPE.msg("is_player() requires an object as the first argument"),
+        ));
     };
 
     let is_player = match bf_args.world_state.flags_of(player) {
         Ok(flags) => flags.contains(ObjFlag::User),
-        Err(WorldStateError::ObjectNotFound(_)) => return Err(BfErr::Code(E_ARGS)),
+        Err(WorldStateError::ObjectNotFound(_)) => {
+            return Err(ErrValue(
+                E_ARGS.msg("is_player() requires a valid object as the first argument"),
+            ));
+        }
         Err(e) => return Err(world_state_bf_err(e)),
     };
     Ok(Ret(bf_args.v_bool(is_player)))
@@ -270,7 +323,9 @@ bf_declare!(is_player, bf_is_player);
 
 fn bf_caller_perms(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
     if !bf_args.args.is_empty() {
-        return Err(BfErr::Code(E_ARGS));
+        return Err(ErrValue(
+            E_ARGS.msg("caller_perms() does not take any arguments"),
+        ));
     }
 
     Ok(Ret(v_obj(bf_args.caller_perms())))
@@ -279,16 +334,20 @@ bf_declare!(caller_perms, bf_caller_perms);
 
 fn bf_set_task_perms(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
     if bf_args.args.len() != 1 {
-        return Err(BfErr::Code(E_ARGS));
+        return Err(ErrValue(E_ARGS.msg("set_task_perms() requires 1 argument")));
     }
     let Variant::Obj(perms_for) = bf_args.args[0].variant().clone() else {
-        return Err(BfErr::Code(E_TYPE));
+        return Err(ErrValue(
+            E_TYPE.msg("set_task_perms() requires an object as the first argument"),
+        ));
     };
 
     // If the caller is not a wizard, perms_for must be the caller
     let perms = bf_args.task_perms().map_err(world_state_bf_err)?;
     if !perms.check_is_wizard().map_err(world_state_bf_err)? && perms_for != perms.who {
-        return Err(BfErr::Code(E_PERM));
+        return Err(ErrValue(E_PERM.msg(
+            "set_task_perms() requires the caller to be a wizard or the caller itself",
+        )));
     }
     bf_args.exec_state.set_task_perms(perms_for);
 
@@ -298,7 +357,9 @@ bf_declare!(set_task_perms, bf_set_task_perms);
 
 fn bf_callers(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
     if !bf_args.args.is_empty() {
-        return Err(BfErr::Code(E_ARGS));
+        return Err(ErrValue(
+            E_ARGS.msg("callers() does not take any arguments"),
+        ));
     }
 
     // We have to exempt ourselves from the callers list.
@@ -325,7 +386,9 @@ bf_declare!(callers, bf_callers);
 
 fn bf_task_id(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
     if !bf_args.args.is_empty() {
-        return Err(BfErr::Code(E_ARGS));
+        return Err(ErrValue(
+            E_ARGS.msg("task_id() does not take any arguments"),
+        ));
     }
 
     Ok(Ret(v_int(bf_args.exec_state.task_id as i64)))
@@ -334,13 +397,17 @@ bf_declare!(task_id, bf_task_id);
 
 fn bf_idle_seconds(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
     if bf_args.args.len() != 1 {
-        return Err(BfErr::Code(E_ARGS));
+        return Err(ErrValue(E_ARGS.msg("idle_seconds() requires 1 argument")));
     }
     let Variant::Obj(who) = bf_args.args[0].variant() else {
-        return Err(BfErr::Code(E_TYPE));
+        return Err(ErrValue(
+            E_TYPE.msg("idle_seconds() requires an object as the first argument"),
+        ));
     };
     let Ok(idle_seconds) = bf_args.session.idle_seconds(who.clone()) else {
-        return Err(BfErr::Code(E_INVARG));
+        return Err(ErrValue(E_INVARG.msg(
+            "idle_seconds() requires a valid object as the first argument",
+        )));
     };
 
     Ok(Ret(v_int(idle_seconds as i64)))
@@ -349,13 +416,19 @@ bf_declare!(idle_seconds, bf_idle_seconds);
 
 fn bf_connected_seconds(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
     if bf_args.args.len() != 1 {
-        return Err(BfErr::Code(E_ARGS));
+        return Err(ErrValue(
+            E_ARGS.msg("connected_seconds() requires 1 argument"),
+        ));
     }
     let Variant::Obj(who) = bf_args.args[0].variant() else {
-        return Err(BfErr::Code(E_TYPE));
+        return Err(ErrValue(E_TYPE.msg(
+            "connected_seconds() requires an object as the first argument",
+        )));
     };
     let Ok(connected_seconds) = bf_args.session.connected_seconds(who.clone()) else {
-        return Err(BfErr::Code(E_INVARG));
+        return Err(ErrValue(E_INVARG.msg(
+            "connected_seconds() requires a valid object as the first argument",
+        )));
     };
 
     Ok(Ret(v_int(connected_seconds as i64)))
@@ -371,11 +444,15 @@ Returns a network-specific string identifying the connection being used by the g
  */
 fn bf_connection_name(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
     if bf_args.args.len() != 1 {
-        return Err(BfErr::Code(E_ARGS));
+        return Err(ErrValue(
+            E_ARGS.msg("connection_name() requires 1 argument"),
+        ));
     }
 
     let Variant::Obj(player) = bf_args.args[0].variant() else {
-        return Err(BfErr::Code(E_TYPE));
+        return Err(ErrValue(
+            E_TYPE.msg("connection_name() requires an object as the first argument"),
+        ));
     };
 
     let caller = bf_args.caller_perms();
@@ -386,11 +463,15 @@ fn bf_connection_name(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
         .map_err(world_state_bf_err)?
         && caller != *player
     {
-        return Err(BfErr::Code(E_PERM));
+        return Err(ErrValue(E_PERM.msg(
+            "connection_name() requires the caller to be a wizard or the caller itself",
+        )));
     }
 
     let Ok(connection_name) = bf_args.session.connection_name(player.clone()) else {
-        return Err(BfErr::Code(E_ARGS));
+        return Err(ErrValue(E_ARGS.msg(
+            "connection_name() requires a valid object as the first argument",
+        )));
     };
 
     Ok(Ret(v_string(connection_name)))
@@ -399,13 +480,15 @@ bf_declare!(connection_name, bf_connection_name);
 
 fn bf_shutdown(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
     if bf_args.args.len() > 1 {
-        return Err(BfErr::Code(E_ARGS));
+        return Err(ErrValue(E_ARGS.msg("shutdown() requires 0 or 1 arguments")));
     }
     let msg = if bf_args.args.is_empty() {
         None
     } else {
         let Variant::Str(msg) = bf_args.args[0].variant() else {
-            return Err(BfErr::Code(E_TYPE));
+            return Err(ErrValue(
+                E_TYPE.msg("shutdown() requires a string as the first argument"),
+            ));
         };
         Some(msg.as_str().to_string())
     };
@@ -424,7 +507,7 @@ bf_declare!(shutdown, bf_shutdown);
 
 fn bf_time(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
     if !bf_args.args.is_empty() {
-        return Err(BfErr::Code(E_ARGS));
+        return Err(ErrValue(E_ARGS.msg("time() does not take any arguments")));
     }
     Ok(Ret(v_int(
         SystemTime::now()
@@ -437,13 +520,15 @@ bf_declare!(time, bf_time);
 
 fn bf_ftime(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
     if bf_args.args.len() > 1 {
-        return Err(BfErr::Code(E_ARGS));
+        return Err(ErrValue(E_ARGS.msg("ftime() requires 0 or 1 arguments")));
     }
 
     // If argument is provided and equals 1, return uptime
     if bf_args.args.len() == 1 {
         let Variant::Int(arg) = bf_args.args[0].variant() else {
-            return Err(BfErr::Code(E_TYPE));
+            return Err(ErrValue(
+                E_TYPE.msg("ftime() requires an integer as the first argument"),
+            ));
         };
 
         if *arg == 1 {
@@ -461,7 +546,9 @@ fn bf_ftime(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
             // ftime(0) behaves the same as ftime()
             // Fall through to the default case
         } else {
-            return Err(BfErr::Code(E_INVARG));
+            return Err(ErrValue(
+                E_INVARG.msg("ftime() requires 0 or 1 as the first argument"),
+            ));
         }
     }
 
@@ -477,13 +564,15 @@ bf_declare!(ftime, bf_ftime);
 
 fn bf_ctime(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
     if bf_args.args.len() > 1 {
-        return Err(BfErr::Code(E_ARGS));
+        return Err(ErrValue(E_ARGS.msg("ctime() requires 0 or 1 arguments")));
     }
     let time = if bf_args.args.is_empty() {
         SystemTime::now()
     } else {
         let Variant::Int(time) = bf_args.args[0].variant() else {
-            return Err(BfErr::Code(E_TYPE));
+            return Err(ErrValue(
+                E_TYPE.msg("ctime() requires an integer as the first argument"),
+            ));
         };
         if *time < 0 {
             SystemTime::UNIX_EPOCH - Duration::from_secs(time.unsigned_abs())
@@ -513,16 +602,20 @@ fn bf_raise(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
     // and <value>, which defaults to zero, are made available to any `try'-`except' statements that catch the error.  If the error is not caught, then <message> will
     // appear on the first line of the traceback printed to the user.
     if bf_args.args.is_empty() || bf_args.args.len() > 3 {
-        return Err(BfErr::Code(E_ARGS));
+        return Err(ErrValue(E_ARGS.msg("raise() requires 1 to 3 arguments")));
     }
 
     let Variant::Err(err) = bf_args.args[0].variant() else {
-        return Err(BfErr::Code(E_ARGS));
+        return Err(ErrValue(
+            E_ARGS.msg("raise() requires an error as the first argument"),
+        ));
     };
 
     let msg = if bf_args.args.len() > 1 {
         let Variant::Str(msg) = bf_args.args[1].variant() else {
-            return Err(BfErr::Code(E_TYPE));
+            return Err(ErrValue(
+                E_TYPE.msg("raise() requires a string as the second argument"),
+            ));
         };
         Some(msg.as_str().to_string())
     } else {
@@ -535,14 +628,21 @@ fn bf_raise(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
         None
     };
 
-    Err(BfErr::Raise(*err, msg, value))
+    if err.msg.is_some() || err.value.is_some() {
+        return Err(ErrValue(
+            E_INVARG.msg("raise() requires an error with no message or value"),
+        ));
+    }
+    Err(BfErr::Raise(Error::new(err.err_type, msg, value)))
 }
 
 bf_declare!(raise, bf_raise);
 
 fn bf_server_version(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
     if !bf_args.args.is_empty() {
-        return Err(BfErr::Code(E_ARGS));
+        return Err(ErrValue(
+            E_ARGS.msg("server_version() does not take any arguments"),
+        ));
     }
     let version_string = format!("{}+{}", PKG_VERSION, SHORT_COMMIT);
     Ok(Ret(v_string(version_string)))
@@ -551,7 +651,7 @@ bf_declare!(server_version, bf_server_version);
 
 fn bf_suspend(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
     if bf_args.args.len() > 1 {
-        return Err(BfErr::Code(E_ARGS));
+        return Err(ErrValue(E_ARGS.msg("suspend() requires 0 or 1 arguments")));
     }
 
     let suspend_condition = if bf_args.args.is_empty() {
@@ -560,10 +660,16 @@ fn bf_suspend(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
         let seconds = match bf_args.args[0].variant() {
             Variant::Float(seconds) => *seconds,
             Variant::Int(seconds) => *seconds as f64,
-            _ => return Err(BfErr::Code(E_TYPE)),
+            _ => {
+                return Err(ErrValue(
+                    E_TYPE.msg("suspend() requires a number as the first argument"),
+                ));
+            }
         };
         if seconds < 0.0 {
-            return Err(BfErr::Code(E_INVARG));
+            return Err(ErrValue(
+                E_INVARG.msg("suspend() requires a positive number as the first argument"),
+            ));
         }
         TaskSuspend::Timed(Duration::from_secs_f64(seconds))
     };
@@ -574,7 +680,7 @@ bf_declare!(suspend, bf_suspend);
 
 fn bf_commit(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
     if !bf_args.args.is_empty() {
-        return Err(BfErr::Code(E_ARGS));
+        return Err(ErrValue(E_ARGS.msg("commit() does not take any arguments")));
     }
 
     Ok(VmInstr(ExecutionResult::TaskSuspend(TaskSuspend::Commit)))
@@ -590,7 +696,7 @@ fn bf_rollback(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
         .map_err(world_state_bf_err)?;
 
     if bf_args.args.len() > 1 {
-        return Err(BfErr::Code(E_ARGS));
+        return Err(ErrValue(E_ARGS.msg("rollback() requires 0 or 1 arguments")));
     }
 
     let output_session = !bf_args.args.is_empty() && bf_args.args[0].is_true();
@@ -601,11 +707,13 @@ bf_declare!(rollback, bf_rollback);
 
 fn bf_wait_task(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
     if bf_args.args.len() > 1 {
-        return Err(BfErr::Code(E_ARGS));
+        return Err(ErrValue(E_ARGS.msg("wait_task() requires 1 argument")));
     }
 
     let Variant::Int(task_id) = bf_args.args[0].variant().clone() else {
-        return Err(BfErr::Code(E_TYPE));
+        return Err(ErrValue(
+            E_TYPE.msg("wait_task() requires an integer as the first argument"),
+        ));
     };
 
     Ok(VmInstr(ExecutionResult::TaskSuspend(
@@ -616,7 +724,7 @@ bf_declare!(wait_task, bf_wait_task);
 
 fn bf_read(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
     if bf_args.args.len() > 1 {
-        return Err(BfErr::Code(E_ARGS));
+        return Err(ErrValue(E_ARGS.msg("read() requires 0 or 1 arguments")));
     }
 
     // We don't actually support reading from arbitrary connections that aren't the current player,
@@ -624,7 +732,9 @@ fn bf_read(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
     // network listener model.
     if bf_args.args.len() == 1 {
         let Variant::Obj(requested_player) = bf_args.args[0].variant() else {
-            return Err(BfErr::Code(E_ARGS));
+            return Err(ErrValue(
+                E_ARGS.msg("read() requires an object as the first argument"),
+            ));
         };
         let player = &bf_args.exec_state.top().player;
         if requested_player != player {
@@ -634,7 +744,9 @@ fn bf_read(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
                 caller = ?bf_args.exec_state.caller(),
                 ?player,
                 "read() called with non-current player");
-            return Err(BfErr::Code(E_ARGS));
+            return Err(ErrValue(
+                E_ARGS.msg("read() requires the current player as the first argument"),
+            ));
         }
     }
 
@@ -644,7 +756,9 @@ bf_declare!(read, bf_read);
 
 fn bf_queued_tasks(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
     if !bf_args.args.is_empty() {
-        return Err(BfErr::Code(E_ARGS));
+        return Err(ErrValue(
+            E_ARGS.msg("queued_tasks() does not take any arguments"),
+        ));
     }
 
     // Ask the scheduler (through its mailbox) to describe all the tasks.
@@ -694,7 +808,7 @@ fn bf_active_tasks(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
     let tasks = match bf_args.task_scheduler_client.active_tasks() {
         Ok(tasks) => tasks,
         Err(e) => {
-            return Err(BfErr::Code(e));
+            return Err(ErrValue(e));
         }
     };
 
@@ -798,14 +912,18 @@ bf_declare!(active_tasks, bf_active_tasks);
 /// It is guaranteed that queue_info(X) will return zero for any X not in the result of queue_info().
 fn bf_queue_info(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
     if bf_args.args.len() > 1 {
-        return Err(BfErr::Code(E_ARGS));
+        return Err(ErrValue(
+            E_ARGS.msg("queue_info() requires 0 or 1 arguments"),
+        ));
     }
 
     let player = if bf_args.args.is_empty() {
         None
     } else {
         let Variant::Obj(player) = bf_args.args[0].variant() else {
-            return Err(BfErr::Code(E_TYPE));
+            return Err(ErrValue(
+                E_TYPE.msg("queue_info() requires an object as the first argument"),
+            ));
         };
         Some(player)
     };
@@ -835,7 +953,9 @@ fn bf_queue_info(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
             // Player must be either a wizard, or the player themselves.
             let perms = bf_args.task_perms().map_err(world_state_bf_err)?;
             if !perms.check_is_wizard().map_err(world_state_bf_err)? && !p.eq(&perms.who) {
-                return Err(BfErr::Code(E_PERM));
+                return Err(ErrValue(E_PERM.msg(
+                    "queue_info() requires the caller to be a wizard or the caller itself",
+                )));
             }
             let queued_tasks = tasks.iter().filter(|t| &t.permissions == p).count();
             Ok(Ret(v_int(queued_tasks as i64)))
@@ -850,11 +970,13 @@ fn bf_kill_task(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
     // Kills the task with the given <task-id>.
     // The task can be suspended / queued or running.
     if bf_args.args.len() != 1 {
-        return Err(BfErr::Code(E_ARGS));
+        return Err(ErrValue(E_ARGS.msg("kill_task() requires 1 argument")));
     }
 
     let Variant::Int(victim_task_id) = bf_args.args[0].variant() else {
-        return Err(BfErr::Code(E_TYPE));
+        return Err(ErrValue(
+            E_TYPE.msg("kill_task() requires an integer as the first argument"),
+        ));
     };
 
     // If the task ID is itself, that means returning an Complete execution result, which will cascade
@@ -871,7 +993,7 @@ fn bf_kill_task(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
         bf_args.task_perms().map_err(world_state_bf_err)?,
     );
     if let Variant::Err(err) = result.variant() {
-        return Err(BfErr::Code(*err));
+        return Err(ErrValue(err.clone()));
     }
     Ok(Ret(result))
 }
@@ -881,11 +1003,13 @@ fn bf_resume(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
     // Syntax: resume(INT task-ID[, ANY value])
     // Resumes a previously suspended task, optionally with a value to pass back to the suspend() call
     if bf_args.args.len() > 2 {
-        return Err(BfErr::Code(E_ARGS));
+        return Err(ErrValue(E_ARGS.msg("resume() requires 1 or 2 arguments")));
     }
 
     let Variant::Int(resume_task_id) = bf_args.args[0].variant() else {
-        return Err(BfErr::Code(E_TYPE));
+        return Err(ErrValue(
+            E_TYPE.msg("resume() requires an integer as the first argument"),
+        ));
     };
 
     // Optional 2nd argument is the value to return from suspend() in the resumed task.
@@ -899,7 +1023,9 @@ fn bf_resume(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
 
     // Resuming ourselves makes no sense, it's not suspended. E_INVARG.
     if task_id == bf_args.exec_state.task_id {
-        return Err(BfErr::Code(E_ARGS));
+        return Err(ErrValue(
+            E_ARGS.msg("resume() cannot resume the current task"),
+        ));
     }
 
     let result = bf_args.task_scheduler_client.resume_task(
@@ -908,7 +1034,7 @@ fn bf_resume(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
         return_value.clone(),
     );
     if let Variant::Err(err) = result.variant() {
-        return Err(BfErr::Code(*err));
+        return Err(ErrValue(err.clone()));
     }
     Ok(Ret(result))
 }
@@ -919,7 +1045,9 @@ fn bf_ticks_left(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
     //
     // Returns the number of ticks left in the current time slice.
     if !bf_args.args.is_empty() {
-        return Err(BfErr::Code(E_ARGS));
+        return Err(ErrValue(
+            E_ARGS.msg("ticks_left() does not take any arguments"),
+        ));
     }
 
     let ticks_left = bf_args
@@ -936,7 +1064,9 @@ fn bf_seconds_left(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
     //
     // Returns the number of seconds left in the current time slice.
     if !bf_args.args.is_empty() {
-        return Err(BfErr::Code(E_ARGS));
+        return Err(ErrValue(
+            E_ARGS.msg("seconds_left() does not take any arguments"),
+        ));
     }
 
     let seconds_left = match bf_args.exec_state.time_left() {
@@ -953,16 +1083,20 @@ fn bf_boot_player(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
     //
     // Disconnects the player with the given object number.
     if bf_args.args.len() != 1 {
-        return Err(BfErr::Code(E_ARGS));
+        return Err(ErrValue(E_ARGS.msg("boot_player() requires 1 argument")));
     }
 
     let Variant::Obj(player) = bf_args.args[0].variant() else {
-        return Err(BfErr::Code(E_TYPE));
+        return Err(ErrValue(
+            E_TYPE.msg("boot_player() requires an object as the first argument"),
+        ));
     };
 
     let task_perms = bf_args.task_perms().map_err(world_state_bf_err)?;
     if task_perms.who != *player && !task_perms.check_is_wizard().map_err(world_state_bf_err)? {
-        return Err(BfErr::Code(E_PERM));
+        return Err(ErrValue(E_PERM.msg(
+            "boot_player() requires the caller to be a wizard or the caller itself",
+        )));
     }
 
     bf_args.task_scheduler_client.boot_player(player.clone());
@@ -976,22 +1110,29 @@ fn bf_call_function(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
     //
     // Calls the given function with the given arguments and returns the result.
     if bf_args.args.is_empty() {
-        return Err(BfErr::Code(E_ARGS));
+        return Err(ErrValue(
+            E_ARGS.msg("call_function() requires at least 1 argument"),
+        ));
     }
 
-    let func_name = bf_args.args[0].as_symbol().map_err(Code)?;
+    let func_name = bf_args.args[0].as_symbol().map_err(ErrValue)?;
 
     // Arguments are everything left, if any.
-    let (_, args) = bf_args.args.pop_front().map_err(|_| BfErr::Code(E_ARGS))?;
+    let (_, args) = bf_args
+        .args
+        .pop_front()
+        .map_err(|_| ErrValue(E_ARGS.msg("call_function() requires at least 1 argument")))?;
     let Variant::List(arguments) = args.variant() else {
-        return Err(BfErr::Code(E_TYPE));
+        return Err(ErrValue(
+            E_TYPE.msg("call_function() requires a list as the second argument"),
+        ));
     };
 
     // Find the function id for the given function name.
 
-    let builtin = BUILTINS
-        .find_builtin(func_name)
-        .ok_or(BfErr::Code(E_INVARG))?;
+    let builtin = BUILTINS.find_builtin(func_name).ok_or(ErrValue(
+        E_INVARG.msg("call_function() requires a valid function name as the first argument"),
+    ))?;
 
     // Then ask the scheduler to run the function as a continuation of what we're doing now.
     Ok(VmInstr(ExecutionResult::DispatchBuiltin {
@@ -1009,16 +1150,22 @@ is not a wizard, then `E_PERM' is raised.  If <is-error> is provided and true, t
 */
 fn bf_server_log(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
     if bf_args.args.is_empty() || bf_args.args.len() > 2 {
-        return Err(BfErr::Code(E_ARGS));
+        return Err(ErrValue(
+            E_ARGS.msg("server_log() requires 1 or 2 arguments"),
+        ));
     }
 
     let Variant::Str(message) = bf_args.args[0].variant() else {
-        return Err(BfErr::Code(E_TYPE));
+        return Err(ErrValue(
+            E_TYPE.msg("server_log() requires a string as the first argument"),
+        ));
     };
 
     let is_error = if bf_args.args.len() == 2 {
         let Variant::Int(is_error) = bf_args.args[1].variant() else {
-            return Err(BfErr::Code(E_TYPE));
+            return Err(ErrValue(
+                E_TYPE.msg("server_log() requires an integer as the second argument"),
+            ));
         };
         *is_error == 1
     } else {
@@ -1031,7 +1178,9 @@ fn bf_server_log(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
         .check_is_wizard()
         .map_err(world_state_bf_err)?
     {
-        return Err(BfErr::Code(E_PERM));
+        return Err(ErrValue(
+            E_PERM.msg("server_log() requires the caller to be a wizard"),
+        ));
     }
 
     if is_error {
@@ -1077,16 +1226,20 @@ fn bf_function_info_to_list(bf: &Builtin) -> Var {
 
 fn bf_function_info(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
     if bf_args.args.len() > 1 {
-        return Err(BfErr::Code(E_ARGS));
+        return Err(ErrValue(
+            E_ARGS.msg("function_info() requires 0 or 1 arguments"),
+        ));
     }
 
     if bf_args.args.len() == 1 {
-        let func_name = bf_args.args[0].as_symbol().map_err(BfErr::Code)?;
-        let bf = BUILTINS
-            .find_builtin(func_name)
-            .ok_or(BfErr::Code(E_ARGS))?;
+        let func_name = bf_args.args[0].as_symbol().map_err(ErrValue)?;
+        let bf = BUILTINS.find_builtin(func_name).ok_or(ErrValue(
+            E_ARGS.msg("function_info() requires a valid function name as the first argument"),
+        ))?;
         let Some(desc) = BUILTINS.description_for(bf) else {
-            return Err(BfErr::Code(E_ARGS));
+            return Err(ErrValue(E_ARGS.msg(
+                "function_info() requires a valid function name as the first argument",
+            )));
         };
         let desc = bf_function_info_to_list(desc);
         return Ok(Ret(desc));
@@ -1115,27 +1268,35 @@ fn bf_listen(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
         .map_err(world_state_bf_err)?;
 
     if bf_args.args.len() < 2 || bf_args.args.len() > 4 {
-        return Err(BfErr::Code(E_ARGS));
+        return Err(ErrValue(E_ARGS.msg("listen() requires 2 to 4 arguments")));
     }
 
     let Variant::Obj(object) = bf_args.args[0].variant().clone() else {
-        return Err(BfErr::Code(E_TYPE));
+        return Err(ErrValue(
+            E_TYPE.msg("listen() requires an object as the first argument"),
+        ));
     };
 
     // point is a protocol specific value, but for now we'll just assume it's an integer for port
     let Variant::Int(point) = bf_args.args[1].variant().clone() else {
-        return Err(BfErr::Code(E_TYPE));
+        return Err(ErrValue(
+            E_TYPE.msg("listen() requires an integer as the second argument"),
+        ));
     };
 
     if point < 0 || point > (u16::MAX as i64) {
-        return Err(BfErr::Code(E_INVARG));
+        return Err(ErrValue(E_INVARG.msg(
+            "listen() requires a positive integer as the second argument",
+        )));
     }
 
     let port = point as u16;
 
     let print_messages = if bf_args.args.len() >= 3 {
         let Variant::Int(print_messages) = bf_args.args[2].variant().clone() else {
-            return Err(BfErr::Code(E_TYPE));
+            return Err(ErrValue(
+                E_TYPE.msg("listen() requires an integer as the third argument"),
+            ));
         };
         print_messages == 1
     } else {
@@ -1144,7 +1305,9 @@ fn bf_listen(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
 
     let host_type = if bf_args.args.len() == 4 {
         let Variant::Str(host_type) = bf_args.args[3].variant().clone() else {
-            return Err(BfErr::Code(E_TYPE));
+            return Err(ErrValue(
+                E_TYPE.msg("listen() requires a string as the fourth argument"),
+            ));
         };
         host_type.as_str().to_string()
     } else {
@@ -1157,7 +1320,7 @@ fn bf_listen(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
             .task_scheduler_client
             .listen(object, host_type, port, print_messages)
     {
-        return Err(BfErr::Code(error));
+        return Err(ErrValue(error));
     }
 
     // "Listen() returns canon, a `canonicalized' version of point, with any configuration-specific defaulting or aliasing accounted for. "
@@ -1176,7 +1339,9 @@ fn bf_listeners(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
         .map_err(world_state_bf_err)?;
 
     if !bf_args.args.is_empty() {
-        return Err(BfErr::Code(E_ARGS));
+        return Err(ErrValue(
+            E_ARGS.msg("listeners() does not take any arguments"),
+        ));
     }
 
     let listeners = bf_args.task_scheduler_client.listeners();
@@ -1205,22 +1370,28 @@ fn bf_unlisten(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
         .map_err(world_state_bf_err)?;
 
     if bf_args.args.is_empty() || bf_args.args.len() > 2 {
-        return Err(BfErr::Code(E_ARGS));
+        return Err(ErrValue(E_ARGS.msg("unlisten() requires 1 or 2 arguments")));
     }
 
     // point is a protocol specific value, but for now we'll just assume it's an integer for port
     let Variant::Int(point) = bf_args.args[0].variant().clone() else {
-        return Err(BfErr::Code(E_TYPE));
+        return Err(ErrValue(
+            E_TYPE.msg("unlisten() requires an integer as the first argument"),
+        ));
     };
 
     if point < 0 || point > (u16::MAX as i64) {
-        return Err(BfErr::Code(E_INVARG));
+        return Err(ErrValue(E_INVARG.msg(
+            "unlisten() requires a positive integer as the first argument",
+        )));
     }
 
     let port = point as u16;
     let host_type = if bf_args.args.len() == 4 {
         let Variant::Str(host_type) = bf_args.args[3].variant().clone() else {
-            return Err(BfErr::Code(E_TYPE));
+            return Err(ErrValue(
+                E_TYPE.msg("unlisten() requires a string as the second argument"),
+            ));
         };
         host_type.as_str().to_string()
     } else {
@@ -1228,7 +1399,7 @@ fn bf_unlisten(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
     };
 
     if let Some(err) = bf_args.task_scheduler_client.unlisten(host_type, port) {
-        return Err(BfErr::Code(err));
+        return Err(ErrValue(err));
     }
 
     Ok(Ret(v_none()))
@@ -1245,10 +1416,12 @@ fn bf_eval(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
         .check_programmer()
         .map_err(world_state_bf_err)?;
     if bf_args.args.len() != 1 {
-        return Err(BfErr::Code(E_ARGS));
+        return Err(ErrValue(E_ARGS.msg("bf_eval() requires 1 argument")));
     }
     let Variant::Str(program_code) = bf_args.args[0].variant().clone() else {
-        return Err(BfErr::Code(E_TYPE));
+        return Err(ErrValue(
+            E_TYPE.msg("bf_eval() requires a string as the first argument"),
+        ));
     };
 
     let tramp = bf_args
@@ -1301,7 +1474,9 @@ bf_declare!(dump_database, bf_dump_database);
 
 fn bf_memory_usage(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
     if !bf_args.args.is_empty() {
-        return Err(BfErr::Code(E_ARGS));
+        return Err(ErrValue(
+            E_ARGS.msg("memory_usage() does not take any arguments"),
+        ));
     }
 
     // Must be wizard.
@@ -1314,28 +1489,28 @@ fn bf_memory_usage(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
     // Get system page size
     let page_size = unsafe { libc::sysconf(libc::_SC_PAGESIZE) };
     if page_size == -1 {
-        return Err(BfErr::Code(Error::E_QUOTA));
+        return Err(Code(E_QUOTA));
     }
 
     // Then read /proc/self/statm
     let mut statm = String::new();
     std::fs::File::open("/proc/self/statm")
-        .map_err(|_| BfErr::Code(Error::E_QUOTA))?
+        .map_err(|_| Code(E_QUOTA))?
         .read_to_string(&mut statm)
-        .map_err(|_| BfErr::Code(Error::E_QUOTA))?;
+        .map_err(|_| Code(E_QUOTA))?;
 
     // Split on whitespace -- then we have VmSize and VmRSS in pages
     let mut statm = statm.split_whitespace();
     let vm_size = statm
         .next()
-        .ok_or(BfErr::Code(Error::E_QUOTA))?
+        .ok_or(Code(E_QUOTA))?
         .parse::<i64>()
-        .map_err(|_| BfErr::Code(Error::E_QUOTA))?;
+        .map_err(|_| Code(E_QUOTA))?;
     let vm_rss = statm
         .next()
-        .ok_or(BfErr::Code(Error::E_QUOTA))?
+        .ok_or(Code(E_QUOTA))?
         .parse::<i64>()
-        .map_err(|_| BfErr::Code(Error::E_QUOTA))?;
+        .map_err(|_| Code(E_QUOTA))?;
 
     // Return format for memory_usage is:
     // {block-size, nused, nfree}
@@ -1358,7 +1533,9 @@ fn db_disk_size(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
     //
     // Returns the number of bytes currently occupied by the database on disk.
     if !bf_args.args.is_empty() {
-        return Err(BfErr::Code(E_ARGS));
+        return Err(ErrValue(
+            E_ARGS.msg("db_disk_size() does not take any arguments"),
+        ));
     }
 
     // Must be wizard.
@@ -1382,7 +1559,9 @@ bf_declare!(db_disk_size, db_disk_size);
 */
 fn load_server_options(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
     if !bf_args.args.is_empty() {
-        return Err(BfErr::Code(E_ARGS));
+        return Err(ErrValue(
+            E_ARGS.msg("load_server_options() does not take any arguments"),
+        ));
     }
 
     bf_args
@@ -1482,23 +1661,27 @@ fn bf_force_input(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
     /*Syntax:  force_input (obj <conn>, str <line> [, <at-front>])   => none
      */
     if bf_args.args.len() < 2 || bf_args.args.len() > 3 {
-        return Err(BfErr::Code(E_ARGS));
+        return Err(ErrValue(
+            E_ARGS.msg("force_input() requires 2 or 3 arguments"),
+        ));
     }
 
     // We always ignore 3rd argument ("at_front"), it makes no sense in mooR.
     let Variant::Obj(conn) = bf_args.args[0].variant().clone() else {
-        return Err(BfErr::Code(E_TYPE));
+        return Err(ErrValue(
+            E_TYPE.msg("force_input() requires an object as the first argument"),
+        ));
     };
 
     // Must be either player or wizard
     let perms = bf_args.task_perms().map_err(world_state_bf_err)?;
 
     if perms.who != conn && !perms.check_is_wizard().map_err(world_state_bf_err)? {
-        return Err(BfErr::Code(E_PERM));
+        return Err(Code(E_PERM));
     }
 
     let Variant::Str(line) = bf_args.args[1].variant().clone() else {
-        return Err(BfErr::Code(E_TYPE));
+        return Err(Code(E_TYPE));
     };
 
     match bf_args
@@ -1506,7 +1689,7 @@ fn bf_force_input(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
         .force_input(conn, line.as_str().to_string())
     {
         Ok(task_id) => Ok(Ret(v_int(task_id as i64))),
-        Err(e) => Err(Code(e)),
+        Err(e) => Err(ErrValue(e)),
     }
 }
 bf_declare!(force_input, bf_force_input);
@@ -1523,10 +1706,10 @@ fn bf_worker_request(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
         .map_err(world_state_bf_err)?;
 
     if bf_args.args.len() < 2 {
-        return Err(BfErr::Code(E_ARGS));
+        return Err(Code(E_ARGS));
     }
 
-    let worker_type = bf_args.args[0].as_symbol().map_err(BfErr::Code)?;
+    let worker_type = bf_args.args[0].as_symbol().map_err(ErrValue)?;
 
     // The args are everything after the first argument
     let args = bf_args.args.iter().skip(1).collect();

--- a/crates/kernel/src/builtins/bf_strings.rs
+++ b/crates/kernel/src/builtins/bf_strings.rs
@@ -17,7 +17,7 @@ use base64::Engine;
 use base64::engine::general_purpose;
 use md5::Digest;
 use moor_compiler::offset_for_builtin;
-use moor_var::Error::{E_ARGS, E_INVARG, E_TYPE};
+use moor_var::{E_ARGS, E_INVARG, E_TYPE};
 use moor_var::{Sequence, Variant};
 use moor_var::{v_int, v_map, v_str, v_string};
 use rand::distributions::Alphanumeric;

--- a/crates/kernel/src/builtins/bf_values.rs
+++ b/crates/kernel/src/builtins/bf_values.rs
@@ -16,9 +16,9 @@ use crate::builtins::BfRet::Ret;
 use crate::builtins::{BfCallState, BfErr, BfRet, BuiltinFunction, world_state_bf_err};
 use md5::Digest;
 use moor_compiler::{offset_for_builtin, to_literal};
-use moor_var::Error::{E_ARGS, E_INVARG, E_RANGE, E_TYPE};
 use moor_var::Variant;
 use moor_var::{AsByteBuffer, Sequence};
+use moor_var::{E_ARGS, E_INVARG, E_RANGE, E_TYPE};
 use moor_var::{v_float, v_int, v_obj, v_objid, v_str, v_sym, v_sym_str};
 
 fn bf_typeof(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
@@ -215,7 +215,7 @@ fn bf_length(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
 
     match bf_args.args[0].len() {
         Ok(l) => Ok(Ret(v_int(l as i64))),
-        Err(e) => Err(BfErr::Code(e)),
+        Err(e) => Err(BfErr::ErrValue(e)),
     }
 }
 bf_declare!(length, bf_length);

--- a/crates/kernel/src/builtins/bf_values.rs
+++ b/crates/kernel/src/builtins/bf_values.rs
@@ -57,7 +57,9 @@ bf_declare!(tostr, bf_tostr);
 fn bf_tosym(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
     // Convert scalar values to symbols.
     if bf_args.args.len() != 1 {
-        return Err(BfErr::Code(E_ARGS));
+        return Err(BfErr::ErrValue(
+            E_ARGS.msg("tosym() requires exactly 1 argument"),
+        ));
     }
 
     match bf_args.args[0].variant() {
@@ -68,14 +70,18 @@ fn bf_tosym(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
         Variant::Str(s) => Ok(Ret(v_sym_str(s.as_str()))),
         Variant::Err(e) => Ok(Ret(v_sym(e.name()))),
         Variant::Sym(s) => Ok(Ret(v_sym(*s))),
-        _ => Err(BfErr::Code(E_TYPE)),
+        _ => Err(BfErr::ErrValue(E_TYPE.msg(
+            "tosym() requires a string, boolean, error, or symbol argument",
+        ))),
     }
 }
 bf_declare!(tosym, bf_tosym);
 
 fn bf_toliteral(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
     if bf_args.args.len() != 1 {
-        return Err(BfErr::Code(E_ARGS));
+        return Err(BfErr::ErrValue(
+            E_ARGS.msg("toliteral() requires exactly 1 argument"),
+        ));
     }
     let literal = to_literal(&bf_args.args[0]);
     Ok(Ret(v_str(literal.as_str())))
@@ -84,7 +90,9 @@ bf_declare!(toliteral, bf_toliteral);
 
 fn bf_toint(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
     if bf_args.args.len() != 1 {
-        return Err(BfErr::Code(E_ARGS));
+        return Err(BfErr::ErrValue(
+            E_ARGS.msg("toint() requires exactly 1 argument"),
+        ));
     }
     match bf_args.args[0].variant() {
         Variant::Int(i) => Ok(Ret(v_int(*i))),
@@ -99,24 +107,32 @@ fn bf_toint(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
         }
         Variant::Err(e) => {
             let Some(v) = e.to_int() else {
-                return Err(BfErr::Code(E_INVARG));
+                return Err(BfErr::ErrValue(
+                    E_INVARG.msg("cannot convert this error to integer"),
+                ));
             };
 
             Ok(Ret(v_int(v as i64)))
         }
-        _ => Err(BfErr::Code(E_INVARG)),
+        _ => Err(BfErr::ErrValue(
+            E_INVARG.msg("cannot convert this type to integer"),
+        )),
     }
 }
 bf_declare!(toint, bf_toint);
 
 fn bf_toobj(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
     if bf_args.args.len() != 1 {
-        return Err(BfErr::Code(E_ARGS));
+        return Err(BfErr::ErrValue(
+            E_ARGS.msg("toobj() requires exactly 1 argument"),
+        ));
     }
     match bf_args.args[0].variant() {
         Variant::Int(i) => {
             let i = if *i < i32::MIN as i64 || *i > i32::MAX as i64 {
-                return Err(BfErr::Code(E_RANGE));
+                return Err(BfErr::ErrValue(
+                    E_RANGE.msg("integer value outside valid object ID range"),
+                ));
             } else {
                 *i as i32
             };
@@ -124,7 +140,9 @@ fn bf_toobj(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
         }
         Variant::Float(f) => {
             let f = if *f < i32::MIN as f64 || *f > i32::MAX as f64 {
-                return Err(BfErr::Code(E_RANGE));
+                return Err(BfErr::ErrValue(
+                    E_RANGE.msg("float value outside valid object ID range"),
+                ));
             } else {
                 *f as i32
             };
@@ -145,14 +163,18 @@ fn bf_toobj(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
             }
         }
         Variant::Obj(o) => Ok(Ret(v_obj(o.clone()))),
-        _ => Err(BfErr::Code(E_INVARG)),
+        _ => Err(BfErr::ErrValue(
+            E_INVARG.msg("cannot convert this type to object"),
+        )),
     }
 }
 bf_declare!(toobj, bf_toobj);
 
 fn bf_tofloat(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
     if bf_args.args.len() != 1 {
-        return Err(BfErr::Code(E_ARGS));
+        return Err(BfErr::ErrValue(
+            E_ARGS.msg("tofloat() requires exactly 1 argument"),
+        ));
     }
     match bf_args.args[0].variant() {
         Variant::Int(i) => Ok(Ret(v_float(*i as f64))),
@@ -167,19 +189,25 @@ fn bf_tofloat(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
 
         Variant::Err(e) => {
             let Some(v) = e.to_int() else {
-                return Err(BfErr::Code(E_INVARG));
+                return Err(BfErr::ErrValue(
+                    E_INVARG.msg("cannot convert this error to float"),
+                ));
             };
 
             Ok(Ret(v_float(v as f64)))
         }
-        _ => Err(BfErr::Code(E_INVARG)),
+        _ => Err(BfErr::ErrValue(
+            E_INVARG.msg("cannot convert this type to float"),
+        )),
     }
 }
 bf_declare!(tofloat, bf_tofloat);
 
 fn bf_equal(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
     if bf_args.args.len() != 2 {
-        return Err(BfErr::Code(E_ARGS));
+        return Err(BfErr::ErrValue(
+            E_ARGS.msg("equal() requires exactly 2 arguments"),
+        ));
     }
     let (a1, a2) = (&bf_args.args[0], &bf_args.args[1]);
     let result = a1.eq_case_sensitive(a2);
@@ -189,7 +217,9 @@ bf_declare!(equal, bf_equal);
 
 fn bf_value_bytes(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
     if bf_args.args.len() != 1 {
-        return Err(BfErr::Code(E_ARGS));
+        return Err(BfErr::ErrValue(
+            E_ARGS.msg("value_bytes() requires exactly 1 argument"),
+        ));
     }
     let count = bf_args.args[0].size_bytes();
     Ok(Ret(v_int(count as i64)))
@@ -198,7 +228,9 @@ bf_declare!(value_bytes, bf_value_bytes);
 
 fn bf_value_hash(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
     if bf_args.args.len() != 1 {
-        return Err(BfErr::Code(E_ARGS));
+        return Err(BfErr::ErrValue(
+            E_ARGS.msg("value_hash() requires exactly 1 argument"),
+        ));
     }
     let s = to_literal(&bf_args.args[0]);
     let hash_digest = md5::Md5::digest(s.as_bytes());
@@ -210,7 +242,9 @@ bf_declare!(value_hash, bf_value_hash);
 
 fn bf_length(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
     if bf_args.args.len() != 1 {
-        return Err(BfErr::Code(E_ARGS));
+        return Err(BfErr::ErrValue(
+            E_ARGS.msg("length() requires exactly 1 argument"),
+        ));
     }
 
     match bf_args.args[0].len() {
@@ -222,13 +256,17 @@ bf_declare!(length, bf_length);
 
 fn bf_object_bytes(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
     if bf_args.args.len() != 1 {
-        return Err(BfErr::Code(E_ARGS));
+        return Err(BfErr::ErrValue(
+            E_ARGS.msg("object_bytes() requires exactly 1 argument"),
+        ));
     }
     let Variant::Obj(o) = bf_args.args[0].variant() else {
-        return Err(BfErr::Code(E_INVARG));
+        return Err(BfErr::ErrValue(
+            E_INVARG.msg("object_bytes() requires an object argument"),
+        ));
     };
     if !bf_args.world_state.valid(o).map_err(world_state_bf_err)? {
-        return Err(BfErr::Code(E_INVARG));
+        return Err(BfErr::ErrValue(E_INVARG.msg("object is not valid")));
     };
     let size = bf_args
         .world_state
@@ -286,7 +324,6 @@ pub(crate) fn register_bf_values(builtins: &mut [Box<dyn BuiltinFunction>]) {
     builtins[offset_for_builtin("object_bytes")] = Box::new(BfObjectBytes {});
     builtins[offset_for_builtin("value_hash")] = Box::new(BfValueHash {});
     builtins[offset_for_builtin("length")] = Box::new(BfLength {});
-
     builtins[offset_for_builtin("error_code")] = Box::new(BfErrorCode {});
     builtins[offset_for_builtin("error_message")] = Box::new(BfErrorMessage {});
 }

--- a/crates/kernel/src/builtins/mod.rs
+++ b/crates/kernel/src/builtins/mod.rs
@@ -37,9 +37,9 @@ use moor_common::model::WorldState;
 use moor_common::model::WorldStateError;
 use moor_common::util::PerfCounter;
 use moor_compiler::{BUILTINS, BuiltinId};
-use moor_var::Symbol;
 use moor_var::Var;
 use moor_var::{Error, List};
+use moor_var::{ErrorCode, Symbol};
 use moor_var::{Obj, v_bool_int};
 
 mod bf_age_crypto;
@@ -210,9 +210,11 @@ pub enum BfRet {
 #[derive(Debug, Clone, PartialEq, Error)]
 pub enum BfErr {
     #[error("Error in built-in function: {0}")]
-    Code(Error),
-    #[error("Raised error: {0:?} {1:?} {2:?}")]
-    Raise(Error, Option<String>, Option<Var>),
+    ErrValue(Error),
+    #[error("Error in built-in function: {0}")]
+    Code(ErrorCode),
+    #[error("Raised error: {0:?}")]
+    Raise(Error),
     #[error("Transaction rollback-retry")]
     Rollback,
 }
@@ -242,6 +244,6 @@ macro_rules! bf_declare {
 pub(crate) fn world_state_bf_err(err: WorldStateError) -> BfErr {
     match err {
         WorldStateError::RollbackRetry => BfErr::Rollback,
-        _ => BfErr::Code(err.into()),
+        _ => BfErr::ErrValue(err.into()),
     }
 }

--- a/crates/kernel/src/tasks/mod.rs
+++ b/crates/kernel/src/tasks/mod.rs
@@ -344,7 +344,7 @@ pub mod scheduler_test_utils {
     use std::time::Duration;
 
     use moor_common::tasks::{CommandError, SchedulerError};
-    use moor_var::{Error::E_VERBNF, Obj, SYSTEM_OBJECT, Var};
+    use moor_var::{E_VERBNF, Obj, SYSTEM_OBJECT, Var};
 
     use super::{TaskHandle, TaskResult};
     use crate::config::FeaturesConfig;
@@ -373,8 +373,10 @@ pub mod scheduler_test_utils {
         {
             // Some errors can be represented as a MOO `Var`; translate those to a `Var`, so that
             // `moot` tests can match against them.
-            Err(TaskAbortedException(Exception { code, .. })) => Ok(code.into()),
-            Err(CommandExecutionError(CommandError::NoCommandMatch)) => Ok(E_VERBNF.into()),
+            Err(TaskAbortedException(Exception { error, .. })) => Ok(error.into()),
+            Err(CommandExecutionError(CommandError::NoCommandMatch)) => {
+                Ok(E_VERBNF.msg("No command match").into())
+            }
             Err(err) => Err(err),
             Ok(TaskResult::Result(var)) => Ok(var),
             Ok(TaskResult::Replaced(_)) => panic!("Unexpected task restart"),

--- a/crates/kernel/src/tasks/task.rs
+++ b/crates/kernel/src/tasks/task.rs
@@ -324,11 +324,7 @@ impl Task {
                     return None;
                 };
 
-                warn!(
-                    task_id = self.task_id,
-                    msg = exception.msg,
-                    "Task exception"
-                );
+                warn!(task_id = self.task_id, ?exception, "Task exception");
                 self.vm_host.stop();
 
                 task_scheduler_client.exception(exception);
@@ -773,7 +769,7 @@ mod tests {
     use moor_common::util::BitEnum;
     use moor_compiler::{CompileOptions, Program, compile};
     use moor_db::{DatabaseConfig, TxDB};
-    use moor_var::Error::E_DIV;
+    use moor_var::E_DIV;
     use moor_var::{AsByteBuffer, NOTHING, SYSTEM_OBJECT};
     use moor_var::{Symbol, v_obj};
     use moor_var::{v_int, v_str};
@@ -959,7 +955,7 @@ mod tests {
         let TaskControlMsg::TaskException(exception) = msg else {
             panic!("Expected TaskException, got {:?}", msg);
         };
-        assert_eq!(exception.code, E_DIV);
+        assert_eq!(exception.error.err_type, E_DIV);
     }
 
     // notify() will dispatch to the scheduler

--- a/crates/kernel/src/tasks/vm_host.rs
+++ b/crates/kernel/src/tasks/vm_host.rs
@@ -28,10 +28,10 @@ use moor_common::tasks::{AbortLimitReason, TaskId};
 use moor_compiler::Name;
 use moor_compiler::Program;
 use moor_compiler::{CompileOptions, compile};
-use moor_var::Error::E_MAXREC;
+use moor_var::E_MAXREC;
+use moor_var::Obj;
 use moor_var::Var;
 use moor_var::{AsByteBuffer, List};
-use moor_var::{ErrorPack, Obj};
 use moor_var::{Symbol, v_none};
 
 use crate::PhantomUnsync;
@@ -236,10 +236,6 @@ impl VmHost {
                     result = self.vm_exec_state.push_error(e);
                     continue;
                 }
-                ExecutionResult::PushErrorPack(e, m, v) => {
-                    result = self.vm_exec_state.push_error_pack(ErrorPack::new(e, m, v));
-                    continue;
-                }
                 ExecutionResult::RaiseError(e) => {
                     result = self.vm_exec_state.raise_error(e);
                     continue;
@@ -386,7 +382,7 @@ impl VmHost {
         if self.vm_exec_state.stack.len() >= vm_exec_params.max_stack_depth {
             // Absolutely raise-unwind an error here instead of just offering it as a potential
             // return value if this is a non-d verb. At least I think this the right thing to do?
-            return self.vm_exec_state.throw_error(E_MAXREC);
+            return self.vm_exec_state.throw_error(E_MAXREC.into());
         }
 
         // Pick the right kind of execution flow depending on the activation -- builtin or MOO?

--- a/crates/kernel/src/vm/mod.rs
+++ b/crates/kernel/src/vm/mod.rs
@@ -70,8 +70,6 @@ pub enum ExecutionResult {
     /// An error occurred during execution, that we might need to push to the stack and
     /// potentially resume or unwind, depending on the context.
     PushError(Error),
-    /// As above, but with extra meta-data.
-    PushErrorPack(Error, String, Var),
     /// An error occurred during execution, that should definitely be treated as a proper "raise"
     /// and unwind event unless there's a catch handler in place
     RaiseError(Error),

--- a/crates/kernel/src/vm/moo_execute.rs
+++ b/crates/kernel/src/vm/moo_execute.rs
@@ -26,7 +26,7 @@ use moor_var::{
     v_empty_map, v_err, v_float, v_flyweight, v_int, v_list, v_map, v_none, v_obj, v_str, v_sym,
 };
 use moor_var::{Symbol, VarType};
-use std::ops::Add;
+use std::ops::{Add, Deref};
 use std::time::Duration;
 
 lazy_static! {
@@ -777,8 +777,12 @@ pub fn moo_frame_execute(
                             };
                             e.clone()
                         });
-                        f.catch_stack
-                            .push((CatchType::Errors(error_codes.into_iter().collect()), *label));
+                        f.catch_stack.push((
+                            CatchType::Errors(
+                                error_codes.into_iter().map(|x| x.deref().clone()).collect(),
+                            ),
+                            *label,
+                        ));
                     }
                     Variant::Int(0) => {
                         f.catch_stack.push((CatchType::Any, *label));

--- a/crates/kernel/src/vm/moo_execute.rs
+++ b/crates/kernel/src/vm/moo_execute.rs
@@ -19,8 +19,8 @@ use crate::vm::vm_unwind::FinallyReason;
 use lazy_static::lazy_static;
 use moor_common::model::WorldState;
 use moor_common::util::PerfTimerGuard;
-use moor_compiler::{Op, ScatterLabel};
-use moor_var::Error::{E_ARGS, E_DIV, E_INVARG, E_INVIND, E_RANGE, E_TYPE, E_VARNF};
+use moor_compiler::{Op, ScatterLabel, to_literal};
+use moor_var::{E_ARGS, E_DIV, E_INVARG, E_INVIND, E_RANGE, E_TYPE, E_VARNF};
 use moor_var::{
     Error, IndexMode, Obj, Sequence, TypeClass, Var, Variant, v_bool_int, v_empty_list,
     v_empty_map, v_err, v_float, v_flyweight, v_int, v_list, v_map, v_none, v_obj, v_str, v_sym,
@@ -165,7 +165,9 @@ pub fn moo_frame_execute(
                     // didn't 'throw' and unwind the stack -- we need to get out of the loop.
                     // So we preemptively jump (here and below for List) and then raise the error.
                     f.jump(&operand.end_label);
-                    return ExecutionResult::RaiseError(E_TYPE);
+                    return ExecutionResult::RaiseError(
+                        E_TYPE.msg("invalid count value in for loop"),
+                    );
                 };
                 let count_i = *count_i as usize;
 
@@ -176,11 +178,15 @@ pub fn moo_frame_execute(
                     f.pop();
 
                     f.jump(&operand.end_label);
-                    return ExecutionResult::RaiseError(E_TYPE);
+                    return ExecutionResult::RaiseError(
+                        E_TYPE.msg("invalid sequence type in for loop"),
+                    );
                 };
 
                 let Ok(list_len) = seq.len() else {
-                    return ExecutionResult::RaiseError(E_TYPE);
+                    return ExecutionResult::RaiseError(
+                        E_TYPE.msg("invalid sequence length in for loop"),
+                    );
                 };
 
                 // If we've exhausted the list, pop the count and list and jump out.
@@ -201,7 +207,9 @@ pub fn moo_frame_execute(
                         .map(|v| (count.add(&v_int(1)).unwrap(), v.clone())),
                     TypeClass::Associative(a) => a.index(count_i),
                     TypeClass::Scalar => {
-                        return ExecutionResult::RaiseError(E_TYPE);
+                        return ExecutionResult::RaiseError(
+                            E_TYPE.msg("invalid sequence type in for loop"),
+                        );
                     }
                 };
                 let k_v = match k_v {
@@ -265,7 +273,9 @@ pub fn moo_frame_execute(
                             // the loop (with a messed up stack) otherwise.
                             f.jump(end_label);
 
-                            return ExecutionResult::RaiseError(E_TYPE);
+                            return ExecutionResult::RaiseError(
+                                E_TYPE.msg("invalid range type in for loop"),
+                            );
                         }
                     };
                     (from.clone(), next_val)
@@ -322,7 +332,7 @@ pub fn moo_frame_execute(
                 let (tail, list) = (f.pop(), f.peek_top_mut());
                 if !list.is_sequence() || list.type_code() == VarType::TYPE_STR {
                     f.pop();
-                    return ExecutionResult::PushError(E_TYPE);
+                    return ExecutionResult::PushError(E_TYPE.msg("invalid value in list append"));
                 }
                 // TODO: quota check SVO_MAX_LIST_CONCAT -> E_QUOTA in list add and append
                 let result = list.push(&tail);
@@ -342,12 +352,12 @@ pub fn moo_frame_execute(
                 // Don't allow strings here.
                 if list.type_code() == VarType::TYPE_STR {
                     f.pop();
-                    return ExecutionResult::PushError(E_TYPE);
+                    return ExecutionResult::PushError(E_TYPE.msg("invalid value in list append"));
                 }
 
                 if !tail.is_sequence() || !list.is_sequence() {
                     f.pop();
-                    return ExecutionResult::PushError(E_TYPE);
+                    return ExecutionResult::PushError(E_TYPE.msg("invalid value in list append"));
                 }
                 let new_list = list.append(&tail);
                 match new_list {
@@ -397,7 +407,9 @@ pub fn moo_frame_execute(
                     }
                     _ => {
                         f.pop();
-                        return ExecutionResult::PushError(E_TYPE);
+                        return ExecutionResult::PushError(
+                            E_TYPE.msg("invalid value in map insert"),
+                        );
                     }
                 }
             }
@@ -406,19 +418,25 @@ pub fn moo_frame_execute(
                 let contents = f.pop();
                 // Contents must be a list
                 let Variant::List(contents) = contents.variant() else {
-                    return ExecutionResult::PushError(E_TYPE);
+                    return ExecutionResult::PushError(
+                        E_TYPE.msg("invalid value for flyweight contents, must be list"),
+                    );
                 };
                 let mut slots = Vec::with_capacity(*num_slots);
                 for _ in 0..*num_slots {
                     let (k, v) = (f.pop(), f.pop());
                     let Ok(sym) = k.as_symbol() else {
-                        return ExecutionResult::PushError(E_TYPE);
+                        return ExecutionResult::PushError(
+                            E_TYPE.msg("invalid value for flyweight slot, must be a valid symbol"),
+                        );
                     };
                     slots.push((sym, v));
                 }
                 let delegate = f.pop();
                 let Variant::Obj(delegate) = delegate.variant() else {
-                    return ExecutionResult::PushError(E_TYPE);
+                    return ExecutionResult::PushError(
+                        E_TYPE.msg("invalid value for flyweight delegate, must be object"),
+                    );
                 };
                 // Slots should be v_str -> value, num_slots times
 
@@ -476,7 +494,7 @@ pub fn moo_frame_execute(
                 // `inf`.
                 let divargs = f.peek_range(2);
                 if matches!(divargs[1].variant(), Variant::Int(0) | Variant::Float(0.0)) {
-                    return ExecutionResult::PushError(E_DIV);
+                    return ExecutionResult::PushError(E_DIV.msg("division by zero"));
                 };
                 binary_var_op!(self, f, state, div);
             }
@@ -489,7 +507,7 @@ pub fn moo_frame_execute(
             Op::Mod => {
                 let divargs = f.peek_range(2);
                 if matches!(divargs[1].variant(), Variant::Int(0) | Variant::Float(0.0)) {
-                    return ExecutionResult::PushError(E_DIV);
+                    return ExecutionResult::PushError(E_DIV.msg("division by zero"));
                 };
                 binary_var_op!(self, f, state, modulus);
             }
@@ -531,13 +549,11 @@ pub fn moo_frame_execute(
             Op::Push(ident) => {
                 let Some(v) = f.get_env(ident) else {
                     if let Some(var_name) = f.program.var_names.name_of(ident) {
-                        return ExecutionResult::PushErrorPack(
-                            E_VARNF,
-                            format!("Variable `{var_name}` not found"),
-                            v_none(),
+                        return ExecutionResult::PushError(
+                            E_VARNF.with_msg(|| format!("Variable `{var_name}` not found")),
                         );
                     } else {
-                        return ExecutionResult::PushError(E_VARNF);
+                        return ExecutionResult::PushError(E_VARNF.msg("Variable not found"));
                     }
                 };
                 f.push(v.clone());
@@ -598,7 +614,11 @@ pub fn moo_frame_execute(
                 let (propname, obj) = (f.pop(), f.peek_top());
 
                 let Ok(propname) = propname.as_symbol() else {
-                    return ExecutionResult::PushError(E_TYPE);
+                    return ExecutionResult::PushError(
+                        E_TYPE.with_msg(|| {
+                            format!("Invalid property name: {}", to_literal(&propname))
+                        }),
+                    );
                 };
 
                 let value = get_property(world_state, &permissions, obj, propname, features_config);
@@ -615,7 +635,11 @@ pub fn moo_frame_execute(
                 let (propname, obj) = f.peek2();
 
                 let Ok(propname) = propname.as_symbol() else {
-                    return ExecutionResult::PushError(E_TYPE);
+                    return ExecutionResult::PushError(
+                        E_TYPE.with_msg(|| {
+                            format!("Invalid property name: {}", to_literal(propname))
+                        }),
+                    );
                 };
 
                 let value = get_property(world_state, &permissions, obj, propname, features_config);
@@ -632,10 +656,16 @@ pub fn moo_frame_execute(
                 let (rhs, propname, obj) = (f.pop(), f.pop(), f.peek_top());
 
                 let Variant::Obj(obj) = obj.variant() else {
-                    return ExecutionResult::PushError(E_TYPE);
+                    return ExecutionResult::PushError(E_TYPE.with_msg(|| {
+                        format!("Invalid value for property access: {}", to_literal(obj))
+                    }));
                 };
                 let Ok(propname) = propname.as_symbol() else {
-                    return ExecutionResult::PushError(E_TYPE);
+                    return ExecutionResult::PushError(
+                        E_TYPE.with_msg(|| {
+                            format!("Invalid property name: {}", to_literal(&propname))
+                        }),
+                    );
                 };
                 let update_result =
                     world_state.update_property(&permissions, obj, propname, &rhs.clone());
@@ -645,7 +675,7 @@ pub fn moo_frame_execute(
                         f.poke(0, rhs);
                     }
                     Err(e) => {
-                        return ExecutionResult::PushError(e.to_error_code());
+                        return ExecutionResult::PushError(e.to_error());
                     }
                 }
             }
@@ -657,12 +687,16 @@ pub fn moo_frame_execute(
                     Variant::Int(time) => *time as f64,
                     Variant::Float(time) => *time,
                     _ => {
-                        return ExecutionResult::PushError(E_TYPE);
+                        return ExecutionResult::PushError(
+                            E_TYPE.msg("invalid value for delay time in fork"),
+                        );
                     }
                 };
 
                 if time < 0.0 {
-                    return ExecutionResult::PushError(E_INVARG);
+                    return ExecutionResult::PushError(
+                        E_INVARG.msg("invalid value for delay time in fork"),
+                    );
                 }
                 let delay = (time != 0.0).then(|| Duration::from_secs_f64(time));
 
@@ -671,17 +705,21 @@ pub fn moo_frame_execute(
             Op::Pass => {
                 let args = f.pop();
                 let Variant::List(args) = args.variant() else {
-                    return ExecutionResult::PushError(E_TYPE);
+                    return ExecutionResult::PushError(E_TYPE.msg("invalid value in pass"));
                 };
                 return ExecutionResult::DispatchVerbPass(args.clone());
             }
             Op::CallVerb => {
                 let (args, verb, obj) = (f.pop(), f.pop(), f.pop());
                 let Variant::List(l) = args.variant() else {
-                    return ExecutionResult::PushError(E_TYPE);
+                    return ExecutionResult::PushError(E_TYPE.with_msg(|| {
+                        format!("Invalid target for verb dispatch: {}", to_literal(&args))
+                    }));
                 };
                 let Ok(verb) = verb.as_symbol() else {
-                    return ExecutionResult::PushError(E_TYPE);
+                    return ExecutionResult::PushError(
+                        E_TYPE.with_msg(|| format!("Invalid verb name: {}", to_literal(&verb))),
+                    );
                 };
                 return ExecutionResult::PrepareVerbDispatch {
                     this: obj,
@@ -703,7 +741,9 @@ pub fn moo_frame_execute(
                 // Pop arguments, should be a list.
                 let args = f.pop();
                 let Variant::List(args) = args.variant() else {
-                    return ExecutionResult::PushError(E_ARGS);
+                    return ExecutionResult::PushError(
+                        E_ARGS.msg("invalid value for function call"),
+                    );
                 };
                 return ExecutionResult::DispatchBuiltin {
                     builtin: *id,
@@ -722,7 +762,7 @@ pub fn moo_frame_execute(
                             let Variant::Err(e) = v.variant() else {
                                 panic!("Error codes list contains non-error code");
                             };
-                            *e
+                            e.clone()
                         });
                         f.catch_stack
                             .push((CatchType::Errors(error_codes.into_iter().collect()), *label));
@@ -842,8 +882,10 @@ pub fn moo_frame_execute(
                 let rhs_values = {
                     let rhs = f.peek_top();
                     let Variant::List(rhs_values) = rhs.variant() else {
+                        let scatter_err = E_TYPE
+                            .with_msg(|| format!("Invalid value for scatter: {}", to_literal(rhs)));
                         f.pop();
-                        return ExecutionResult::PushError(E_TYPE);
+                        return ExecutionResult::PushError(scatter_err);
                     };
                     rhs_values.clone()
                 };
@@ -851,7 +893,12 @@ pub fn moo_frame_execute(
                 let len = rhs_values.len();
                 if len < nreq || !have_rest && len > nargs {
                     f.pop();
-                    return ExecutionResult::PushError(E_ARGS);
+                    return ExecutionResult::PushError(E_ARGS.with_msg(|| {
+                        format!(
+                            "Invalid number of arguments for scatter, expected {}, got {}",
+                            nreq, len
+                        )
+                    }));
                 }
                 let mut nopt_avail = len - nreq;
                 let nrest = if have_rest && len >= nargs {
@@ -877,7 +924,9 @@ pub fn moo_frame_execute(
                         }
                         ScatterLabel::Required(id) => {
                             let Some(arg) = args_iter.next() else {
-                                return ExecutionResult::PushError(E_ARGS);
+                                return ExecutionResult::PushError(
+                                    E_ARGS.msg("Missing required arg for scatter"),
+                                );
                             };
 
                             f.set_variable(id, arg.clone());
@@ -886,7 +935,9 @@ pub fn moo_frame_execute(
                             if nopt_avail > 0 {
                                 nopt_avail -= 1;
                                 let Some(arg) = args_iter.next() else {
-                                    return ExecutionResult::PushError(E_ARGS);
+                                    return ExecutionResult::PushError(
+                                        E_ARGS.msg("Missing optional arg for scatter"),
+                                    );
                                 };
                                 f.set_variable(id, arg.clone());
                             } else if jump_where.is_none() && jump_to.is_some() {
@@ -903,7 +954,7 @@ pub fn moo_frame_execute(
             Op::CheckListForSplice => {
                 if !f.peek_top().is_sequence() {
                     f.pop();
-                    return ExecutionResult::PushError(E_TYPE);
+                    return ExecutionResult::PushError(E_TYPE.msg("invalid value in list splice"));
                 }
             }
 
@@ -958,14 +1009,18 @@ pub fn moo_frame_execute(
                     .unwrap()
                     .clone();
                 let Variant::Int(position) = position.variant() else {
-                    return ExecutionResult::PushError(E_TYPE);
+                    return ExecutionResult::PushError(
+                        E_TYPE.msg("invalid value in list comprehension"),
+                    );
                 };
                 let position = *position;
                 if position > list.len().unwrap() as i64 {
                     f.jump(&list_comprehension.end_label);
                 } else {
                     let Ok(item) = list.index(&v_int(position), IndexMode::OneBased) else {
-                        return ExecutionResult::PushError(E_RANGE);
+                        return ExecutionResult::PushError(
+                            E_RANGE.msg("invalid index in list comprehension"),
+                        );
                     };
                     f.set_variable(&list_comprehension.item_variable, item);
                 }
@@ -978,10 +1033,14 @@ pub fn moo_frame_execute(
                     .expect("Bad range position variable in range comprehension")
                     .clone();
                 let Ok(new_position) = position.add(&v_int(1)) else {
-                    return ExecutionResult::PushError(E_TYPE);
+                    return ExecutionResult::PushError(
+                        E_TYPE.msg("invalid value in list comprehension"),
+                    );
                 };
                 let Ok(new_list) = list.push(&result) else {
-                    return ExecutionResult::PushError(E_TYPE);
+                    return ExecutionResult::PushError(
+                        E_TYPE.msg("invalid value in list comprehension"),
+                    );
                 };
                 f.set_variable(id, new_position);
                 f.push(new_list);
@@ -1009,7 +1068,7 @@ fn get_property(
             let result = world_state.retrieve_property(permissions, obj, propname);
             match result {
                 Ok(v) => Ok(v),
-                Err(e) => Err(e.to_error_code()),
+                Err(e) => Err(e.to_error()),
             }
         }
         Variant::Flyweight(flyweight) => {
@@ -1042,11 +1101,14 @@ fn get_property(
                 let result = world_state.retrieve_property(permissions, delegate, propname);
                 match result {
                     Ok(v) => v,
-                    Err(e) => return Err(e.to_error_code()),
+                    Err(e) => return Err(e.to_error()),
                 }
             };
             Ok(value)
         }
-        _ => Err(E_INVIND),
+        _ => {
+            Err(E_INVIND
+                .with_msg(|| format!("Invalid value for property access: {}", to_literal(obj))))
+        }
     }
 }

--- a/crates/kernel/src/vm/vm_test.rs
+++ b/crates/kernel/src/vm/vm_test.rs
@@ -50,6 +50,7 @@ mod tests {
             for_sequence_operands: vec![],
             range_comprehensions: vec![],
             list_comprehensions: vec![],
+            error_operands: vec![],
             main_vector: Arc::new(main_vector),
             fork_vectors: vec![],
             line_number_spans: vec![],

--- a/crates/kernel/src/vm/vm_test.rs
+++ b/crates/kernel/src/vm/vm_test.rs
@@ -25,8 +25,8 @@ mod tests {
         v_obj, v_objid, v_str, v_sym_str,
     };
 
-    use moor_var::Error::*;
     use moor_var::NOTHING;
+    use moor_var::*;
     use moor_var::{AsByteBuffer, SYSTEM_OBJECT};
 
     use crate::builtins::BuiltinRegistry;

--- a/crates/textdump/src/read.rs
+++ b/crates/textdump/src/read.rs
@@ -28,7 +28,7 @@ use crate::{EncodingMode, Object, Propval, Textdump, Verb, Verbdef};
 use moor_common::model::CompileError;
 use moor_common::model::WorldStateError;
 use moor_compiler::Label;
-use moor_var::{Error, NOTHING, Sequence, Variant, v_list, v_map};
+use moor_var::{Error, ErrorCode, NOTHING, Sequence, Variant, v_error, v_list, v_map};
 use moor_var::{
     List, Symbol, Var, VarType, v_bool_int, v_err, v_float, v_int, v_none, v_obj, v_str, v_sym,
 };
@@ -191,11 +191,11 @@ impl<R: Read> TextdumpReader<R> {
                     Ok(e_num) => {
                         let etype: Error =
                             Error::from_repr(e_num as u8).expect("Invalid error code");
-                        v_err(etype)
+                        v_error(etype)
                     }
                     Err(..) => {
                         let s = Symbol::mk_case_insensitive(&s);
-                        v_err(Error::Custom(s))
+                        v_err(ErrorCode::ErrCustom(s))
                     }
                 }
             }

--- a/crates/textdump/src/write.rs
+++ b/crates/textdump/src/write.rs
@@ -11,7 +11,7 @@
 // this program. If not, see <https://www.gnu.org/licenses/>.
 //
 
-use moor_var::{Error, Obj, Sequence};
+use moor_var::{ErrorCode, Obj, Sequence};
 use moor_var::{Var, VarType, Variant};
 use std::collections::BTreeMap;
 use std::io;
@@ -84,11 +84,11 @@ impl<W: io::Write> TextdumpWriter<W> {
             Variant::Err(e) => {
                 // integer form errors get written with their classic MOO repr
                 // "custom" we write the string literal
-                match e {
-                    Error::Custom(s) => {
+                match e.err_type {
+                    ErrorCode::ErrCustom(s) => {
                         writeln!(self.writer, "{}\n{}", VarType::TYPE_ERR as i64, s)?;
                     }
-                    e => {
+                    _ => {
                         let v = e.to_int().unwrap();
                         writeln!(self.writer, "{}\n{}", VarType::TYPE_ERR as i64, v)?;
                     }

--- a/crates/var/src/error.rs
+++ b/crates/var/src/error.rs
@@ -11,18 +11,24 @@
 // this program. If not, see <https://www.gnu.org/licenses/>.
 //
 
-use std::fmt::{Display, Formatter};
-
 use crate::Symbol;
 use crate::var::Var;
 use ErrorCode::*;
 use bincode::{Decode, Encode};
+use std::fmt::{Debug, Display, Formatter};
+use std::hash::{Hash, Hasher};
 
-#[derive(Clone, Debug, Eq, Ord, PartialOrd, Hash, Encode, Decode)]
+#[derive(Clone, Eq, Ord, PartialOrd, Encode, Decode)]
 pub struct Error {
     pub err_type: ErrorCode,
     pub msg: Option<String>,
     pub value: Option<Box<Var>>,
+}
+
+impl Hash for Error {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.err_type.hash(state);
+    }
 }
 
 impl Error {
@@ -32,6 +38,16 @@ impl Error {
             msg,
             value: value.map(Box::new),
         }
+    }
+}
+
+// TODO: Debug for Error should be more informative, but we need to be careful about what it returns
+//   because the `moot` tests use this to compare results via string comparison, and we don't want
+//   to break that.  We need to do some work in the moot test runner to make it handle error comparisons
+//   better, and then we can make this more informative again.
+impl Debug for Error {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.err_type)
     }
 }
 

--- a/crates/var/src/error.rs
+++ b/crates/var/src/error.rs
@@ -87,32 +87,67 @@ pub enum ErrorCode {
     ErrCustom(Symbol),
 }
 
-impl Display for ErrorCode {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        match self {
-            E_NONE => write!(f, "E_NONE"),
-            E_TYPE => write!(f, "E_TYPE"),
-            E_DIV => write!(f, "E_DIV"),
-            E_PERM => write!(f, "E_PERM"),
-            E_PROPNF => write!(f, "E_PROPNF"),
-            E_VERBNF => write!(f, "E_VERBNF"),
-            E_VARNF => write!(f, "E_VARNF"),
-            E_INVIND => write!(f, "E_INVIND"),
-            E_RECMOVE => write!(f, "E_RECMOVE"),
-            E_MAXREC => write!(f, "E_MAXREC"),
-            E_RANGE => write!(f, "E_RANGE"),
-            E_ARGS => write!(f, "E_ARGS"),
-            E_NACC => write!(f, "E_NACC"),
-            E_INVARG => write!(f, "E_INVARG"),
-            E_QUOTA => write!(f, "E_QUOTA"),
-            E_FLOAT => write!(f, "E_FLOAT"),
-            E_FILE => write!(f, "E_FILE"),
-            E_EXEC => write!(f, "E_EXEC"),
-            E_INTRPT => write!(f, "E_INTRPT"),
-            ErrCustom(sym) => write!(f, "{sym}"),
+impl ErrorCode {
+    pub fn parse_str(s: &str) -> Option<Self> {
+        match s.to_uppercase().as_str() {
+            "E_NONE" => Some(E_NONE),
+            "E_TYPE" => Some(E_TYPE),
+            "E_DIV" => Some(E_DIV),
+            "E_PERM" => Some(E_PERM),
+            "E_PROPNF" => Some(E_PROPNF),
+            "E_VERBNF" => Some(E_VERBNF),
+            "E_VARNF" => Some(E_VARNF),
+            "E_INVIND" => Some(E_INVIND),
+            "E_RECMOVE" => Some(E_RECMOVE),
+            "E_MAXREC" => Some(E_MAXREC),
+            "E_RANGE" => Some(E_RANGE),
+            "E_ARGS" => Some(E_ARGS),
+            "E_NACC" => Some(E_NACC),
+            "E_INVARG" => Some(E_INVARG),
+            "E_QUOTA" => Some(E_QUOTA),
+            "E_FLOAT" => Some(E_FLOAT),
+            "E_FILE" => Some(E_FILE),
+            "E_EXEC" => Some(E_EXEC),
+            "E_INTRPT" => Some(E_INTRPT),
+            s => Some(ErrCustom(Symbol::mk_case_insensitive(s))),
         }
     }
 }
+
+impl From<ErrorCode> for String {
+    fn from(val: ErrorCode) -> Self {
+        match val {
+            E_NONE => "E_NONE".into(),
+            E_TYPE => "E_TYPE".into(),
+            E_DIV => "E_DIV".into(),
+            E_PERM => "E_PERM".into(),
+            E_PROPNF => "E_PROPNF".into(),
+            E_VERBNF => "E_VERBNF".into(),
+            E_VARNF => "E_VARNF".into(),
+            E_INVIND => "E_INVIND".into(),
+            E_RECMOVE => "E_RECMOVE".into(),
+            E_MAXREC => "E_MAXREC".into(),
+            E_RANGE => "E_RANGE".into(),
+            E_ARGS => "E_ARGS".into(),
+            E_NACC => "E_NACC".into(),
+            E_INVARG => "E_INVARG".into(),
+            E_QUOTA => "E_QUOTA".into(),
+            E_FLOAT => "E_FLOAT".into(),
+            E_FILE => "E_FILE".into(),
+            E_EXEC => "E_EXEC".into(),
+            E_INTRPT => "E_INTRPT".into(),
+            ErrCustom(sym) => sym.to_string(),
+        }
+    }
+}
+
+impl Display for ErrorCode {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let s: String = (*self).into();
+        write!(f, "{}", s)
+    }
+}
+
 impl ErrorCode {
     pub fn msg(self, s: &str) -> Error {
         Error::new(self, Some(s.into()), None)
@@ -241,31 +276,5 @@ impl Error {
     #[must_use]
     pub fn name(&self) -> Symbol {
         Symbol::mk(&format!("{}", self.err_type))
-    }
-
-    pub fn parse_str(s: &str) -> Option<Self> {
-        let e = match s.to_uppercase().as_str() {
-            "E_NONE" => Some(E_NONE),
-            "E_TYPE" => Some(E_TYPE),
-            "E_DIV" => Some(E_DIV),
-            "E_PERM" => Some(E_PERM),
-            "E_PROPNF" => Some(E_PROPNF),
-            "E_VERBNF" => Some(E_VERBNF),
-            "E_VARNF" => Some(E_VARNF),
-            "E_INVIND" => Some(E_INVIND),
-            "E_RECMOVE" => Some(E_RECMOVE),
-            "E_MAXREC" => Some(E_MAXREC),
-            "E_RANGE" => Some(E_RANGE),
-            "E_ARGS" => Some(E_ARGS),
-            "E_NACC" => Some(E_NACC),
-            "E_INVARG" => Some(E_INVARG),
-            "E_QUOTA" => Some(E_QUOTA),
-            "E_FLOAT" => Some(E_FLOAT),
-            "E_FILE" => Some(E_FILE),
-            "E_EXEC" => Some(E_EXEC),
-            "E_INTRPT" => Some(E_INTRPT),
-            s => Some(ErrCustom(Symbol::mk_case_insensitive(s))),
-        };
-        e.map(|e| Error::new(e, None, None))
     }
 }

--- a/crates/var/src/flyweight.rs
+++ b/crates/var/src/flyweight.rs
@@ -50,7 +50,7 @@
 //! The structure of the flyweight also resembles an XML/HTML node, with a delegate as the tag name,
 //!  slots as the attributes, and contents as the inner text/nodes.
 
-use crate::Error::E_TYPE;
+use crate::error::ErrorCode::E_TYPE;
 use crate::{Error, List, Obj, Sequence, Symbol, Var, Variant};
 use bincode::de::{BorrowDecoder, Decoder};
 use bincode::enc::Encoder;
@@ -242,7 +242,7 @@ impl Sequence for Flyweight {
     fn index_set(&self, index: usize, value: &Var) -> Result<Var, Error> {
         let new_contents = self.0.contents.index_set(index, value)?;
         let Variant::List(new_contents_as_list) = new_contents.variant() else {
-            return Err(E_TYPE);
+            return Err(E_TYPE.msg("invalid contents type in flyweight"));
         };
         Ok(self.with_new_contents(new_contents_as_list.clone()))
     }
@@ -250,7 +250,7 @@ impl Sequence for Flyweight {
     fn push(&self, value: &Var) -> Result<Var, Error> {
         let new_contents = self.0.contents.push(value)?;
         let Variant::List(new_contents_as_list) = new_contents.variant() else {
-            return Err(E_TYPE);
+            return Err(E_TYPE.msg("invalid contents type in flyweight"));
         };
         Ok(self.with_new_contents(new_contents_as_list.clone()))
     }
@@ -258,7 +258,7 @@ impl Sequence for Flyweight {
     fn insert(&self, index: usize, value: &Var) -> Result<Var, Error> {
         let new_contents = self.0.contents.insert(index, value)?;
         let Variant::List(new_contents_as_list) = new_contents.variant() else {
-            return Err(E_TYPE);
+            return Err(E_TYPE.msg("invalid contents type in flyweight"));
         };
         Ok(self.with_new_contents(new_contents_as_list.clone()))
     }
@@ -270,7 +270,7 @@ impl Sequence for Flyweight {
     fn range_set(&self, from: isize, to: isize, with: &Var) -> Result<Var, Error> {
         let new_contents = self.0.contents.range_set(from, to, with)?;
         let Variant::List(new_contents_as_list) = new_contents.variant() else {
-            return Err(E_TYPE);
+            return Err(E_TYPE.msg("invalid contents type in flyweight"));
         };
         Ok(self.with_new_contents(new_contents_as_list.clone()))
     }
@@ -278,7 +278,7 @@ impl Sequence for Flyweight {
     fn append(&self, other: &Var) -> Result<Var, Error> {
         let new_contents = self.0.contents.append(other)?;
         let Variant::List(new_contents_as_list) = new_contents.variant() else {
-            return Err(E_TYPE);
+            return Err(E_TYPE.msg("invalid contents type in flyweight"));
         };
         Ok(self.with_new_contents(new_contents_as_list.clone()))
     }
@@ -286,7 +286,7 @@ impl Sequence for Flyweight {
     fn remove_at(&self, index: usize) -> Result<Var, Error> {
         let new_contents = self.0.contents.remove_at(index)?;
         let Variant::List(new_contents_as_list) = new_contents.variant() else {
-            return Err(E_TYPE);
+            return Err(E_TYPE.msg("invalid contents type in flyweight"));
         };
         Ok(self.with_new_contents(new_contents_as_list.clone()))
     }

--- a/crates/var/src/lib.rs
+++ b/crates/var/src/lib.rs
@@ -25,7 +25,7 @@ mod var;
 mod variant;
 
 use bincode::{Decode, Encode};
-pub use error::{Error, ErrorPack};
+pub use error::{Error, ErrorCode, ErrorCode::*};
 pub use flyweight::Flyweight;
 pub use list::List;
 pub use map::Map;
@@ -35,9 +35,9 @@ pub use string::Str;
 use strum::FromRepr;
 pub use symbol::Symbol;
 pub use var::{
-    Var, v_bool, v_bool_int, v_empty_list, v_empty_map, v_empty_str, v_err, v_float, v_flyweight,
-    v_int, v_list, v_list_iter, v_map, v_map_iter, v_none, v_obj, v_objid, v_str, v_string, v_sym,
-    v_sym_str,
+    Var, v_bool, v_bool_int, v_empty_list, v_empty_map, v_empty_str, v_err, v_error, v_float,
+    v_flyweight, v_int, v_list, v_list_iter, v_map, v_map_iter, v_none, v_obj, v_objid, v_str,
+    v_string, v_sym, v_sym_str,
 };
 pub use variant::Variant;
 

--- a/crates/var/src/var.rs
+++ b/crates/var/src/var.rs
@@ -23,6 +23,7 @@ use bincode::{Decode, Encode};
 use std::cmp::{Ordering, min};
 use std::fmt::{Debug, Formatter};
 use std::hash::Hash;
+use std::sync::Arc;
 
 #[derive(Clone, Encode, Decode)]
 pub struct Var(Variant);
@@ -62,7 +63,7 @@ impl Var {
     }
 
     pub fn mk_error(e: Error) -> Self {
-        Var(Variant::Err(e))
+        Var(Variant::Err(Arc::new(e)))
     }
 
     pub fn mk_object(o: Obj) -> Self {

--- a/crates/var/src/var.rs
+++ b/crates/var/src/var.rs
@@ -12,7 +12,8 @@
 //
 
 use crate::Associative;
-use crate::Error::{E_INVARG, E_RANGE, E_TYPE};
+use crate::error::ErrorCode;
+use crate::error::ErrorCode::{E_INVARG, E_RANGE, E_TYPE};
 use crate::list::List;
 use crate::variant::Variant;
 use crate::{BincodeAsByteBufferExt, Symbol};
@@ -119,7 +120,9 @@ impl Var {
             Variant::Str(s) => Ok(Symbol::mk_case_insensitive(s.as_str())),
             Variant::Sym(s) => Ok(*s),
             Variant::Err(e) => Ok(e.name()),
-            _ => Err(E_TYPE),
+            _ => Err(E_TYPE.with_msg(|| {
+                format!("Cannot convert {} to symbol", self.type_code().to_literal())
+            })),
         }
     }
 
@@ -147,18 +150,30 @@ impl Var {
     /// Otherwise returns the value
     pub fn index(&self, index: &Var, index_mode: IndexMode) -> Result<Self, Error> {
         if self.type_class().is_scalar() {
-            return Err(E_TYPE);
+            return Err(E_TYPE.with_msg(|| {
+                format!(
+                    "Cannot index into scalar value {}",
+                    self.type_code().to_literal()
+                )
+            }));
         }
         let idx = match index.variant() {
             Variant::Int(i) => {
                 let i = index_mode.adjust_i64(*i);
                 if i < 0 {
-                    return Err(E_RANGE);
+                    return Err(E_RANGE.with_msg(|| {
+                        format!("Cannot index into sequence with negative index {}", i)
+                    }));
                 }
                 i as usize
             }
             _ => {
-                return Err(E_TYPE);
+                return Err(E_TYPE.with_msg(|| {
+                    format!(
+                        "Cannot index into sequence with non-integer index {}",
+                        index.type_code().to_literal()
+                    )
+                }));
             }
         };
 
@@ -171,7 +186,8 @@ impl Var {
                 let value = a.index(idx)?;
                 Ok(value.1)
             }
-            _ => Err(E_TYPE),
+            _ => Err(E_TYPE
+                .with_msg(|| format!("Cannot index into type {}", self.type_code().to_literal()))),
         }
     }
 
@@ -190,7 +206,12 @@ impl Var {
                 let value = a.get(key)?;
                 Ok(value)
             }
-            _ => Err(E_TYPE),
+            _ => Err(E_TYPE.with_msg(|| {
+                format!(
+                    "Cannot index value from type {}",
+                    self.type_code().to_literal()
+                )
+            })),
         }
     }
 
@@ -202,7 +223,9 @@ impl Var {
                 Ok(value)
             }
             TypeClass::Associative(s) => s.set(key, value),
-            _ => Err(E_TYPE),
+            _ => Err(E_TYPE.with_msg(|| {
+                format!("Cannot set value in type {}", self.type_code().to_literal())
+            })),
         }
     }
 
@@ -220,15 +243,26 @@ impl Var {
                         let i = index_mode.adjust_i64(*i);
 
                         if i < 0 {
-                            return Err(E_RANGE);
+                            return Err(E_RANGE.with_msg(|| {
+                                format!("Cannot index into sequence with negative index {}", i)
+                            }));
                         }
                         i as usize
                     }
-                    _ => return Err(E_INVARG),
+                    _ => {
+                        return Err(E_INVARG.with_msg(|| {
+                            format!(
+                                "Cannot index into sequence with non-integer index {}",
+                                idx.type_code().to_literal()
+                            )
+                        }));
+                    }
                 };
                 s.index_set(idx, value)
             }
-            _ => Err(E_TYPE),
+            _ => Err(E_TYPE.with_msg(|| {
+                format!("Cannot set value in type {}", self.type_code().to_literal())
+            })),
         }
     }
 
@@ -241,7 +275,14 @@ impl Var {
             TypeClass::Sequence(s) => {
                 let index = match index.variant() {
                     Variant::Int(i) => index_mode.adjust_i64(*i),
-                    _ => return Err(E_INVARG),
+                    _ => {
+                        return Err(E_INVARG.with_msg(|| {
+                            format!(
+                                "Cannot insert into sequence with non-integer index {}",
+                                index.type_code().to_literal()
+                            )
+                        }));
+                    }
                 };
                 let index = if index < 0 {
                     0
@@ -250,12 +291,19 @@ impl Var {
                 };
 
                 if index > s.len() {
-                    return Err(E_RANGE);
+                    return Err(E_RANGE.with_msg(|| {
+                        format!(
+                            "Cannot insert into sequence with index {} greater than length {}",
+                            index,
+                            s.len()
+                        )
+                    }));
                 }
 
                 s.insert(index, value)
             }
-            _ => Err(E_TYPE),
+            _ => Err(E_TYPE
+                .with_msg(|| format!("Cannot insert into type {}", self.type_code().to_literal()))),
         }
     }
 
@@ -264,18 +312,37 @@ impl Var {
             TypeClass::Sequence(s) => {
                 let from = match from.variant() {
                     Variant::Int(i) => index_mode.adjust_i64(*i),
-                    _ => return Err(E_INVARG),
+                    _ => {
+                        return Err(E_INVARG.with_msg(|| {
+                            format!(
+                                "Cannot index into sequence with non-integer index {}",
+                                from.type_code().to_literal()
+                            )
+                        }));
+                    }
                 };
 
                 let to = match to.variant() {
                     Variant::Int(i) => index_mode.adjust_i64(*i),
-                    _ => return Err(E_INVARG),
+                    _ => {
+                        return Err(E_INVARG.with_msg(|| {
+                            format!(
+                                "Cannot index into sequence with non-integer index {}",
+                                to.type_code().to_literal()
+                            )
+                        }));
+                    }
                 };
 
                 s.range(from, to)
             }
             TypeClass::Associative(a) => a.range(from, to),
-            TypeClass::Scalar => Err(E_TYPE),
+            TypeClass::Scalar => Err(E_TYPE.with_msg(|| {
+                format!(
+                    "Cannot index into scalar value {}",
+                    self.type_code().to_literal()
+                )
+            })),
         }
     }
 
@@ -290,32 +357,53 @@ impl Var {
             TypeClass::Sequence(s) => {
                 let from = match from.variant() {
                     Variant::Int(i) => index_mode.adjust_i64(*i),
-                    _ => return Err(E_INVARG),
+                    _ => {
+                        return Err(E_INVARG.with_msg(|| {
+                            format!(
+                                "Cannot index into sequence with non-integer index {}",
+                                from.type_code().to_literal()
+                            )
+                        }));
+                    }
                 };
 
                 let to = match to.variant() {
                     Variant::Int(i) => index_mode.adjust_i64(*i),
-                    _ => return Err(E_INVARG),
+                    _ => {
+                        return Err(E_INVARG.with_msg(|| {
+                            format!(
+                                "Cannot index into sequence with non-integer index {}",
+                                to.type_code().to_literal()
+                            )
+                        }));
+                    }
                 };
 
                 s.range_set(from, to, with)
             }
             TypeClass::Associative(a) => a.range_set(from, to, with),
-            TypeClass::Scalar => Err(E_TYPE),
+            TypeClass::Scalar => Err(E_TYPE.with_msg(|| {
+                format!(
+                    "Cannot index into scalar value {}",
+                    self.type_code().to_literal()
+                )
+            })),
         }
     }
 
     pub fn append(&self, other: &Var) -> Result<Var, Error> {
         match self.type_class() {
             TypeClass::Sequence(s) => s.append(other),
-            _ => Err(E_TYPE),
+            _ => Err(E_TYPE
+                .with_msg(|| format!("Cannot append to type {}", self.type_code().to_literal()))),
         }
     }
 
     pub fn push(&self, value: &Var) -> Result<Var, Error> {
         match self.type_class() {
             TypeClass::Sequence(s) => s.push(value),
-            _ => Err(E_TYPE),
+            _ => Err(E_TYPE
+                .with_msg(|| format!("Cannot push to type {}", self.type_code().to_literal()))),
         }
     }
 
@@ -329,7 +417,12 @@ impl Var {
                 let c = a.contains_key(value, case_sensitive)?;
                 Ok(v_bool_int(c))
             }
-            TypeClass::Scalar => Err(E_INVARG),
+            TypeClass::Scalar => Err(E_INVARG.with_msg(|| {
+                format!(
+                    "Cannot check for membership in scalar value {}",
+                    self.type_code().to_literal()
+                )
+            })),
         }
     }
 
@@ -354,7 +447,12 @@ impl Var {
                     .unwrap_or(-1);
                 Ok(v_int(index_mode.reverse_adjust_isize(idx as isize) as i64))
             }
-            _ => Err(E_TYPE),
+            _ => Err(E_TYPE.with_msg(|| {
+                format!(
+                    "Cannot check for membership in type {}",
+                    self.type_code().to_literal()
+                )
+            })),
         }
     }
 
@@ -363,23 +461,34 @@ impl Var {
             TypeClass::Sequence(s) => {
                 let index = match index.variant() {
                     Variant::Int(i) => index_mode.adjust_i64(*i),
-                    _ => return Err(E_INVARG),
+                    _ => {
+                        return Err(E_INVARG.with_msg(|| {
+                            format!(
+                                "Cannot index into sequence with non-integer index {}",
+                                index.type_code().to_literal()
+                            )
+                        }));
+                    }
                 };
 
                 if index < 0 {
-                    return Err(E_RANGE);
+                    return Err(E_RANGE.with_msg(|| {
+                        format!("Cannot index into sequence with negative index {}", index)
+                    }));
                 }
 
                 s.remove_at(index as usize)
             }
-            _ => Err(E_TYPE),
+            _ => Err(E_TYPE
+                .with_msg(|| format!("Cannot remove from type {}", self.type_code().to_literal()))),
         }
     }
 
     pub fn remove(&self, value: &Var, case_sensitive: bool) -> Result<(Var, Option<Var>), Error> {
         match self.type_class() {
             TypeClass::Associative(a) => Ok(a.remove(value, case_sensitive)),
-            _ => Err(E_INVARG),
+            _ => Err(E_INVARG
+                .with_msg(|| format!("Cannot remove from type {}", self.type_code().to_literal()))),
         }
     }
 
@@ -403,7 +512,12 @@ impl Var {
         match self.type_class() {
             TypeClass::Sequence(s) => Ok(s.is_empty()),
             TypeClass::Associative(a) => Ok(a.is_empty()),
-            TypeClass::Scalar => Err(E_INVARG),
+            TypeClass::Scalar => Err(E_INVARG.with_msg(|| {
+                format!(
+                    "Cannot check if scalar value {} is empty",
+                    self.type_code().to_literal()
+                )
+            })),
         }
     }
 
@@ -451,7 +565,12 @@ impl Var {
         match self.type_class() {
             TypeClass::Sequence(s) => Ok(s.len()),
             TypeClass::Associative(a) => Ok(a.len()),
-            TypeClass::Scalar => Err(E_INVARG),
+            TypeClass::Scalar => Err(E_INVARG.with_msg(|| {
+                format!(
+                    "Cannot get length of scalar value {}",
+                    self.type_code().to_literal()
+                )
+            })),
         }
     }
 
@@ -513,7 +632,11 @@ pub fn v_float(f: f64) -> Var {
     Var::mk_float(f)
 }
 
-pub fn v_err(e: Error) -> Var {
+pub fn v_err(e: ErrorCode) -> Var {
+    Var::mk_error(e.into())
+}
+
+pub fn v_error(e: Error) -> Var {
     Var::mk_error(e)
 }
 

--- a/crates/var/src/variant.rs
+++ b/crates/var/src/variant.rs
@@ -21,6 +21,7 @@ use bincode::{Decode, Encode};
 use std::cmp::Ordering;
 use std::fmt::{Debug, Formatter};
 use std::hash::{Hash, Hasher};
+use std::sync::Arc;
 
 /// Our series of types
 #[derive(Clone, Encode, Decode)]
@@ -33,7 +34,7 @@ pub enum Variant {
     List(List),
     Str(string::Str),
     Map(map::Map),
-    Err(Error),
+    Err(Arc<Error>),
     Flyweight(Flyweight),
     Sym(Symbol),
 }

--- a/crates/web-host/src/host/mod.rs
+++ b/crates/web-host/src/host/mod.rs
@@ -19,7 +19,9 @@ mod ws_connection;
 
 pub use auth::connect_auth_handler;
 pub use auth::create_auth_handler;
-use moor_var::{Var, Variant, v_err, v_float, v_int, v_list, v_map, v_none, v_objid, v_str};
+use moor_var::{
+    Var, Variant, v_error, v_float, v_int, v_list, v_map, v_none, v_objid, v_str,
+};
 pub use props::properties_handler;
 pub use props::property_retrieval_handler;
 use serde::Serialize;
@@ -182,7 +184,7 @@ pub fn json_as_var(j: &serde_json::Value) -> Result<Var, JsonParseError> {
                 )
                 .ok_or(JsonParseError::UnknownError)?;
 
-                return Ok(v_err(e));
+                return Ok(v_error(e));
             }
 
             Err(JsonParseError::UnknownType)
@@ -208,7 +210,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use moor_var::{v_err, v_float, v_int, v_str};
+    use moor_var::{E_ARGS, v_err, v_float, v_int, v_str};
 
     #[test]
     fn test_int_to_fro() {
@@ -236,7 +238,7 @@ mod tests {
 
     #[test]
     fn test_error_to_fro() {
-        let n = v_err(moor_var::Error::E_ARGS);
+        let n = v_err(E_ARGS);
         let j = super::var_as_json(&n);
         let n2 = super::json_as_var(&j).unwrap();
         assert_eq!(n, n2);

--- a/crates/web-host/src/host/mod.rs
+++ b/crates/web-host/src/host/mod.rs
@@ -19,9 +19,7 @@ mod ws_connection;
 
 pub use auth::connect_auth_handler;
 pub use auth::create_auth_handler;
-use moor_var::{
-    Var, Variant, v_error, v_float, v_int, v_list, v_map, v_none, v_objid, v_str,
-};
+use moor_var::{Var, Variant, v_err, v_float, v_int, v_list, v_map, v_none, v_objid, v_str};
 pub use props::properties_handler;
 pub use props::property_retrieval_handler;
 use serde::Serialize;
@@ -176,15 +174,17 @@ pub fn json_as_var(j: &serde_json::Value) -> Result<Var, JsonParseError> {
             }
 
             if let Some(error_name) = o.get("error") {
+                // TODO: support messages & values from the errors
+
                 // Match against the symbols in Error
-                let e = moor_var::Error::parse_str(
+                let e = moor_var::ErrorCode::parse_str(
                     error_name
                         .as_str()
                         .ok_or(JsonParseError::InvalidRepresentation)?,
                 )
                 .ok_or(JsonParseError::UnknownError)?;
 
-                return Ok(v_error(e));
+                return Ok(v_err(e));
             }
 
             Err(JsonParseError::UnknownType)

--- a/crates/web-host/src/host/web_host.rs
+++ b/crates/web-host/src/host/web_host.rs
@@ -23,8 +23,7 @@ use axum::response::{IntoResponse, Response};
 use eyre::eyre;
 
 use moor_common::model::ObjectRef;
-use moor_var::Error::E_INVIND;
-use moor_var::{Obj, Symbol, v_err};
+use moor_var::{E_INVIND, Obj, Symbol, v_err};
 use rpc_async_client::rpc_client::RpcSendClient;
 use rpc_common::AuthToken;
 use rpc_common::HostClientToDaemonMessage::{Attach, ConnectionEstablish};

--- a/crates/web-host/src/host/ws_connection.rs
+++ b/crates/web-host/src/host/ws_connection.rs
@@ -83,7 +83,6 @@ pub struct NarrativeOutput {
 #[derive(Debug, Clone, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct Traceback {
     error: String,
-    msg: String,
     traceback: Vec<String>,
 }
 
@@ -626,9 +625,8 @@ impl WebSocketConnection {
                 present: None,
                 unpresent: None,
                 traceback: Some(Traceback {
-                    error: exception.code.message(),
+                    error: format!("{}", exception),
                     traceback,
-                    msg: exception.msg.clone(),
                 }),
             },
         )

--- a/doc/builtins/builtin_functions_status.md
+++ b/doc/builtins/builtin_functions_status.md
@@ -9,7 +9,7 @@ included in the notes column.
 ### Lists
 
 | Name         | Complete | Notes |
-| ------------ | -------- | ----- |
+|--------------|----------|-------|
 | `length`     | &check;  |       |
 | `setadd`     | &check;  |       |
 | `setremove`  | &check;  |       |
@@ -26,7 +26,7 @@ included in the notes column.
 ### Strings
 
 | Name        | Complete | Notes                                                                                                |
-| ----------- | -------- | ---------------------------------------------------------------------------------------------------- |
+|-------------|----------|------------------------------------------------------------------------------------------------------|
 | `tostr`     | &check;  |                                                                                                      |
 | `toliteral` | &check;  |                                                                                                      |
 | `crypt`     | &check;  | Pretty damned insecure, only here to support existing core password functions.                       |
@@ -39,7 +39,7 @@ included in the notes column.
 ### Numbers
 
 | Name       | Complete | Notes |
-| ---------- | -------- | ----- |
+|------------|----------|-------|
 | `toint`    | &check;  |       |
 | `tonum`    | &check;  |       |
 | `tofloat`  | &check;  |       |
@@ -70,7 +70,7 @@ included in the notes column.
 ### Objects
 
 | Name              | Complete | Notes                              |
-| ----------------- | -------- | ---------------------------------- |
+|-------------------|----------|------------------------------------|
 | `toobj`           | &check;  |                                    |
 | `typeof`          | &check;  |                                    |
 | `create`          | &check;  | Quota support not implemented yet. |
@@ -88,7 +88,7 @@ included in the notes column.
 ### Properties
 
 | Name                | Complete | Notes |
-| ------------------- | -------- | ----- |
+|---------------------|----------|-------|
 | `properties`        | &check;  |       |
 | `property_info`     | &check;  |       |
 | `set_property_info` | &check;  |       |
@@ -100,7 +100,7 @@ included in the notes column.
 ### Verbs
 
 | Name            | Complete | Notes                                 |
-| --------------- | -------- | ------------------------------------- |
+|-----------------|----------|---------------------------------------|
 | `verbs`         | &check;  |                                       |
 | `verb_info`     | &check;  |                                       |
 | `set_verb_info` | &check;  |                                       |
@@ -116,7 +116,7 @@ included in the notes column.
 ### Values / encoding
 
 | Name            | Complete | Notes                                                                              |
-| --------------- | -------- | ---------------------------------------------------------------------------------- |
+|-----------------|----------|------------------------------------------------------------------------------------|
 | `value_bytes`   | &check;  |                                                                                    |
 | `value_hash`    |          |                                                                                    |
 | `string_hash`   | &check;  |                                                                                    |
@@ -128,7 +128,7 @@ included in the notes column.
 ### Server
 
 | Name                  | Complete | Notes                                                                    |
-| --------------------- | -------- | ------------------------------------------------------------------------ |
+|-----------------------|----------|--------------------------------------------------------------------------|
 | `server_version`      | &check;  | Crate version + short commit hash, for now                               |
 | `renumber`            |          |                                                                          |
 | `reset_max_object`    |          |                                                                          |
@@ -150,7 +150,7 @@ included in the notes column.
 ### Tasks
 
 | Name           | Complete | Notes                                                                                 |
-| -------------- | -------- | ------------------------------------------------------------------------------------- |
+|----------------|----------|---------------------------------------------------------------------------------------|
 | `task_id`      | &check;  |                                                                                       |
 | `queued_tasks` | &check;  |                                                                                       |
 | `kill_task`    | &check;  |                                                                                       |
@@ -162,7 +162,7 @@ included in the notes column.
 ### Execution
 
 | Name             | Complete | Notes        |
-| ---------------- | -------- | ------------ |
+|------------------|----------|--------------|
 | `call_function`  | &check;  |              |
 | `raise`          | &check;  |              |
 | `suspend`        | &check;  |              |
@@ -177,7 +177,7 @@ included in the notes column.
 ### Network connections
 
 | Name                      | Complete | Notes                                                                                                |
-| ------------------------- | -------- | ---------------------------------------------------------------------------------------------------- |
+|---------------------------|----------|------------------------------------------------------------------------------------------------------|
 | `set_connection_option`   |          |                                                                                                      |
 | `connection_option`       |          |                                                                                                      |
 | `connection_options`      |          |                                                                                                      |
@@ -193,7 +193,7 @@ included in the notes column.
 Functions not in the original LambdaMOO, but were in Toast, and ported over
 
 | Name                   | Complete | Notes                                                               |
-| ---------------------- | -------- | ------------------------------------------------------------------- |
+|------------------------|----------|---------------------------------------------------------------------|
 | `age_generate_keypair` | &check;  | Generates a new X25519 keypair for use with age encryption.         |
 | `age_encrypt`          | &check;  | Encrypts a message using age encryption for one or more recipients. |
 | `age_decrypt`          | &check;  | Decrypts an age-encrypted message using one or more private keys.   |
@@ -219,23 +219,30 @@ Functions not part of the original LambdaMOO, but added in moor
 ### XML / HTML content management
 
 | Name        | Description                                                      | Notes                                                 |
-| ----------- | ---------------------------------------------------------------- | ----------------------------------------------------- |
+|-------------|------------------------------------------------------------------|-------------------------------------------------------|
 | `xml_parse` | Parse a string c ntaining XML into a tree of flyweight objects   | Available only if the flyweights feature is turned on |
 | `to_xml`    | Convert a tree of flyweight objects into a string containing XML | Available only if the flyweights feature is turned on |
 
 ### Flyweights & Symbols (new types)
 
 | Name          | Description                                                             | Notes                                                 |
-| ------------- | ----------------------------------------------------------------------- | ----------------------------------------------------- |
+|---------------|-------------------------------------------------------------------------|-------------------------------------------------------|
 | `slots`       | Returns the slots on a given flyweight                                  | Available only if the flyweights feature is turned on |
 | `remove_slot` | Returns a copy of the flyweight with the given slot removed, if present | Available only if the flyweights feature is turned on |
 | `add_slot`    | Returns a copy of the flyweight with a new slot added                   | Available only if the flyweights feature is turned on |
 | `tosym`       | Turns the given value into a Symbol                                     | Available only if the symbols feature is turned on    |
 
+### Expanded error handling
+
+| Name            | Description                                                                    | Notes |
+|-----------------|--------------------------------------------------------------------------------|-------|
+| `error_code`    | Strip off any message or value from an error and return only the code portion  |       |
+| `error_message` | Return the message portion of the error, or the default message if none exists |       |
+
 ### Admin
 
 | Name          | Description                                                     | Notes |
-| ------------- | --------------------------------------------------------------- | ----- |
+|---------------|-----------------------------------------------------------------|-------|
 | `vm_counters` | Performance counters for profiling VM internals                 |       |
 | `bf_counters` | Performance counters for profiling builtin function performance |       |
 | `db_counters` | Performance counters for profiling DB performance               |       |
@@ -243,7 +250,7 @@ Functions not part of the original LambdaMOO, but added in moor
 ### Tasks
 
 | Name           | Description                                                                                                                                                                       | Notes                           |
-| -------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------- |
+|----------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------|
 | `active_tasks` | Return information about running non-suspended/non-queued tasks which are actively running                                                                                        |                                 |
 | `wait_task`    | Causes the current task to wait for a given task id to not be in the background queue                                                                                             |                                 |
 | `commit`       | Causes the current task to immediately commit its data, suspend, and then come out of suspension                                                                                  | Semantically same as suspend(0) |

--- a/doc/builtins/values.md
+++ b/doc/builtins/values.md
@@ -129,3 +129,28 @@ Computes an MD5 hash of a value's literal representation.
 Note: Most of these functions follow a consistent pattern of validating arguments and providing appropriate error
 handling. Type conversion functions generally attempt to convert intelligently between types and provide sensible
 defaults or errors when conversion isn't possible.
+
+## Error Handling Functions
+
+### `error_message`
+
+Returns the error message associated with an error value.
+
+**Description:****Arguments:**
+
+- `error`: The error value to get the message from
+
+**Returns:** The error message string
+
+### `error_code`
+
+Strips off the message from an error value and returns just the error without it.
+
+**Description:****Arguments:**
+
+- `error`: The error value to get the code from
+
+**Returns:** The error code of the error value
+
+
+

--- a/doc/extensions.md
+++ b/doc/extensions.md
@@ -85,6 +85,26 @@ copy and update like other MOO primitive types.
 
 Performance wise, construction and lookup are O(log n) operations, and iteration is O(n).
 
+### Custom errors and errors with attached messages
+
+LambdaMOO had a set of hardcoded builtin-in errors with numeric values. It also uses the same errors for exceptions,
+and allows optional messages an an optional value to be passed when raising them, but these are not part of the error
+value itself.
+
+`mooR` adds support for custom errors, where any value that comes after `E_` is treated as an error identifier, though
+it does not have a numeric value (and will raise error if you try to call `tonum()` on it).
+
+Additionally, `mooR` extends errors with an optional message component which can be used to provide more context:
+
+```moo
+E_PROPNF("$foo.bar does not exist")
+```
+
+This is useful for debugging and error handling, as it allows you to provide more information about the error.
+
+Most of the builtin functions and builtin types have been updated to produce more descriptive error messages
+when they fail. This can help greatly with debugging and understanding what went wrong in your code.
+
 ### Symbol type
 
 `mooR` adds a symbol type which represents interned strings similar to those found in Lisp, Scheme and other languages.

--- a/doc/language.md
+++ b/doc/language.md
@@ -39,98 +39,99 @@ LambdaMOO Programmers Manual or various tutorials.
 MOO supports several types of statements:
 
 1. **Control Flow Statements**:
-   - `if`/`elseif`/`else`/`endif` - Conditional execution
-   - `while`/`endwhile` - Loop as long as condition is true
-   - `for`/`endfor` - Iteration over ranges or collections
-   - `fork`/`endfork` - Parallel execution threads
-   - `try`/`except`/`finally`/`endtry` - Exception handling
-   - `break` and `continue` - Loop control
-   - `return` - Return from the current verb
+    - `if`/`elseif`/`else`/`endif` - Conditional execution
+    - `while`/`endwhile` - Loop as long as condition is true
+    - `for`/`endfor` - Iteration over ranges or collections
+    - `fork`/`endfork` - Parallel execution threads
+    - `try`/`except`/`finally`/`endtry` - Exception handling
+    - `break` and `continue` - Loop control
+    - `return` - Return from the current verb
 
 2. **Variable Declaration and Assignment**:
-   - `let` - Declares local variables
-   - `const` - Declares constants
-   - `global` - Declares global variables
+    - `let` - Declares local variables
+    - `const` - Declares constants
+    - `global` - Declares global variables
 
 3. **Block Structure**:
-   - `begin`/`end` - Groups statements into a block
+    - `begin`/`end` - Groups statements into a block
 
 4. **Expression Statements**:
-   - Any expression followed by a semicolon
+    - Any expression followed by a semicolon
 
 ## Variables and Types
 
 MOO supports several basic data types:
 
 1. **Primitive Types**:
-   - Integer (`INT`) - Whole numbers
-   - Float (`FLOAT`) - Decimal numbers
-   - String (`STR`) - Text in double quotes
-   - Boolean (`BOOL`) - `true` or `false`
-   - Object (`OBJ`) - References to objects in the DB, written as `#123` or `$room`. Note that `$` is a special prefix
-     for "system" objects, which are objects referenced off the system object `#0`. `$room` is short-hand for
-     `#0.room`.
-   - Error (`ERR`) - Error values, starting with `E_`
-   - Symbol (`SYM`) - Symbolic identifiers prefixed with a single quote, as in Scheme or Lisp, e.g. `'symbol`
+    - Integer (`INT`) - Whole numbers
+    - Float (`FLOAT`) - Decimal numbers
+    - String (`STR`) - Text in double quotes
+    - Boolean (`BOOL`) - `true` or `false`
+    - Object (`OBJ`) - References to objects in the DB, written as `#123` or `$room`. Note that `$` is a special prefix
+      for "system" objects, which are objects referenced off the system object `#0`. `$room` is short-hand for
+      `#0.room`.
+    - Error (`ERR`) - Error values, literal values starting with `E_`, optionally followed (in parentheses) by a string
+      describing the error. For example, `E_PERM("Permission denied")` or `E_PERM`.
+    - Symbol (`SYM`) - Symbolic identifiers prefixed with a single quote, as in Scheme or Lisp, e.g. `'symbol`
 
 2. **Complex Types**:
 
-   - List (`LIST`) - Ordered collections in curly braces `{1, 2, 3}`. Lists can contain any type of value, including
-     other
-     lists.
-     _Note that unlike most programming languages (and like Pascal, Lua, Julia, etc.) lists are 1-indexed, not
-     zero-indexed._
+    - List (`LIST`) - Ordered collections in curly braces `{1, 2, 3}`. Lists can contain any type of value, including
+      other
+      lists.
+      _Note that unlike most programming languages (and like Pascal, Lua, Julia, etc.) lists are 1-indexed, not
+      zero-indexed._
 
-   - Map (`MAP`) - Key-value collections in square brackets `[key -> value]`
-   - Flyweight (`FLYWEIGHT`) - Lightweight objects with structure `<parent, [slots], {contents}>`
+    - Map (`MAP`) - Key-value collections in square brackets `[key -> value]`
+    - Flyweight (`FLYWEIGHT`) - Lightweight objects with structure `<parent, [slots], {contents}>`
 
 _Note that MOO's lists and maps have "opposite" syntax to most programming languages. Lists are
 `{1, 2, 3}` and maps are `[key -> value]`._ This is a product of the age of the language, which predates the
 introduction of Python and other similar languages that used square brackets for lists and curly braces for maps.
 
 3. **Type Constants**:
-   - `INT`, `NUM`, `FLOAT`, `STR`, `ERR`, `OBJ`, `LIST`, `MAP`, `BOOL`, `FLYWEIGHT`, `SYM`
+    - `INT`, `NUM`, `FLOAT`, `STR`, `ERR`, `OBJ`, `LIST`, `MAP`, `BOOL`, `FLYWEIGHT`, `SYM`
 
 ## Expressions
 
 Expressions can include:
 
 1. **Arithmetic Operations**:
-   - Addition (`+`), Subtraction (`-`), Multiplication (`*`), Division (`/`), Modulus (`%`), Power (`^`)
+    - Addition (`+`), Subtraction (`-`), Multiplication (`*`), Division (`/`), Modulus (`%`), Power (`^`)
 
 2. **Comparison Operations**:
-   - Equal (`==`), Not Equal (`!=`), Less Than (`<`), Greater Than (`>`), Less Than or Equal (`<=`), Greater Than or
-     Equal (`>=`)
+    - Equal (`==`), Not Equal (`!=`), Less Than (`<`), Greater Than (`>`), Less Than or Equal (`<=`), Greater Than or
+      Equal (`>=`)
 
 3. **Logical Operations**:
-   - Logical AND (`&&`), Logical OR (`||`), Logical NOT (`!`)
+    - Logical AND (`&&`), Logical OR (`||`), Logical NOT (`!`)
 
 4. **Special Operations**:
-   - Range (`..`) - Used in range selection and range iteration
-   - In-range (`in`) - Tests if a value is in a sequence (list or map)
+    - Range (`..`) - Used in range selection and range iteration
+    - In-range (`in`) - Tests if a value is in a sequence (list or map)
 
 5. **Conditional Expression**:
-   - `expr ? true_expr | false_expr` - Ternary conditional expression the same as C's `?:` operator.
+    - `expr ? true_expr | false_expr` - Ternary conditional expression the same as C's `?:` operator.
 
 6. **Variable Assignment**:
-   - `var = expr` - Assigns value to variable
+    - `var = expr` - Assigns value to variable
 
 7. **Object Member Access**:
-   - Property access: `obj.property` or `obj.(expr)`
-   - Verb call: `obj:verb(args)` or `obj:(expr)(args)`
-   - System property or verb: `$property` (looks on `#0` for the property)
+    - Property access: `obj.property` or `obj.(expr)`
+    - Verb call: `obj:verb(args)` or `obj:(expr)(args)`
+    - System property or verb: `$property` (looks on `#0` for the property)
 
 8. **Collection Operations**:
-   - Indexing: `collection[index]`
-   - Range indexing: `collection[start..end]`
-   - List or map assignment: `list[index] = value` - Assigns value to a specific index or key in a list or map
-   - Scatter assignment: `{var1, var2} = list` - Unpacks a list into variables. Has support for optional and rest
-     variables: `{var1, ?optional = default, @rest} = list`
+    - Indexing: `collection[index]`
+    - Range indexing: `collection[start..end]`
+    - List or map assignment: `list[index] = value` - Assigns value to a specific index or key in a list or map
+    - Scatter assignment: `{var1, var2} = list` - Unpacks a list into variables. Has support for optional and rest
+      variables: `{var1, ?optional = default, @rest} = list`
 
 9. **Special Forms**:
-   - Try expression: `` `expr!codes => handler` `` - Evaluates `expr` and handles errors
-   - Range comprehension: `{expr for var in range}` - Creates a list from a generator expression
-   - Range end marker: `$` - Represents the end of a list in range operations
+    - Try expression: `` `expr!codes => handler` `` - Evaluates `expr` and handles errors
+    - Range comprehension: `{expr for var in range}` - Creates a list from a generator expression
+    - Range end marker: `$` - Represents the end of a list in range operations
 
 ## Control Structures
 

--- a/tools/moorc/src/main.rs
+++ b/tools/moorc/src/main.rs
@@ -351,10 +351,7 @@ fn main() {
                 Ok(rv) => rv,
                 Err(e) => match e {
                     SchedulerError::TaskAbortedException(e) => {
-                        error!(
-                            "Test {}:{} aborted: {} ({}): {:?}",
-                            o, verb, e.code, e.msg, e.value
-                        );
+                        error!("Test {}:{} aborted: {}", o, verb, e.error);
                         for l in e.backtrace {
                             let Variant::Str(s) = l.variant() else {
                                 continue;


### PR DESCRIPTION
Allows all errors to carry an optional description. Replaces the use of the special `ErrorPack` struct which was unique only to the exception handler with a more expanded `Error`.

For example: 

```moo
E_PERM("you can't do that")
```

Is now a valid expression.