### PR TITLE
    Rework variable scope management completely

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2800,6 +2800,7 @@ dependencies = [
  "thiserror 2.0.12",
  "tracing",
  "unindent",
+ "uuid 1.16.0",
 ]
 
 [[package]]

--- a/crates/common/src/program/mod.rs
+++ b/crates/common/src/program/mod.rs
@@ -11,6 +11,7 @@
 // this program. If not, see <https://www.gnu.org/licenses/>.
 //
 
+use crate::program::names::Variable;
 use crate::program::program::Program;
 use bincode::{Decode, Encode};
 use moor_var::BincodeAsByteBufferExt;
@@ -36,4 +37,32 @@ impl ProgramType {
             ProgramType::MooR(p) => p.main_vector().is_empty(),
         }
     }
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Encode, Decode)]
+pub enum DeclType {
+    Global,
+    Let,
+    Assign,
+    For,
+    Unknown,
+    Register,
+    Except,
+    WhileLabel,
+    ForkLabel,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Encode, Decode)]
+pub struct Decl {
+    /// The type of declaration, how was it declared?
+    pub decl_type: DeclType,
+    /// The name of the variable (or register id if a register).
+    pub identifier: Variable,
+    /// What scope the variable was declared in.
+    pub depth: usize,
+    /// Is this a constant? Reject subsequent assignments.
+    pub constant: bool,
+    /// The scope id of the variable.
+    /// This is used to determine the scope of the variable when binding (or rebinding at decompile)
+    pub scope_id: usize,
 }

