### PR TITLE
Migrate more `test_objects.rb` tests from Stunt

### DIFF
--- a/crates/common/src/model/defset.rs
+++ b/crates/common/src/model/defset.rs
@@ -97,6 +97,15 @@ impl<T: AsByteBuffer + Clone + HasUuid + Named> ValSet<T> for Defs<T> {
     }
 }
 
+impl<T: AsByteBuffer + Clone + HasUuid + Named> IntoIterator for Defs<T> {
+    type Item = T;
+    type IntoIter = ::std::vec::IntoIter<T>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.contents.into_iter()
+    }
+}
+
 impl<T: AsByteBuffer + Clone + HasUuid + Named> FromIterator<T> for Defs<T> {
     fn from_iter<X: IntoIterator<Item = T>>(iter: X) -> Self {
         Self {

--- a/crates/common/src/model/world_state.rs
+++ b/crates/common/src/model/world_state.rs
@@ -87,39 +87,22 @@ pub enum WorldStateError {
 /// Translations from WorldStateError to MOO error codes.
 impl WorldStateError {
     pub fn to_error(&self) -> Error {
-        match self {
-            Self::ObjectNotFound(o) => E_INVIND.with_msg(|| format!("Object not found: {}", o)),
-            Self::ObjectPermissionDenied => E_PERM.into(),
-            Self::RecursiveMove(a, b) => {
-                E_RECMOVE.with_msg(|| format!("Recursive move detected: {} -> {}", a, b))
-            }
-            Self::VerbNotFound(o, v) => {
-                E_VERBNF.with_msg(|| format!("Verb not found: {}:{}", o, v))
-            }
-            Self::VerbPermissionDenied => E_PERM.into(),
-            Self::InvalidVerb(_) => E_VERBNF.into(),
-            Self::DuplicateVerb(o, v) => {
-                E_INVARG.with_msg(|| format!("Duplicate verb: {}:{}", o, v))
-            }
-            Self::PropertyNotFound(o, p) => {
-                E_PROPNF.with_msg(|| format!("Property not found: {}.{}", o, p))
-            }
-            Self::PropertyPermissionDenied => E_PERM.into(),
-            Self::PropertyDefinitionNotFound(p, d) => {
-                E_PROPNF.with_msg(|| format!("Property not found: {}.{}", p, d))
-            }
-            Self::DuplicatePropertyDefinition(o, p) => {
-                E_INVARG.with_msg(|| format!("Duplicate property definition: {}.{}", o, p))
-            }
-            Self::ChparentPropertyNameConflict(o, new_parent, prop) => E_INVARG.msg(format!(
-                "Property name conflict: {}-or-descendants and {}-or-ancestors both define {}",
-                o, new_parent, prop
-            )),
-            Self::PropertyTypeMismatch => E_TYPE.msg("Property type mismatch"),
-            _ => {
-                panic!("Unhandled error code: {:?}", self);
-            }
-        }
+        let err_code = match self {
+            Self::ObjectNotFound(_) => E_INVIND,
+            Self::ObjectPermissionDenied
+            | Self::VerbPermissionDenied
+            | Self::PropertyPermissionDenied => E_PERM,
+            Self::RecursiveMove(_, _) => E_RECMOVE,
+            Self::VerbNotFound(_, _) | Self::InvalidVerb(_) => E_VERBNF,
+            Self::DuplicateVerb(_, _)
+            | Self::DuplicatePropertyDefinition(_, _)
+            | Self::ChparentPropertyNameConflict(_, _, _) => E_INVARG,
+            Self::PropertyNotFound(_, _) | Self::PropertyDefinitionNotFound(_, _) => E_PROPNF,
+            Self::PropertyTypeMismatch => E_TYPE,
+            _ => panic!("Unhandled error code: {:?}", self),
+        };
+
+        err_code.msg(self.to_string())
     }
 
     pub fn database_error_msg(&self) -> Option<&str> {

--- a/crates/db/src/moor_db_tests.rs
+++ b/crates/db/src/moor_db_tests.rs
@@ -193,16 +193,18 @@ mod tests {
             .unwrap();
         assert_eq!(d, Obj::mk_id(3));
 
-        let desc = tx.descendants(&a).expect("Could not retrieve descendants");
+        let desc = tx
+            .descendants(&a, false)
+            .expect("Could not retrieve descendants");
         assert!(
             desc.is_same(ObjSet::from_items(&[b.clone(), c.clone(), d.clone()])),
             "Descendants doesn't match expected is {:?}",
             desc
         );
 
-        assert_eq!(tx.descendants(&b).unwrap(), ObjSet::empty());
+        assert_eq!(tx.descendants(&b, false).unwrap(), ObjSet::empty());
         assert_eq!(
-            tx.descendants(&c).unwrap(),
+            tx.descendants(&c, false).unwrap(),
             ObjSet::from_items(&[d.clone()])
         );
 
@@ -218,16 +220,16 @@ mod tests {
             ObjSet::from_items(&[d.clone()])
         );
         assert_eq!(tx.get_object_children(&c).unwrap(), ObjSet::empty());
-        assert!(tx.descendants(&a).unwrap().is_same(ObjSet::from_items(&[
-            b.clone(),
-            c.clone(),
-            d.clone()
-        ])));
+        assert!(
+            tx.descendants(&a, false)
+                .unwrap()
+                .is_same(ObjSet::from_items(&[b.clone(), c.clone(), d.clone()]))
+        );
         assert_eq!(
-            tx.descendants(&b).unwrap(),
+            tx.descendants(&b, false).unwrap(),
             ObjSet::from_items(&[d.clone()])
         );
-        assert_eq!(tx.descendants(&c).unwrap(), ObjSet::empty());
+        assert_eq!(tx.descendants(&c, false).unwrap(), ObjSet::empty());
         assert_eq!(tx.commit(), Ok(CommitResult::Success));
     }
 

--- a/crates/kernel/src/vm/builtins/bf_objects.rs
+++ b/crates/kernel/src/vm/builtins/bf_objects.rs
@@ -90,6 +90,7 @@ fn bf_chparent(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
             E_TYPE.msg("chparent() second argument must be an object"),
         ));
     };
+
     // If object is not valid, or if new-parent is neither valid nor equal to #-1, then E_INVARG is raised.
     if !bf_args.world_state.valid(obj).map_err(world_state_bf_err)?
         || !(new_parent.is_nothing()
@@ -102,6 +103,7 @@ fn bf_chparent(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
             E_INVARG.msg("chparent() arguments must be valid objects"),
         ));
     }
+
     bf_args
         .world_state
         .change_parent(&bf_args.task_perms_who(), obj, new_parent)
@@ -150,7 +152,7 @@ fn bf_descendants(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
     }
     let descendants = bf_args
         .world_state
-        .descendants_of(&bf_args.task_perms_who(), obj)
+        .descendants_of(&bf_args.task_perms_who(), obj, false)
         .map_err(world_state_bf_err)?;
 
     let descendants = descendants.iter().map(v_obj).collect::<Vec<_>>();

--- a/crates/kernel/testsuite/moot/objects/test_clear_properties.moot
+++ b/crates/kernel/testsuite/moot/objects/test_clear_properties.moot
@@ -1,0 +1,56 @@
+// Adapted from https://github.com/toddsundsted/stunt/blob/e83e946/test/test_objects.rb
+//   def test_clear_properties
+@programmer
+; add_property($system, "x", create($nothing), {player, "wrc"});
+; $x.f = 1;
+
+; add_property($system, "a", create($x), {player, "wrc"});
+
+; add_property($x, "x", "x", {player, "rc"});
+; return property_info($a, "x");
+{player, "rc"}
+; return $a.x;
+"x"
+
+; add_property($system, "b", create($nothing), {player, "wrc"});
+; chparent($b, $x);
+; return property_info($b, "x");
+{player, "rc"}
+; return $b.x;
+"x"
+
+; $b.x = {"x"};
+; return $b.x;
+{"x"}
+
+; add_property($system, "c", create($x), {player, "wrc"});
+; return property_info($c, "x");
+{player, "rc"}
+; return $c.x;
+"x"
+
+; set_property_info($c, "x", {player, ""});
+; return property_info($c, "x");
+{player, ""}
+
+@programmer
+; $a = create($x);
+; return property_info($a, "x");
+{player, "rc"}
+; return $a.x;
+"x"
+
+; $a.x = {"x"};
+; return $a.x;
+{"x"}
+
+; $b = create($nothing);
+; chparent($b, $x);
+; return property_info($b, "x");
+{player, "rc"}
+; return $b.x;
+"x"
+
+; set_property_info($b, "x", {player, ""});
+; return property_info($b, "x");
+{player, ""}

--- a/crates/kernel/testsuite/moot/objects/test_various_things_that_can_go_wrong.moot
+++ b/crates/kernel/testsuite/moot/objects/test_various_things_that_can_go_wrong.moot
@@ -1,0 +1,33 @@
+// Adapted from https://github.com/toddsundsted/stunt/blob/e83e946/test/test_objects.rb
+//   def test_various_things_that_can_go_wrong 
+@programmer
+; add_property($system, "a", create($nothing), {player, "wrc"});
+; add_property($system, "b", create($nothing), {player, "wrc"});
+; add_property($system, "c", create($nothing), {player, "wrc"});
+
+; add_property($system, "m", create($a), {player, "wrc"});
+; add_property($system, "n", create($b), {player, "wrc"});
+
+; add_property($system, "z", create($nothing), {player, "wrc"});
+
+; add_property($a, "foo", 0, {player, ""});
+; add_property($b, "foo", 0, {player, ""});
+; add_property($c, "foo", 0, {player, ""});
+
+; add_property($m, "bar", 0, {player, ""});
+; add_property($n, "baz", 0, {player, ""});
+
+; add_property($z, "bar", 0, {player, ""});
+
+; return chparent($a, $b);
+E_INVARG
+; return chparent($a, $c);
+E_INVARG
+; return chparent($a, $z);
+E_INVARG
+
+; return chparent($c, $z);
+; return chparent($c, $nothing);
+
+; return chparent($z, $c);
+; return chparent($z, $nothing);

--- a/crates/kernel/testsuite/moot_suite.rs
+++ b/crates/kernel/testsuite/moot_suite.rs
@@ -193,5 +193,5 @@ fn test(db: Box<dyn Database>, path: &Path) {
 fn test_single() {
     // cargo test -p moor-kernel --test moot-suite test_single -- --ignored
     // CARGO_PROFILE_RELEASE_DEBUG=true cargo flamegraph --test moot-suite -- test_single --ignored
-    test_with_db(&testsuite_dir().join("moot/objects/test_clear_properties.moot"));
+    test_with_db(&testsuite_dir().join("moot/objects/test_various_things_that_can_go_wrong.moot"));
 }

--- a/crates/kernel/testsuite/moot_suite.rs
+++ b/crates/kernel/testsuite/moot_suite.rs
@@ -193,5 +193,5 @@ fn test(db: Box<dyn Database>, path: &Path) {
 fn test_single() {
     // cargo test -p moor-kernel --test moot-suite test_single -- --ignored
     // CARGO_PROFILE_RELEASE_DEBUG=true cargo flamegraph --test moot-suite -- test_single --ignored
-    test_with_db(&testsuite_dir().join("moot/objects/test_properties_and_inheritance.moot"));
+    test_with_db(&testsuite_dir().join("moot/objects/test_clear_properties.moot"));
 }

--- a/crates/testing/moot/tests/moot_lmoo.rs
+++ b/crates/testing/moot/tests/moot_lmoo.rs
@@ -85,6 +85,6 @@ fn test_moo(path: &Path) {
 fn test_single() {
     test_moo(
         &PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-            .join("../../kernel/testsuite/moot/objects/test_clear_properties.moot"),
+            .join("../../kernel/testsuite/moot/objects/test_various_things_that_can_go_wrong.moot"),
     );
 }

--- a/crates/testing/moot/tests/moot_lmoo.rs
+++ b/crates/testing/moot/tests/moot_lmoo.rs
@@ -85,6 +85,6 @@ fn test_moo(path: &Path) {
 fn test_single() {
     test_moo(
         &PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-            .join("../../kernel/testsuite/moot/objects/test_properties_and_inheritance.moot"),
+            .join("../../kernel/testsuite/moot/objects/test_clear_properties.moot"),
     );
 }

--- a/crates/var/src/error.rs
+++ b/crates/var/src/error.rs
@@ -150,8 +150,8 @@ impl Display for ErrorCode {
 }
 
 impl ErrorCode {
-    pub fn msg(self, s: &str) -> Error {
-        Error::new(self, Some(s.into()), None)
+    pub fn msg<S: ToString>(self, s: S) -> Error {
+        Error::new(self, Some(s.to_string()), None)
     }
 
     pub fn with_msg<F>(self, f: F) -> Error


### PR DESCRIPTION
There may be a more optimal way to do the property check? I couldn't find it by just reading the code (around) `Defs`.