### PR TITLE
test: Add operand parsing tests and test infrastructure

### DIFF
--- a/crates/compiler/src/lib.rs
+++ b/crates/compiler/src/lib.rs
@@ -25,6 +25,9 @@ mod codegen_tests;
 mod objdef;
 mod var_scope;
 
+#[cfg(test)]
+mod tests;
+
 pub use crate::codegen::compile;
 pub use crate::decompile::program_to_tree;
 pub use crate::objdef::{

--- a/crates/compiler/src/tests/mod.rs
+++ b/crates/compiler/src/tests/mod.rs
@@ -1,0 +1,16 @@
+// Copyright (C) 2025 Ryan Daum <ryan.daum@gmail.com> This program is free
+// software: you can redistribute it and/or modify it under the terms of the GNU
+// General Public License as published by the Free Software Foundation, version
+// 3.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program. If not, see <https://www.gnu.org/licenses/>.
+//
+
+pub mod operand_parsing_tests;
+pub mod test_macros;
+pub mod test_utils;

--- a/crates/compiler/src/tests/operand_parsing_tests.rs
+++ b/crates/compiler/src/tests/operand_parsing_tests.rs
@@ -1,0 +1,170 @@
+// Copyright (C) 2025 Ryan Daum <ryan.daum@gmail.com> This program is free
+// software: you can redistribute it and/or modify it under the terms of the GNU
+// General Public License as published by the Free Software Foundation, version
+// 3.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program. If not, see <https://www.gnu.org/licenses/>.
+//
+
+//! Tests for operand parsing fixes (builtin_call and sysprop)
+
+use crate::{CompileOptions, compile};
+
+#[test]
+fn test_builtin_call_in_scatter_assignment() {
+    let code = "{_, _, perms, @_} = callers()[2];";
+    let result = compile(code, CompileOptions::default());
+    assert!(
+        result.is_ok(),
+        "builtin_call in scatter assignment should compile"
+    );
+}
+
+#[test]
+fn test_builtin_call_in_simple_assignment() {
+    let code = "result = callers()[2];";
+    let result = compile(code, CompileOptions::default());
+    assert!(
+        result.is_ok(),
+        "builtin_call in simple assignment should compile"
+    );
+}
+
+#[test]
+fn test_builtin_call_with_args() {
+    let code = "x = length(args);";
+    let result = compile(code, CompileOptions::default());
+    assert!(result.is_ok(), "builtin_call with args should compile");
+}
+
+#[test]
+fn test_builtin_call_no_args_in_scatter() {
+    let code = "{a, b} = time();";
+    let result = compile(code, CompileOptions::default());
+    assert!(
+        result.is_ok(),
+        "builtin_call with no args in scatter should compile"
+    );
+}
+
+#[test]
+fn test_sysprop_call_in_scatter_assignment() {
+    let code = "{msg, parties} = $pronoun_sub:flatten_message(msg, parties);";
+    let result = compile(code, CompileOptions::default());
+    assert!(
+        result.is_ok(),
+        "sysprop_call in scatter assignment should compile"
+    );
+}
+
+#[test]
+fn test_sysprop_call_in_simple_assignment() {
+    let code = "result = $pronoun_sub:flatten_message(msg, parties);";
+    let result = compile(code, CompileOptions::default());
+    assert!(
+        result.is_ok(),
+        "sysprop_call in simple assignment should compile"
+    );
+}
+
+#[test]
+fn test_sysprop_in_simple_assignment() {
+    let code = "x = $some_prop;";
+    let result = compile(code, CompileOptions::default());
+    assert!(
+        result.is_ok(),
+        "sysprop in simple assignment should compile"
+    );
+}
+
+#[test]
+fn test_sysprop_in_scatter_assignment() {
+    let code = "{a, b} = $some_prop;";
+    let result = compile(code, CompileOptions::default());
+    assert!(
+        result.is_ok(),
+        "sysprop in scatter assignment should compile"
+    );
+}
+
+#[test]
+fn test_builtin_call_plus_sysprop_in_expression() {
+    let code = "result = callers()[2] + $some_prop;";
+    let result = compile(code, CompileOptions::default());
+    assert!(
+        result.is_ok(),
+        "builtin_call + sysprop in expression should compile"
+    );
+}
+
+#[test]
+fn test_mixed_operand_types() {
+    let code = "{a, b} = $obj:verb(callers()[1]);";
+    let result = compile(code, CompileOptions::default());
+    assert!(result.is_ok(), "mixed operand types should compile");
+}
+
+#[test]
+fn test_jhcore_builtin_context() {
+    let code = "parties = $pronoun_sub:parse_parties(p_s_args, caller);";
+    let result = compile(code, CompileOptions::default());
+    assert!(
+        result.is_ok(),
+        "original JHCore builtin context should compile"
+    );
+}
+
+#[test]
+fn test_jhcore_sysprop_context() {
+    let code = "tell = $string_utils:pronoun_sub(msg, @parties);";
+    let result = compile(code, CompileOptions::default());
+    assert!(
+        result.is_ok(),
+        "original JHCore sysprop context should compile"
+    );
+}
+
+#[test]
+fn test_nested_system_calls() {
+    let code = "party_set = $set_utils:union(@$list_utils:slice(parties));";
+    let result = compile(code, CompileOptions::default());
+    assert!(result.is_ok(), "nested system calls should compile");
+}
+
+#[test]
+fn test_jhcore_object16_verb6() {
+    // The original problematic verb from JHCore object #16, verb 6
+    let code = r#"
+{_, _, perms, @_} = callers()[2];
+return !perms.wizard;
+"#;
+    let result = compile(code, CompileOptions::default());
+    assert!(result.is_ok(), "JHCore object #16 verb 6 should compile");
+}
+
+#[test]
+fn test_jhcore_object34_verb0() {
+    // The original problematic verb from JHCore object #34, verb 0
+    let code = r#"
+msg = args[1];
+p_s_args = args[2..length(args)];
+parties = $pronoun_sub:parse_parties(p_s_args, caller);
+wheres = parties[3][1];
+{msg, parties} = $pronoun_sub:flatten_message(msg, parties);
+tell = $string_utils:pronoun_sub(msg, @parties);
+party_set = $set_utils:union(@$list_utils:slice(parties));
+for where in (wheres)
+`where:announce_all_but(party_set, tell) ! E_VERBNF';
+endfor
+for p in (party_set)
+this:say(msg, p, parties);
+endfor
+"#;
+    let result = compile(code, CompileOptions::default());
+    assert!(result.is_ok(), "JHCore object #34 verb 0 should compile");
+}

--- a/crates/compiler/src/tests/test_macros.rs
+++ b/crates/compiler/src/tests/test_macros.rs
@@ -1,0 +1,91 @@
+// Copyright (C) 2025 Ryan Daum <ryan.daum@gmail.com> This program is free
+// software: you can redistribute it and/or modify it under the terms of the GNU
+// General Public License as published by the Free Software Foundation, version
+// 3.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program. If not, see <https://www.gnu.org/licenses/>.
+//
+
+//! General-purpose test macros for parser testing
+
+/// Assert that a parse operation succeeds
+#[macro_export]
+macro_rules! assert_parse_ok {
+    ($code:expr) => {
+        match $crate::compile($code, $crate::CompileOptions::default()) {
+            Ok(_) => {}
+            Err(e) => panic!("Parse failed for code '{}': {:?}", $code, e),
+        }
+    };
+    ($code:expr, $msg:expr) => {
+        match $crate::compile($code, $crate::CompileOptions::default()) {
+            Ok(_) => {}
+            Err(e) => panic!("{}: Parse failed for code '{}': {:?}", $msg, $code, e),
+        }
+    };
+}
+
+/// Assert that a parse operation fails
+#[macro_export]
+macro_rules! assert_parse_fails {
+    ($code:expr) => {
+        match $crate::compile($code, $crate::CompileOptions::default()) {
+            Ok(_) => panic!("Parse unexpectedly succeeded for code '{}'", $code),
+            Err(_) => {}
+        }
+    };
+    ($code:expr, $msg:expr) => {
+        match $crate::compile($code, $crate::CompileOptions::default()) {
+            Ok(_) => panic!(
+                "{}: Parse unexpectedly succeeded for code '{}'",
+                $msg, $code
+            ),
+            Err(_) => {}
+        }
+    };
+}
+
+/// Assert that parsing produces a specific error
+#[macro_export]
+macro_rules! assert_parse_error {
+    ($code:expr, $expected_error:pat) => {
+        match $crate::compile($code, $crate::CompileOptions::default()) {
+            Ok(_) => panic!("Parse unexpectedly succeeded for code '{}'", $code),
+            Err(e) => match e {
+                $expected_error => {}
+                _ => panic!(
+                    "Expected error pattern {} but got {:?}",
+                    stringify!($expected_error),
+                    e
+                ),
+            },
+        }
+    };
+}
+
+/// Assert that two pieces of code compile to the same bytecode
+#[macro_export]
+macro_rules! assert_compiles_same {
+    ($code1:expr, $code2:expr) => {
+        let result1 = $crate::compile($code1, $crate::CompileOptions::default());
+        let result2 = $crate::compile($code2, $crate::CompileOptions::default());
+        match (result1, result2) {
+            (Ok(prog1), Ok(prog2)) => {
+                assert_eq!(
+                    prog1.main_vector().to_vec(),
+                    prog2.main_vector().to_vec(),
+                    "Programs compiled differently:\nCode 1: {}\nCode 2: {}",
+                    $code1,
+                    $code2
+                );
+            }
+            (Err(e1), _) => panic!("First program failed to compile: {:?}", e1),
+            (_, Err(e2)) => panic!("Second program failed to compile: {:?}", e2),
+        }
+    };
+}

--- a/crates/compiler/src/tests/test_utils.rs
+++ b/crates/compiler/src/tests/test_utils.rs
@@ -1,0 +1,115 @@
+// Copyright (C) 2025 Ryan Daum <ryan.daum@gmail.com> This program is free
+// software: you can redistribute it and/or modify it under the terms of the GNU
+// General Public License as published by the Free Software Foundation, version
+// 3.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program. If not, see <https://www.gnu.org/licenses/>.
+//
+
+//! Testing utilities for parser validation and debugging
+
+use crate::{CompileOptions, compile};
+use moor_common::model::CompileError;
+
+/// Result of parsing for test comparisons
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+pub struct ParseTestResult {
+    pub code: String,
+    pub result: Result<(), CompileError>,
+}
+
+impl ParseTestResult {
+    /// Create a new parse test result
+    pub fn new(code: &str) -> Self {
+        let result = compile(code, CompileOptions::default()).map(|_| ());
+        Self {
+            code: code.to_string(),
+            result,
+        }
+    }
+
+    /// Check if parsing succeeded
+    pub fn is_ok(&self) -> bool {
+        self.result.is_ok()
+    }
+
+    /// Check if parsing failed
+    pub fn is_err(&self) -> bool {
+        self.result.is_err()
+    }
+
+    /// Get the error if parsing failed
+    pub fn error(&self) -> Option<&CompileError> {
+        self.result.as_ref().err()
+    }
+
+    /// Print a formatted test result
+    pub fn print_result(&self, test_name: &str) {
+        println!("{test_name}: {}", self.code);
+        match &self.result {
+            Ok(_) => println!("  ✓ Success"),
+            Err(e) => println!("  ✗ Error: {e}"),
+        }
+    }
+}
+
+/// Test multiple code samples and return results
+#[allow(dead_code)]
+pub fn batch_parse_test(samples: &[(&str, &str)]) -> Vec<(String, ParseTestResult)> {
+    samples
+        .iter()
+        .map(|(name, code)| (name.to_string(), ParseTestResult::new(code)))
+        .collect()
+}
+
+/// Print results of batch parsing tests
+#[allow(dead_code)]
+pub fn print_batch_results(results: &[(String, ParseTestResult)]) {
+    let total = results.len();
+    let passed = results.iter().filter(|(_, r)| r.is_ok()).count();
+    let failed = total - passed;
+
+    println!("\nTest Results Summary:");
+    println!("Total: {total}, Passed: {passed}, Failed: {failed}");
+    println!("\nDetailed Results:");
+
+    for (name, result) in results {
+        result.print_result(name);
+    }
+
+    if failed > 0 {
+        println!("\nFailed Tests:");
+        for (name, result) in results.iter().filter(|(_, r)| r.is_err()) {
+            println!("  - {name}: {:?}", result.error());
+        }
+    }
+}
+
+/// Common test cases for operand parsing
+#[allow(dead_code)]
+pub fn operand_test_cases() -> Vec<(&'static str, &'static str)> {
+    vec![
+        ("builtin_call_scatter", "{_, _, perms, @_} = callers()[2];"),
+        ("builtin_call_simple", "result = callers()[2];"),
+        ("builtin_call_args", "x = length(args);"),
+        ("builtin_call_no_args", "{a, b} = time();"),
+        (
+            "sysprop_call_scatter",
+            "{msg, parties} = $pronoun_sub:flatten_message(msg, parties);",
+        ),
+        (
+            "sysprop_call_simple",
+            "result = $pronoun_sub:flatten_message(msg, parties);",
+        ),
+        ("sysprop_simple", "x = $some_prop;"),
+        ("sysprop_scatter", "{a, b} = $some_prop;"),
+        ("mixed_expression", "result = callers()[2] + $some_prop;"),
+        ("mixed_operands", "{a, b} = $obj:verb(callers()[1]);"),
+    ]
+}

--- a/crates/testing/load-tools/src/direct-scheduler-load-test.rs
+++ b/crates/testing/load-tools/src/direct-scheduler-load-test.rs
@@ -685,10 +685,12 @@ async fn main() -> Result<(), eyre::Error> {
     let database = Box::new(database);
 
     // Create config with higher tick limits for load testing
-    let mut config = Config::default();
     // Increase tick limits significantly for load testing - each task does 7000 verb calls
     // We need much higher limits than the default 60k/30k
-    config.features = Arc::new(FeaturesConfig::default());
+    let config = Config {
+        features: Arc::new(FeaturesConfig::default()),
+        ..Default::default()
+    };
     let config = Arc::new(config);
 
     // Create scheduler components


### PR DESCRIPTION
## Summary

This PR adds comprehensive test coverage for operand parsing, particularly for `builtin_call` and `sysprop_call` in various contexts where they previously failed.

## Changes

- **Test Infrastructure**:
  - Added general-purpose test macros (`assert_parse_ok!`, `assert_parse_fails!`, etc.)
  - Added test utilities for batch testing and result formatting
  - Organized tests in a new `tests/` module

- **Operand Parsing Tests**:
  - Tests for `builtin_call` in scatter assignments
  - Tests for `sysprop_call` in various contexts
  - Tests for mixed operand types in expressions
  - Specific regression tests for JHCore verbs that previously failed

