### PR TITLE
feat(book): build single HTML, PDF output

### DIFF
--- a/book/build-single-page.sh
+++ b/book/build-single-page.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+# Build a single PDF from the book's Markdown files.
+
+set -euo pipefail
+
+check_dep() {
+    dep="$1"; shift
+    if ! command -v "$dep" >/dev/null 2>&1; then
+        echo >&2 "Error: $dep is not installed. Please install it to build the PDF."
+        exit 1
+    fi
+}
+
+check_dep pandoc
+
+# Common pandoc options
+export MDBOOK_output__pandoc__hosted_html=https://rdaum.github.io/moor/
+# Disable pagetoc
+export MDBOOK_preprocessor__pagetoc__renderers=[]
+# Disable our custom theme files; the `pagetoc`-generated `@media` rules confuse mdbook-pandoc
+export MDBOOK_output__html__additional_js=[]
+export MDBOOK_output__html__additional_css=[]
+
+# Configure enabled backends
+got_backend=no
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --html)
+            export MDBOOK_output__pandoc__profile__html__output_file=moor.html
+            export MDBOOK_output__pandoc__profile__html__to=html
+            got_backend=yes
+            shift
+            ;;
+        --pdf)
+            check_dep pdflatex
+            export MDBOOK_output__pandoc__profile__pdf__output_file=moor.pdf
+            export MDBOOK_output__pandoc__profile__pdf__to=pdf
+            got_backend=yes
+            shift
+            ;;
+        *)
+            echo >&2 "Unknown option: $1. Try --html and/or --pdf."
+            exit 1
+            ;;
+    esac
+done
+
+if [[ "$got_backend" == "no" ]]; then
+    echo "Error: No output backend specified. Use --html and/or --pdf."
+    exit 1
+fi
+
+# Install dependencies
+./install-tools.sh
+cargo install --vers "^0.10" mdbook-pandoc
+
+# Do the thing
+mdbook build


### PR DESCRIPTION
**N.B.:** the rendering pipeline is *completely* different from normal `mdbook` rendering, so do *not* use this to verify formatting, even vaguely.

# Usage

```sh
cd book
./build-single-page.sh --html
# or maybe: ./build-single-page.sh --pdf
# or even: ./build-single-page.sh --html --pdf
```

Output ends up, relative to the repo root, in: `book/book/pandoc/{html,pdf}/moor.{html,pdf}`

# HTML screenshot

![image](https://github.com/user-attachments/assets/a253a5cd-10da-449f-a969-7d95e97145c5)