--- a/crates/common/src/program/opcode.rs
+++ b/crates/common/src/program/opcode.rs
@@ -202,7 +202,7 @@ mod tests {
     fn size_opcode() {
         use std::mem::size_of;
         assert_eq!(size_of::<Op>(), 16);
-        assert_eq!(size_of::<Name>(), 2);
+        assert_eq!(size_of::<Name>(), 4);
         assert_eq!(size_of::<Offset>(), 2);
         assert_eq!(size_of::<Label>(), 2);
     }

--- a/crates/compiler/Cargo.toml
+++ b/crates/compiler/Cargo.toml
@@ -37,3 +37,4 @@ thiserror.workspace = true
 
 ## Logging & tracing
 tracing.workspace = true
+uuid = { version = "1.16.0", features = ["v4"] }

--- a/crates/compiler/src/codegen.rs
+++ b/crates/compiler/src/codegen.rs
@@ -732,11 +732,9 @@ impl CodegenState {
                     for stmt in &arm.statements {
                         self.generate_stmt(stmt)?;
                     }
-                    if arm.environment_width > 0 {
-                        self.emit(Op::EndScope {
-                            num_bindings: arm.environment_width as u16,
-                        });
-                    }
+                    self.emit(Op::EndScope {
+                        num_bindings: arm.environment_width as u16,
+                    });
                     self.emit(Jump { label: end_label });
 
                     // This is where we jump to if the condition is false; either the end of the
@@ -748,20 +746,16 @@ impl CodegenState {
                     let end_label = self.make_jump_label(None);
                     // Decompilation has to elide this begin/end scope pair, as it's not actually
                     // present in the source code.
-                    if otherwise.environment_width > 0 {
-                        self.emit(Op::BeginScope {
-                            num_bindings: otherwise.environment_width as u16,
-                            end_label,
-                        });
-                    }
+                    self.emit(Op::BeginScope {
+                        num_bindings: otherwise.environment_width as u16,
+                        end_label,
+                    });
                     for stmt in &otherwise.statements {
                         self.generate_stmt(stmt)?;
                     }
-                    if otherwise.environment_width > 0 {
-                        self.emit(Op::EndScope {
-                            num_bindings: otherwise.environment_width as u16,
-                        });
-                    }
+                    self.emit(Op::EndScope {
+                        num_bindings: otherwise.environment_width as u16,
+                    });
                     self.commit_jump_label(end_label);
                 }
                 self.commit_jump_label(end_label);
@@ -802,11 +796,9 @@ impl CodegenState {
                 for stmt in body {
                     self.generate_stmt(stmt)?;
                 }
-                if *environment_width > 0 {
-                    self.emit(Op::EndScope {
-                        num_bindings: *environment_width as u16,
-                    });
-                }
+                self.emit(Op::EndScope {
+                    num_bindings: *environment_width as u16,
+                });
                 self.emit(Jump { label: loop_top });
                 self.commit_jump_label(end_label);
                 self.pop_stack(2);
@@ -839,11 +831,9 @@ impl CodegenState {
                 for stmt in body {
                     self.generate_stmt(stmt)?;
                 }
-                if *environment_width > 0 {
-                    self.emit(Op::EndScope {
-                        num_bindings: *environment_width as u16,
-                    });
-                }
+                self.emit(Op::EndScope {
+                    num_bindings: *environment_width as u16,
+                });
                 self.emit(Jump { label: loop_top });
                 self.commit_jump_label(end_label);
                 self.pop_stack(2);
@@ -887,11 +877,9 @@ impl CodegenState {
                 self.emit(Jump {
                     label: loop_start_label,
                 });
-                if *environment_width > 0 {
-                    self.emit(Op::EndScope {
-                        num_bindings: *environment_width as u16,
-                    });
-                }
+                self.emit(Op::EndScope {
+                    num_bindings: *environment_width as u16,
+                });
                 self.commit_jump_label(loop_end_label);
                 self.loops.pop();
             }

--- a/crates/compiler/src/lib.rs
+++ b/crates/compiler/src/lib.rs
@@ -39,4 +39,4 @@ pub use moor_common::program::builtins::{
 pub use moor_common::program::labels::{JumpLabel, Label, Offset};
 pub use moor_common::program::opcode::{Op, ScatterLabel};
 pub use moor_common::program::program::{EMPTY_PROGRAM, Program};
-pub use var_scope::{DeclType, VarScope};
+pub use var_scope::VarScope;

--- a/crates/compiler/src/unparse.rs
+++ b/crates/compiler/src/unparse.rs
@@ -11,10 +11,11 @@
 // this program. If not, see <https://www.gnu.org/licenses/>.
 //
 
+use crate::ast;
 use crate::ast::{Expr, Stmt, StmtNode};
 use crate::decompile::DecompileError;
 use crate::parse::Parse;
-use crate::{DeclType, ast};
+use moor_common::program::DeclType;
 use moor_common::program::names::{Name, Variable};
 use moor_common::util::quote_str;
 use moor_var::{Obj, Sequence, Var, Variant};
@@ -309,8 +310,7 @@ impl<'a> Unparse<'a> {
                 //   as the let scatter syntax does not have granularity per-var.
                 let is_local = vars.iter().any(|var| {
                     let bound_name = self.tree.names_mapping[&var.id];
-                    let scope_depth = self.tree.names.depth_of(&bound_name).unwrap();
-                    scope_depth > 0
+                    bound_name.1 > 0
                 });
                 let is_const = vars
                     .iter()

--- a/crates/kernel/src/vm/builtins/bf_objects.rs
+++ b/crates/kernel/src/vm/builtins/bf_objects.rs
@@ -23,9 +23,9 @@ use moor_var::{E_ARGS, E_INVARG, E_NACC, E_PERM, E_TYPE};
 use moor_var::{List, Variant, v_bool};
 use moor_var::{NOTHING, v_list_iter};
 use moor_var::{Sequence, Symbol, v_list};
-use moor_var::{v_int, v_none, v_obj, v_str, v_sym_str};
+use moor_var::{v_int, v_obj, v_str, v_sym_str};
 
-use crate::vm::builtins::BfRet::{Ret, VmInstr};
+use crate::vm::builtins::BfRet::{Ret, RetNil, VmInstr};
 use crate::vm::builtins::{BfCallState, BfErr, BfRet, BuiltinFunction, world_state_bf_err};
 use crate::vm::vm_host::ExecutionResult::DispatchVerb;
 use crate::vm::{VerbCall, VerbExecutionRequest};
@@ -108,7 +108,7 @@ fn bf_chparent(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
         .world_state
         .change_parent(&bf_args.task_perms_who(), obj, new_parent)
         .map_err(world_state_bf_err)?;
-    Ok(Ret(v_none()))
+    Ok(RetNil)
 }
 
 fn bf_children(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
@@ -734,7 +734,7 @@ fn bf_move(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
 
                 // Enter func was called, and returned. Result is irrelevant. We're done.
                 // Return v_none.
-                return Ok(Ret(v_none()));
+                return Ok(RetNil);
             }
             _ => {
                 panic!("Invalid trampoline state: {} in bf_move", tramp);
@@ -834,7 +834,7 @@ fn bf_set_player_flag(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
         bf_args.exec_state.set_task_perms(obj.clone());
     }
 
-    Ok(Ret(v_none()))
+    Ok(RetNil)
 }
 
 fn bf_players(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {

--- a/crates/kernel/src/vm/builtins/bf_properties.rs
+++ b/crates/kernel/src/vm/builtins/bf_properties.rs
@@ -18,10 +18,10 @@ use moor_var::Sequence;
 use moor_var::Variant;
 use moor_var::{E_ARGS, E_INVARG, E_TYPE};
 use moor_var::{List, v_empty_list};
-use moor_var::{v_list, v_none, v_obj, v_string};
+use moor_var::{v_list, v_obj, v_string};
 
 use crate::vm::builtins::BfErr::{Code, ErrValue};
-use crate::vm::builtins::BfRet::Ret;
+use crate::vm::builtins::BfRet::{Ret, RetNil};
 use crate::vm::builtins::{BfCallState, BfErr, BfRet, BuiltinFunction, world_state_bf_err};
 
 // property_info (obj <object>, str <prop-name>)              => list\
@@ -188,7 +188,7 @@ fn bf_add_property(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
             Some(value),
         )
         .map_err(world_state_bf_err)?;
-    Ok(Ret(v_none()))
+    Ok(RetNil)
 }
 
 fn bf_delete_property(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {

--- a/crates/kernel/src/vm/builtins/bf_server.rs
+++ b/crates/kernel/src/vm/builtins/bf_server.rs
@@ -23,7 +23,7 @@ use tracing::{error, info, warn};
 use crate::tasks::{TaskStart, sched_counters};
 use crate::vm::TaskSuspend;
 use crate::vm::builtins::BfErr::{Code, ErrValue};
-use crate::vm::builtins::BfRet::{Ret, VmInstr};
+use crate::vm::builtins::BfRet::{Ret, RetNil, VmInstr};
 use crate::vm::builtins::{
     BfCallState, BfErr, BfRet, BuiltinFunction, bf_perf_counters, world_state_bf_err,
 };
@@ -272,7 +272,7 @@ fn bf_present(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
         .task_scheduler_client
         .notify(player.clone(), Box::new(event));
 
-    Ok(Ret(v_none()))
+    Ok(RetNil)
 }
 
 fn bf_connected_players(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
@@ -352,7 +352,7 @@ fn bf_set_task_perms(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
     }
     bf_args.exec_state.set_task_perms(perms_for);
 
-    Ok(Ret(v_none()))
+    Ok(RetNil)
 }
 
 fn bf_callers(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
@@ -496,7 +496,7 @@ fn bf_shutdown(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
 
     bf_args.task_scheduler_client.shutdown(msg);
 
-    Ok(Ret(v_none()))
+    Ok(RetNil)
 }
 
 fn bf_time(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
@@ -619,11 +619,6 @@ fn bf_raise(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
         None
     };
 
-    if err.msg.is_some() || err.value.is_some() {
-        return Err(ErrValue(
-            E_INVARG.msg("raise() requires an error with no message or value"),
-        ));
-    }
     Err(BfErr::Raise(Error::new(err.err_type, msg, value)))
 }
 
@@ -965,7 +960,7 @@ fn bf_kill_task(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
     let victim_task_id = *victim_task_id as TaskId;
 
     if victim_task_id == bf_args.exec_state.task_id {
-        return Ok(VmInstr(ExecutionResult::Complete(v_none())));
+        return Ok(VmInstr(ExecutionResult::Complete(v_int(0))));
     }
 
     let result = bf_args.task_scheduler_client.kill_task(
@@ -1047,7 +1042,7 @@ fn bf_seconds_left(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
     }
 
     let seconds_left = match bf_args.exec_state.time_left() {
-        None => v_none(),
+        None => v_int(-1),
         Some(d) => v_int(d.as_secs() as i64),
     };
 
@@ -1077,7 +1072,7 @@ fn bf_boot_player(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
 
     bf_args.task_scheduler_client.boot_player(player.clone());
 
-    Ok(Ret(v_none()))
+    Ok(RetNil)
 }
 
 fn bf_call_function(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
@@ -1171,7 +1166,7 @@ fn bf_server_log(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
         );
     }
 
-    Ok(Ret(v_none()))
+    Ok(RetNil)
 }
 
 fn bf_function_info_to_list(bf: &Builtin) -> Var {
@@ -1371,7 +1366,7 @@ fn bf_unlisten(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
         return Err(ErrValue(err));
     }
 
-    Ok(Ret(v_none()))
+    Ok(RetNil)
 }
 
 pub const BF_SERVER_EVAL_TRAMPOLINE_START_INITIALIZE: usize = 0;
@@ -1536,7 +1531,7 @@ fn load_server_options(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
 
     bf_args.task_scheduler_client.refresh_server_options();
 
-    Ok(Ret(v_none()))
+    Ok(RetNil)
 }
 
 fn counter_map(counters: &[&PerfCounter], use_symbols: bool) -> Var {

--- a/crates/kernel/src/vm/builtins/bf_verbs.rs
+++ b/crates/kernel/src/vm/builtins/bf_verbs.rs
@@ -14,7 +14,7 @@
 use strum::EnumCount;
 use tracing::{error, warn};
 
-use crate::vm::builtins::BfRet::Ret;
+use crate::vm::builtins::BfRet::{Ret, RetNil};
 use crate::vm::builtins::{BfCallState, BfErr, BfRet, BuiltinFunction, world_state_bf_err};
 use moor_common::model::WorldStateError;
 use moor_common::model::{ArgSpec, VerbArgsSpec};
@@ -37,7 +37,7 @@ use moor_var::Variant;
 use moor_var::{E_ARGS, E_INVARG, E_INVIND, E_PERM, E_TYPE, E_VERBNF};
 use moor_var::{Error, v_list_iter};
 use moor_var::{List, v_bool};
-use moor_var::{Var, v_empty_list, v_list, v_none, v_obj, v_str, v_string};
+use moor_var::{Var, v_empty_list, v_list, v_obj, v_str, v_string};
 
 // verb_info (obj <object>, str <verb-desc>) ->  {<owner>, <perms>, <names>}
 fn bf_verb_info(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
@@ -202,7 +202,7 @@ fn bf_set_verb_info(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
         }
     }
 
-    Ok(Ret(v_none()))
+    Ok(RetNil)
 }
 
 fn bf_verb_args(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
@@ -300,7 +300,7 @@ fn bf_set_verb_args(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
                 .map_err(world_state_bf_err)?;
         }
     }
-    Ok(Ret(v_none()))
+    Ok(RetNil)
 }
 
 fn bf_verb_code(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
@@ -428,7 +428,7 @@ fn bf_set_verb_code(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
         .world_state
         .update_verb_with_id(&bf_args.task_perms_who(), obj, verbdef.uuid(), update_attrs)
         .map_err(world_state_bf_err)?;
-    Ok(Ret(v_none()))
+    Ok(RetNil)
 }
 
 // Function: none add_verb (obj object, list info, list args)
@@ -474,7 +474,7 @@ fn bf_add_verb(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
         )
         .map_err(world_state_bf_err)?;
 
-    Ok(Ret(v_none()))
+    Ok(RetNil)
 }
 
 //Function: none delete_verb (obj object, str verb-desc)
@@ -506,7 +506,7 @@ fn bf_delete_verb(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
         .remove_verb(&bf_args.task_perms_who(), obj, verbdef.uuid())
         .map_err(world_state_bf_err)?;
 
-    Ok(Ret(v_none()))
+    Ok(RetNil)
 }
 
 // Syntax:  disassemble (obj <object>, str <verb-desc>)   => list

--- a/crates/kernel/src/vm/builtins/mod.rs
+++ b/crates/kernel/src/vm/builtins/mod.rs
@@ -195,6 +195,10 @@ pub(crate) type BuiltinFunction = fn(&mut BfCallState<'_>) -> Result<BfRet, BfEr
 
 /// Return possibilities from a built-in function.
 pub(crate) enum BfRet {
+    /// Successful return with no relevant value.
+    /// This will just get turned into v_int(0), but I want to call it out as a distinct path.
+    /// We used to return v_none here, until TYPE_NONE became E_VARNF.
+    RetNil,
     /// Successful return, with a value to be pushed to the value stack.
     Ret(Var),
     /// BF wants to return control back to the VM, with specific instructions to things like

--- a/crates/kernel/src/vm/vm_test.rs
+++ b/crates/kernel/src/vm/vm_test.rs
@@ -627,7 +627,7 @@ mod tests {
                 try
                    #1.location:cause_error();
                    return "should not reach here";
-                except error (ANY)
+                except z (ANY)
                    this:raise_error();
                    return "should not reach here";
                 endtry
@@ -1319,5 +1319,24 @@ mod tests {
             List::mk_list(&[]),
         );
         assert_eq!(result.unwrap(), v_int(0));
+    }
+
+    #[test]
+    fn test_regress_except() {
+        //    #[test_case("return {`x ! e_varnf => 666', `321 ! e_verbnf => 123'};",
+        //         v_list(&[v_int(666), v_int(321)]); "catch expr 2")]
+        let program = r#"
+        return {`x ! e_varnf => 666', `321 ! e_verbnf => 123'};
+        "#;
+        let mut state = world_with_test_program(program);
+        let session = Arc::new(NoopClientSession::new());
+        let result = call_verb(
+            state.as_mut(),
+            session,
+            BuiltinRegistry::new(),
+            "test",
+            List::mk_list(&[]),
+        );
+        assert_eq!(result.unwrap(), v_list(&[v_int(666), v_int(321)]));
     }
 }

--- a/crates/kernel/testsuite/moot/objects/test_various_things_that_can_go_wrong.moot
+++ b/crates/kernel/testsuite/moot/objects/test_various_things_that_can_go_wrong.moot
@@ -27,7 +27,11 @@ E_INVARG
 E_INVARG
 
 ; return chparent($c, $z);
+0
 ; return chparent($c, $nothing);
+0
 
 ; return chparent($z, $c);
+0
 ; return chparent($z, $nothing);
+0


### PR DESCRIPTION

    
    Gets rid of the use of the bitmasked variable scope with stretchy
    environment.
    Pushes and pops whole scopes at a time.
    v_none() / TYPE_NONE indicates E_VARNF, like in LambdaMOO
    Fixes some long standing issues with offsets for scopes being
    completely wrong in some cases.
    
    Still some niggling issues with decompilation, to restore the original
    variable state at scope time, which is going to be tricky to resolve.
