### PR TITLE
Adding UUOBJIDs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2982,6 +2982,7 @@ dependencies = [
  "papaya",
  "paste",
  "perf-event2",
+ "rand 0.8.5",
  "serde",
  "serde_json",
  "shuttle",

--- a/crates/common/src/model/world_state.rs
+++ b/crates/common/src/model/world_state.rs
@@ -399,6 +399,9 @@ pub trait WorldState: Send {
     /// Returns the (rough) total number of bytes used by database storage subsystem.
     fn db_usage(&self) -> Result<usize, WorldStateError>;
 
+    /// Increment the given sequence, return the new value.
+    fn increment_sequence(&self, seq: usize) -> i64;
+
     /// Commit all modifications made to the state of this world since the start of its transaction.
     fn commit(self: Box<Self>) -> Result<CommitResult, WorldStateError>;
 

--- a/crates/compiler/src/codegen_tests.rs
+++ b/crates/compiler/src/codegen_tests.rs
@@ -23,7 +23,7 @@ mod tests {
     use moor_var::program::opcode::{
         ForRangeOperand, ForSequenceOperand, ScatterArgs, ScatterLabel,
     };
-    use moor_var::{E_INVARG, E_INVIND, E_PERM, E_PROPNF, E_RANGE, Obj};
+    use moor_var::{E_INVARG, E_INVIND, E_PERM, E_PROPNF, E_RANGE, Obj, UuObjid};
 
     #[test]
     fn test_simple_add_expr() {
@@ -1417,6 +1417,59 @@ mod tests {
                 RangeRef,
                 MapInsert,
                 Return,
+                Pop,
+                Done
+            ]
+        );
+    }
+
+    #[test]
+    fn test_uuobjid_resolution() {
+        // First test with a regular object ID to make sure the basic parsing works
+        let program = "return #123;";
+        let binary = compile(program, CompileOptions::default()).unwrap();
+        assert_eq!(
+            binary.main_vector().to_vec(),
+            vec![
+                ImmObjid(Obj::mk_id(123)),
+                Return,
+                Pop,
+                Done
+            ]
+        );
+
+        // Now test with the UUID
+        let program = "return #001A1-9901A71113;";
+        let binary = compile(program, CompileOptions::default()).unwrap();
+
+        // Parse the UUID string to create the expected Obj
+        let uuid = UuObjid::from_uuid_string("001A1-9901A71113").unwrap();
+        let expected_obj = Obj::mk_uuobjid(uuid);
+
+        assert_eq!(
+            binary.main_vector().to_vec(),
+            vec![
+                ImmObjid(expected_obj),
+                Return,
+                Pop,
+                Done
+            ]
+        );
+
+        // Test verb call with UUID
+        let program = "#001A1-9901A71113:tell(\"test\");";
+        let binary = compile(program, CompileOptions::default()).unwrap();
+
+        let test = binary.find_label_for_literal("test".into());
+
+        assert_eq!(
+            binary.main_vector().to_vec(),
+            vec![
+                ImmObjid(expected_obj),
+                ImmSymbol(Symbol::mk("tell")),
+                Imm(test),
+                MakeSingletonList,
+                CallVerb,
                 Pop,
                 Done
             ]

--- a/crates/compiler/src/moo.pest
+++ b/crates/compiler/src/moo.pest
@@ -199,8 +199,8 @@ ASSIGN = _{ "=" ~ !("=" | ">") }
 err = { errcode ~ ("(" ~ expr ~ ")")? }
 errcode = @{ ^"e_" ~ ident_continue+  }
 
-object  = @{ "#" ~ (integer | object_guid) }
-object_guid = @{ ASCII_ALPHANUMERIC{5} ~ "-" ~ ASCII_ALPHANUMERIC{9} }
+object  = @{ "#" ~ (uuid | integer) }
+uuid    = @{ ASCII_HEX_DIGIT{5} ~ "-" ~ ASCII_HEX_DIGIT{10} }
 keyword = @{
     ^"for"
   | ^"endfor"

--- a/crates/compiler/src/moo.pest
+++ b/crates/compiler/src/moo.pest
@@ -199,7 +199,8 @@ ASSIGN = _{ "=" ~ !("=" | ">") }
 err = { errcode ~ ("(" ~ expr ~ ")")? }
 errcode = @{ ^"e_" ~ ident_continue+  }
 
-object  = @{ "#" ~ integer }
+object  = @{ "#" ~ (integer | object_guid) }
+object_guid = @{ ASCII_ALPHANUMERIC{5} ~ "-" ~ ASCII_ALPHANUMERIC{9} }
 keyword = @{
     ^"for"
   | ^"endfor"

--- a/crates/compiler/src/objdef.rs
+++ b/crates/compiler/src/objdef.rs
@@ -370,7 +370,7 @@ fn parse_object_literal(pair: Pair<Rule>) -> Result<Obj, ObjDefParseError> {
     match pair.as_rule() {
         Rule::object => {
             let ostr = &pair.as_str()[1..];
-            if ostr.len() == 15 && ostr.chars().nth(5) == Some('-') {
+            if ostr.len() == 16 && ostr.chars().nth(5) == Some('-') {
                 // This is an uuobjid probably, so we can safely assemble from there.
                 let uuobjid = UuObjid::from_uuid_string(ostr).unwrap();
                 let objid = Obj::mk_uuobjid(uuobjid);

--- a/crates/compiler/src/parse.rs
+++ b/crates/compiler/src/parse.rs
@@ -130,7 +130,7 @@ impl TreeTransformer {
             }
             Rule::object => {
                 let ostr = &pair.as_str()[1..];
-                if ostr.len() == 15 && ostr.chars().nth(5) == Some('-') {
+                if ostr.len() == 16 && ostr.chars().nth(5) == Some('-') {
                     // This is an uuobjid probably, so we can safely assemble from there.
                     let uuobjid = UuObjid::from_uuid_string(ostr).unwrap();
                     let objid = Obj::mk_uuobjid(uuobjid);

--- a/crates/daemon/src/feature_args.rs
+++ b/crates/daemon/src/feature_args.rs
@@ -91,6 +91,13 @@ pub struct FeatureArgs {
                 Note that this is the default behaviour in LambdaMOO."
     )]
     pub persistent_tasks: Option<bool>,
+
+    #[arg(
+        long,
+        help = "Create objects using uuobjids (UUID-based object IDs) instead of objids (integer-based object IDs). \
+                This provides better uniqueness guarantees and avoids integer overflow issues."
+    )]
+    pub use_uuobjids: Option<bool>,
 }
 
 impl FeatureArgs {
@@ -130,6 +137,9 @@ impl FeatureArgs {
         }
         if let Some(args) = self.list_comprehensions {
             config.list_comprehensions = args;
+        }
+        if let Some(args) = self.use_uuobjids {
+            config.use_uuobjids = args;
         }
         Ok(())
     }

--- a/crates/daemon/src/rpc/message_handler.rs
+++ b/crates/daemon/src/rpc/message_handler.rs
@@ -1320,7 +1320,7 @@ impl RpcMessageHandler {
             .set_footer(Footer::from(MOOR_AUTH_TOKEN_FOOTER))
             .set_payload(Payload::from(
                 json!({
-                    "player": oid.id().0,
+                    "player": oid,
                 })
                 .to_string()
                 .as_str(),

--- a/crates/db/src/db_worldstate.rs
+++ b/crates/db/src/db_worldstate.rs
@@ -900,6 +900,10 @@ impl WorldState for DbWorldState {
         Ok((name, aliases))
     }
 
+    fn increment_sequence(&self, seq: usize) -> i64 {
+        self.get_tx().increment_sequence(seq)
+    }
+
     fn db_usage(&self) -> Result<usize, WorldStateError> {
         let _t = PerfTimerGuard::new(&WORLD_STATE_PERF.db_usage);
         self.get_tx().db_usage()

--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -50,6 +50,9 @@ use fast_counter::ConcurrentCounter;
 pub use tx_management::Provider;
 pub use tx_management::{Error, Relation, RelationTransaction, Timestamp, Tx, WorkingSet};
 
+// Re-export sequence constants for use in VM
+pub use moor_db::{SEQUENCE_MAX_OBJECT, SEQUENCE_MAX_UUOBJID};
+
 pub trait Database: Send + WorldStateSource {
     fn loader_client(&self) -> Result<Box<dyn LoaderInterface>, WorldStateError>;
     fn create_snapshot(&self) -> Result<Box<dyn SnapshotInterface>, WorldStateError>;

--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -256,7 +256,7 @@ impl AsByteBuffer for SystemTimeHolder {
 #[repr(C)]
 pub struct ObjAndUUIDHolder {
     pub uuid: [u8; 16],
-    pub obj: u64,
+    pub obj: Obj,
 }
 
 impl PartialOrd for ObjAndUUIDHolder {
@@ -277,12 +277,12 @@ impl ObjAndUUIDHolder {
     pub fn new(obj: &Obj, uuid: Uuid) -> Self {
         Self {
             uuid: *uuid.as_bytes(),
-            obj: obj.id().0 as u64,
+            obj: *obj,
         }
     }
 
     pub fn obj(&self) -> Obj {
-        Obj::mk_id(self.obj as i32)
+        self.obj
     }
 
     pub fn uuid(&self) -> Uuid {

--- a/crates/db/src/prop_cache.rs
+++ b/crates/db/src/prop_cache.rs
@@ -23,7 +23,7 @@ use std::sync::{Arc, Mutex};
 /// Create an optimized cache key by packing Obj and Symbol into a single u64.
 /// Upper 32 bits: obj.id(), Lower 32 bits: symbol.compare_id()
 fn make_cache_key(obj: &Obj, symbol: &Symbol) -> u64 {
-    ((obj.id().0 as u64) << 32) | (symbol.compare_id() as u64)
+    ((obj.as_u64() as u64) << 32) | (symbol.compare_id() as u64)
 }
 
 lazy_static! {

--- a/crates/db/src/relation_defs.rs
+++ b/crates/db/src/relation_defs.rs
@@ -375,6 +375,13 @@ macro_rules! define_relations {
             /// This constant identifies the sequence used to track the highest object ID
             /// that has been allocated, used for generating new unique object IDs.
             pub const SEQUENCE_MAX_OBJECT: usize = 0;
+
+            /// Sequence constant for maximum uuobjid autoincrement counter tracking.
+            ///
+            /// This constant identifies the sequence used to track the highest uuobjid
+            /// autoincrement counter that has been allocated, used for generating new
+            /// unique uuobjids.
+            pub const SEQUENCE_MAX_UUOBJID: usize = 1;
         }
     };
 

--- a/crates/db/src/verb_cache.rs
+++ b/crates/db/src/verb_cache.rs
@@ -21,7 +21,7 @@ use std::sync::{Arc, Mutex};
 /// Create an optimized cache key by packing Obj and Symbol into a single u64.
 /// Upper 32 bits: obj.id(), Lower 32 bits: symbol.compare_id()
 fn make_cache_key(obj: &Obj, symbol: &Symbol) -> u64 {
-    ((obj.id().0 as u64) << 32) | (symbol.compare_id() as u64)
+    ((obj.as_u64()) << 32) | (symbol.compare_id() as u64)
 }
 
 use crate::prop_cache::{ANCESTRY_CACHE_STATS, VERB_CACHE_STATS};

--- a/crates/db/src/ws_transaction.rs
+++ b/crates/db/src/ws_transaction.rs
@@ -226,7 +226,10 @@ impl WorldStateTransaction {
 
         // Update the maximum object number if ours is higher than the current one. This is for the
         // textdump case, where our numbers are coming in arbitrarily.
-        self.update_sequence_max(SEQUENCE_MAX_OBJECT, id.id().0 as i64);
+        // Only do this for objids, not uuobjids
+        if !id.is_uuobjid() {
+            self.update_sequence_max(SEQUENCE_MAX_OBJECT, id.id().0 as i64);
+        }
 
         self.verb_resolution_cache.flush();
         self.ancestry_cache.flush();
@@ -1254,7 +1257,7 @@ impl WorldStateTransaction {
 
 impl WorldStateTransaction {
     /// Increment the given sequence, return the new value.
-    fn increment_sequence(&self, seq: usize) -> i64 {
+    pub fn increment_sequence(&self, seq: usize) -> i64 {
         self.sequences[seq].fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         self.sequences[seq].load(std::sync::atomic::Ordering::Relaxed)
     }

--- a/crates/kernel/src/config.rs
+++ b/crates/kernel/src/config.rs
@@ -69,6 +69,9 @@ pub struct FeaturesConfig {
     ///
     /// This can break backwards compatibility with existing cores, so is off by default.
     pub use_symbols_in_builtins: bool,
+    /// Whether to create objects using uuobjids (UUID-based object IDs) instead of objids (integer-based object IDs).
+    /// This provides better uniqueness guarantees and avoids integer overflow issues.
+    pub use_uuobjids: bool,
 }
 
 impl Default for FeaturesConfig {
@@ -86,6 +89,7 @@ impl Default for FeaturesConfig {
             use_boolean_returns: false,
             use_symbols_in_builtins: false,
             custom_errors: false,
+            use_uuobjids: false,
         }
     }
 }

--- a/crates/kernel/src/vm/builtins/bf_objects.rs
+++ b/crates/kernel/src/vm/builtins/bf_objects.rs
@@ -26,6 +26,7 @@ use moor_var::{List, Variant, v_bool};
 use moor_var::{NOTHING, v_list_iter};
 use moor_var::{Obj, v_int, v_obj};
 use moor_var::{Sequence, Symbol, v_list};
+use moor_db::SEQUENCE_MAX_UUOBJID;
 
 use crate::task_context::{
     current_task_scheduler_client, with_current_transaction, with_current_transaction_mut,
@@ -59,7 +60,13 @@ fn create_object_with_initialize(
             parent,
             owner,
             BitEnum::new(),
-            obj_id,
+            match obj_id {
+                Some(obj_id) => Some(obj_id),
+                None => {
+                    let max = ws.increment_sequence(SEQUENCE_MAX_UUOBJID);
+                    Some(Obj::mk_uuobjid_generated(max as u16))
+                }
+            },
         )
     })
     .map_err(world_state_bf_err)?;

--- a/crates/kernel/src/vm/builtins/bf_values.rs
+++ b/crates/kernel/src/vm/builtins/bf_values.rs
@@ -125,7 +125,13 @@ fn bf_toint(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
     match bf_args.args[0].variant() {
         Variant::Int(i) => Ok(Ret(v_int(*i))),
         Variant::Float(f) => Ok(Ret(v_int(*f as i64))),
-        Variant::Obj(o) => Ok(Ret(v_int(o.id().0 as i64))),
+        Variant::Obj(o) => if o.is_uuobjid() {
+            return Err(BfErr::ErrValue(
+                E_INVARG.msg("cannot convert UUID Objects to integer"),
+            ));
+        } else {
+            Ok(Ret(v_int(o.id().0 as i64)))
+        },
         Variant::Str(s) => {
             let i = s.as_str().parse::<f64>();
             match i {

--- a/crates/kernel/src/vm/mod.rs
+++ b/crates/kernel/src/vm/mod.rs
@@ -19,6 +19,7 @@ use moor_compiler::Offset;
 pub use moor_var::program::ProgramType;
 use moor_var::program::names::Name;
 use moor_var::{List, Obj, Symbol, Var};
+use moor_db::{SEQUENCE_MAX_OBJECT, SEQUENCE_MAX_UUOBJID};
 pub use vm_call::VerbExecutionRequest;
 pub use vm_unwind::FinallyReason;
 

--- a/crates/objdef/src/dump.rs
+++ b/crates/objdef/src/dump.rs
@@ -322,7 +322,7 @@ fn generate_constants_file(
     let mut lines = Vec::new();
     // Sort incrementally by object id.
     let mut objects: Vec<_> = index_names.iter().collect();
-    objects.sort_by(|a, b| a.0.id().0.cmp(&b.0.id().0));
+    objects.sort_by(|a, b| a.0.as_u64().cmp(&b.0.as_u64()));
     for i in objects {
         lines.push(format!("define {} = {};", i.1.to_ascii_uppercase(), i.0));
     }
@@ -357,7 +357,7 @@ pub fn dump_object_definitions(
         // Pick a file name.
         let file_name = match file_names.get(&o.oid) {
             Some(name) => format!("{name}.moo"),
-            None => format!("object_{}.moo", o.oid.id().0),
+            None => format!("object_{}.moo", o.oid.as_u64()),
         };
         let file_path = directory_path.join(file_name);
         let mut file = std::fs::File::create(file_path)?;

--- a/crates/textdump/src/write.rs
+++ b/crates/textdump/src/write.rs
@@ -41,7 +41,7 @@ impl<W: io::Write> TextdumpWriter<W> {
             self.writer,
             "{}\n{}\n{}\n{}",
             verbdef.name,
-            verbdef.owner.id().0,
+            verbdef.owner.as_u64(),
             verbdef.flags,
             verbdef.prep
         )
@@ -133,7 +133,7 @@ impl<W: io::Write> TextdumpWriter<W> {
                 s.as_arc_string()
             )?,
             Variant::Obj(o) => {
-                writeln!(self.writer, "{}\n{}", VarType::TYPE_OBJ as u64, o.id().0)?;
+                writeln!(self.writer, "{}\n{}", VarType::TYPE_OBJ as u64, o.as_u64())?;
             }
             Variant::Str(s) => {
                 match self.encoding_mode {
@@ -194,7 +194,7 @@ impl<W: io::Write> TextdumpWriter<W> {
             Variant::Flyweight(flyweight) => {
                 // delegate, slots (len, [key, value, ...]), contents (len, ...), seal (1/0, string)
                 writeln!(self.writer, "{}", VarType::TYPE_FLYWEIGHT as i64)?;
-                writeln!(self.writer, "{}", flyweight.delegate().id().0)?;
+                writeln!(self.writer, "{}", flyweight.delegate().as_u64())?;
                 writeln!(self.writer, "{}", flyweight.slots().len())?;
                 for (k, v) in flyweight.slots().iter() {
                     writeln!(self.writer, "{k}")?;
@@ -215,7 +215,7 @@ impl<W: io::Write> TextdumpWriter<W> {
 
     fn write_propval(&mut self, propval: &Propval) -> Result<(), io::Error> {
         self.write_var(&propval.value, propval.is_clear)?;
-        writeln!(self.writer, "{}", propval.owner.id().0)?;
+        writeln!(self.writer, "{}", propval.owner.as_u64())?;
         writeln!(self.writer, "{}", propval.flags)?;
         Ok(())
     }
@@ -224,13 +224,13 @@ impl<W: io::Write> TextdumpWriter<W> {
         writeln!(self.writer, "{}\n{}\n", object.id, &object.name)?;
 
         writeln!(self.writer, "{}", object.flags)?;
-        writeln!(self.writer, "{}", object.owner.id().0)?;
-        writeln!(self.writer, "{}", object.location.id().0)?;
-        writeln!(self.writer, "{}", object.contents.id().0)?;
-        writeln!(self.writer, "{}", object.next.id().0)?;
-        writeln!(self.writer, "{}", object.parent.id().0)?;
-        writeln!(self.writer, "{}", object.child.id().0)?;
-        writeln!(self.writer, "{}", object.sibling.id().0)?;
+        writeln!(self.writer, "{}", object.owner.as_u64())?;
+        writeln!(self.writer, "{}", object.location.as_u64())?;
+        writeln!(self.writer, "{}", object.contents.as_u64())?;
+        writeln!(self.writer, "{}", object.next.as_u64())?;
+        writeln!(self.writer, "{}", object.parent.as_u64())?;
+        writeln!(self.writer, "{}", object.child.as_u64())?;
+        writeln!(self.writer, "{}", object.sibling.as_u64())?;
         writeln!(self.writer, "{}", object.verbdefs.len())?;
         for verbdef in &object.verbdefs {
             self.write_verbdef(verbdef)?;
@@ -278,7 +278,7 @@ impl<W: io::Write> TextdumpWriter<W> {
             textdump.users.len()
         )?;
         for user in &textdump.users {
-            writeln!(self.writer, "{}", user.id().0)?;
+            writeln!(self.writer, "{}", user.as_u64())?;
         }
         for object in textdump.objects.values() {
             self.write_object(object)?;

--- a/crates/var/Cargo.toml
+++ b/crates/var/Cargo.toml
@@ -51,5 +51,6 @@ lazy_static.workspace = true
 num-traits.workspace = true
 once_cell.workspace = true
 paste.workspace = true
+rand.workspace = true
 strum.workspace = true
 zerocopy.workspace = true

--- a/crates/var/src/lib.rs
+++ b/crates/var/src/lib.rs
@@ -34,7 +34,7 @@ pub use flyweight::Flyweight;
 pub use lambda::Lambda;
 pub use list::List;
 pub use map::Map;
-pub use obj::{AMBIGUOUS, FAILED_MATCH, NOTHING, Obj, SYSTEM_OBJECT};
+pub use obj::{AMBIGUOUS, FAILED_MATCH, NOTHING, Obj, SYSTEM_OBJECT, UuObjid};
 use std::fmt::Debug;
 pub use string::Str;
 use strum::FromRepr;

--- a/crates/var/src/obj.rs
+++ b/crates/var/src/obj.rs
@@ -69,6 +69,10 @@ pub struct UuObjid(pub u64);
 // Internal representation is lower 32 bits is db object id (if a db object), top 3 bits is a "type"
 // code, with the remaining 13-bits unused for now.
 impl Obj {
+    pub fn as_u64(&self) -> u64 {
+        self.0
+    }
+    
     fn decode_as_objid(&self) -> i32 {
         // Mask out upper 32 bits
         (self.0 & 0x0000_ffff_ffff) as i32

--- a/crates/var/src/obj.rs
+++ b/crates/var/src/obj.rs
@@ -16,9 +16,11 @@ use crate::encode::{DecodingError, EncodingError};
 use binary_layout::LayoutAs;
 use bincode::{Decode, Encode};
 use byteview::ByteView;
+use rand::Rng;
 use serde::{Deserialize, Serialize};
 use std::fmt::{Debug, Display, Formatter};
 use std::ops::Add;
+use std::time::{SystemTime, UNIX_EPOCH};
 use zerocopy::{FromBytes, Immutable, IntoBytes};
 
 /// The "system" object in MOO is a place where a bunch of basic sys functionality hangs off of, and
@@ -56,9 +58,13 @@ pub const FAILED_MATCH: Obj = Obj::mk_id(-3);
 pub struct Obj(u64);
 
 const OBJID_TYPE_CODE: u8 = 0;
+const UUOBJID_TYPE_CODE: u8 = 1;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub struct Objid(pub i32);
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct UuObjid(pub u64);
 
 // Internal representation is lower 32 bits is db object id (if a db object), top 3 bits is a "type"
 // code, with the remaining 13-bits unused for now.
@@ -74,6 +80,17 @@ impl Obj {
         let as_u32 = i32::cast_unsigned(id);
         let as_u64 = as_u32 as u64;
         Self((as_u64 & 0x0000_ffff_ffff) | ((OBJID_TYPE_CODE as u64) << 61))
+    }
+
+    fn decode_as_uuobjid(&self) -> UuObjid {
+        // Extract the 60-bit UUID value from the lower 60 bits
+        let uuid_value = self.0 & 0x0FFF_FFFF_FFFF_FFFF;
+        UuObjid(uuid_value)
+    }
+
+    fn encode_as_uuobjid(uuid: UuObjid) -> Self {
+        // Pack the 60-bit UUID value into the lower 60 bits with type code
+        Self((uuid.0 & 0x0FFF_FFFF_FFFF_FFFF) | ((UUOBJID_TYPE_CODE as u64) << 61))
     }
 
     fn object_type_code(&self) -> u8 {
@@ -104,13 +121,27 @@ impl Add for Obj {
 
 impl Debug for Obj {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        f.write_fmt(format_args!("Obj(#{})", self.decode_as_objid()))
+        match self.object_type_code() {
+            OBJID_TYPE_CODE => f.write_fmt(format_args!("Obj(#{})", self.decode_as_objid())),
+            UUOBJID_TYPE_CODE => {
+                let uuid = self.decode_as_uuobjid();
+                f.write_fmt(format_args!("Obj({})", uuid.to_uuid_string()))
+            }
+            _ => f.write_fmt(format_args!("Obj(UnknownType:{})", self.object_type_code())),
+        }
     }
 }
 
 impl Display for Obj {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        f.write_fmt(format_args!("#{}", self.decode_as_objid()))
+        match self.object_type_code() {
+            OBJID_TYPE_CODE => f.write_fmt(format_args!("#{}", self.decode_as_objid())),
+            UUOBJID_TYPE_CODE => {
+                let uuid = self.decode_as_uuobjid();
+                f.write_fmt(format_args!("{}", uuid.to_uuid_string()))
+            }
+            _ => f.write_fmt(format_args!("UnknownType:{}", self.object_type_code())),
+        }
     }
 }
 
@@ -127,7 +158,14 @@ impl Obj {
 
     #[must_use]
     pub fn to_literal(&self) -> String {
-        format!("#{}", self.decode_as_objid())
+        match self.object_type_code() {
+            OBJID_TYPE_CODE => format!("#{}", self.decode_as_objid()),
+            UUOBJID_TYPE_CODE => {
+                let uuid = self.decode_as_uuobjid();
+                uuid.to_uuid_string()
+            }
+            _ => format!("UnknownType:{}", self.object_type_code()),
+        }
     }
 
     #[must_use]
@@ -146,6 +184,30 @@ impl Obj {
     pub fn id(&self) -> Objid {
         assert_eq!(self.object_type_code(), OBJID_TYPE_CODE);
         Objid(self.decode_as_objid())
+    }
+
+    /// Creates a new Obj with a UuObjid
+    pub fn mk_uuobjid(uuid: UuObjid) -> Self {
+        Self::encode_as_uuobjid(uuid)
+    }
+
+    /// Creates a new Obj with a generated UuObjid
+    pub fn mk_uuobjid_generated(autoincrement: u16) -> Self {
+        Self::mk_uuobjid(UuObjid::generate(autoincrement))
+    }
+
+    /// Gets the UuObjid from this Obj if it's a UuObjid type
+    pub fn uuobjid(&self) -> Option<UuObjid> {
+        if self.object_type_code() == UUOBJID_TYPE_CODE {
+            Some(self.decode_as_uuobjid())
+        } else {
+            None
+        }
+    }
+
+    /// Checks if this Obj is a UuObjid
+    pub fn is_uuobjid(&self) -> bool {
+        self.object_type_code() == UUOBJID_TYPE_CODE
     }
 }
 
@@ -196,11 +258,87 @@ impl TryFrom<&str> for Obj {
                 DecodingError::CouldNotDecode(format!("Could not parse Objid: {e}"))
             })?;
             Ok(Self::mk_id(value))
+        } else if value.contains('-') {
+            // Try to parse as UUID format: FFFFF-FFFFFFFFFF
+            let uuid = UuObjid::from_uuid_string(value)?;
+            Ok(Self::mk_uuobjid(uuid))
         } else {
             Err(DecodingError::CouldNotDecode(format!(
-                "Expected Objid to start with '#', got {value}"
+                "Expected Objid to start with '#' or be in UUID format FFFFF-FFFFFFFFFF, got {value}"
             )))
         }
+    }
+}
+
+impl UuObjid {
+    /// Creates a new UuObjid with the specified components
+    /// - autoincrement: 16 bits (0-65535, wraps around)
+    /// - rng: 4 bits (0-15)
+    /// - epoch_ms: 40 bits (Linux epoch milliseconds, truncated to 40 bits)
+    pub fn new(autoincrement: u16, rng: u8, epoch_ms: u64) -> Self {
+        // Ensure inputs fit in their allocated bits
+        let autoincrement = autoincrement & 0xFFFF; // 16 bits
+        let rng = (rng & 0x0F) as u64; // 4 bits
+        let epoch_ms = epoch_ms & 0xFFFF_FFFF_FF; // 40 bits
+        
+        // Pack into 60 bits: [autoincrement (16)] [rng (4)] [epoch_ms (40)]
+        let packed = (autoincrement as u64) << 44 | (rng << 40) | epoch_ms;
+        Self(packed)
+    }
+    
+    /// Creates a new UuObjid with current time and random components
+    pub fn generate(autoincrement: u16) -> Self {
+        let mut rng = rand::thread_rng();
+        let rng_val = rng.r#gen::<u8>() & 0x0F; // 4 bits
+        
+        // Get current time in milliseconds since Unix epoch
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis() as u64;
+        
+        // Truncate to 40 bits (take the lower 40 bits)
+        let epoch_ms = now & 0xFFFF_FFFF_FF;
+        
+        Self::new(autoincrement, rng_val, epoch_ms)
+    }
+    
+    /// Extracts the components from the UuObjid
+    pub fn components(&self) -> (u16, u8, u64) {
+        let autoincrement = ((self.0 >> 44) & 0xFFFF) as u16;
+        let rng = ((self.0 >> 40) & 0x0F) as u8;
+        let epoch_ms = self.0 & 0xFFFF_FFFF_FF;
+        (autoincrement, rng, epoch_ms)
+    }
+    
+    /// Formats the UuObjid as a UUID-like string: FFFFF-FFFFFFFFFF
+    /// First group: Autoincrement (16 bits) + RNG (4 bits) = 20 bits total
+    /// Second group: Epoch milliseconds (40 bits)
+    pub fn to_uuid_string(&self) -> String {
+        let (autoincrement, rng, epoch_ms) = self.components();
+        let first_group = ((autoincrement as u64) << 4) | (rng as u64);
+        format!("{:05X}-{:010X}", first_group, epoch_ms)
+    }
+    
+    /// Parses a UUID-like string back to UuObjid
+    pub fn from_uuid_string(s: &str) -> Result<Self, DecodingError> {
+        let parts: Vec<&str> = s.split('-').collect();
+        if parts.len() != 2 {
+            return Err(DecodingError::CouldNotDecode(
+                "Expected format FFFFF-FFFFFFFFFF".to_string()
+            ));
+        }
+        
+        let first_group = u64::from_str_radix(parts[0], 16)
+            .map_err(|e| DecodingError::CouldNotDecode(format!("Invalid first group: {}", e)))?;
+        
+        let epoch_ms = u64::from_str_radix(parts[1], 16)
+            .map_err(|e| DecodingError::CouldNotDecode(format!("Invalid epoch_ms: {}", e)))?;
+        
+        let autoincrement = ((first_group >> 4) & 0xFFFF) as u16;
+        let rng = (first_group & 0x0F) as u8;
+        
+        Ok(Self::new(autoincrement, rng, epoch_ms))
     }
 }
 
@@ -229,5 +367,74 @@ mod tests {
         let obj = Obj::mk_id(0x7fff_ffff);
         assert_eq!(obj.id(), Objid(0x7fff_ffff));
         assert_eq!(obj.to_literal(), "#2147483647");
+    }
+
+    #[test]
+    fn test_uuobjid() {
+        // Test manual creation
+        let uuid = UuObjid::new(0x1234, 0x5, 0x1234567890);
+        assert_eq!(uuid.to_uuid_string(), "12345-1234567890");
+        
+        let (autoincrement, rng, epoch_ms) = uuid.components();
+        assert_eq!(autoincrement, 0x1234);
+        assert_eq!(rng, 0x5);
+        assert_eq!(epoch_ms, 0x1234567890);
+
+        // Test parsing
+        let parsed = UuObjid::from_uuid_string("12345-1234567890").unwrap();
+        assert_eq!(parsed, uuid);
+
+        // Test Obj integration
+        let obj = Obj::mk_uuobjid(uuid);
+        assert!(obj.is_uuobjid());
+        assert!(!obj.is_sysobj());
+        assert_eq!(obj.to_literal(), "12345-1234567890");
+        assert_eq!(obj.uuobjid(), Some(uuid));
+
+        // Test string parsing
+        let obj_from_str = Obj::try_from("12345-1234567890").unwrap();
+        assert_eq!(obj_from_str, obj);
+    }
+
+    #[test]
+    fn test_uuobjid_generation() {
+        let uuid = UuObjid::generate(0x1234);
+        let (autoincrement, rng, epoch_ms) = uuid.components();
+        
+        assert_eq!(autoincrement, 0x1234);
+        assert!(rng <= 0x0F);
+        
+        // Check that epoch_ms is reasonable (should be recent)
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis() as u64;
+        let now_truncated = now & 0xFFFF_FFFF_FF;
+        
+        // Allow for some time difference (within 1 second)
+        assert!(epoch_ms >= now_truncated - 1000 || epoch_ms <= now_truncated + 1000);
+    }
+
+    #[test]
+    fn test_uuobjid_edge_cases() {
+        // Test maximum values
+        let uuid = UuObjid::new(0xFFFF, 0x0F, 0xFFFF_FFFF_FF);
+        assert_eq!(uuid.to_uuid_string(), "FFFFF-FFFFFFFFFF");
+        
+        // Test zero values
+        let uuid = UuObjid::new(0, 0, 0);
+        assert_eq!(uuid.to_uuid_string(), "00000-0000000000");
+    }
+
+    #[test]
+    fn test_uuobjid_parsing_errors() {
+        // Invalid format
+        assert!(UuObjid::from_uuid_string("invalid").is_err());
+        assert!(UuObjid::from_uuid_string("12345").is_err());
+        assert!(UuObjid::from_uuid_string("12345-1234567890-extra").is_err());
+        
+        // Invalid hex
+        assert!(UuObjid::from_uuid_string("GGGGG-1234567890").is_err());
+        assert!(UuObjid::from_uuid_string("12345-GGGGGGGGGG").is_err());
     }
 }

--- a/crates/var/src/obj.rs
+++ b/crates/var/src/obj.rs
@@ -129,7 +129,7 @@ impl Debug for Obj {
             OBJID_TYPE_CODE => f.write_fmt(format_args!("Obj(#{})", self.decode_as_objid())),
             UUOBJID_TYPE_CODE => {
                 let uuid = self.decode_as_uuobjid();
-                f.write_fmt(format_args!("Obj({})", uuid.to_uuid_string()))
+                f.write_fmt(format_args!("Obj(#{})", uuid.to_uuid_string()))
             }
             _ => f.write_fmt(format_args!("Obj(UnknownType:{})", self.object_type_code())),
         }
@@ -142,7 +142,7 @@ impl Display for Obj {
             OBJID_TYPE_CODE => f.write_fmt(format_args!("#{}", self.decode_as_objid())),
             UUOBJID_TYPE_CODE => {
                 let uuid = self.decode_as_uuobjid();
-                f.write_fmt(format_args!("{}", uuid.to_uuid_string()))
+                f.write_fmt(format_args!("#{}", uuid.to_uuid_string()))
             }
             _ => f.write_fmt(format_args!("UnknownType:{}", self.object_type_code())),
         }

--- a/crates/web-host/src/host/mod.rs
+++ b/crates/web-host/src/host/mod.rs
@@ -76,7 +76,7 @@ pub fn var_as_json(v: &Var) -> serde_json::Value {
             })
         }
         Variant::Obj(o) => json!(Oid {
-            oid: o.id().0 as i64
+            oid: o.as_u64() as i64
         }),
         Variant::Int(i) => serde_json::Value::Number(Number::from(*i)),
         Variant::Float(f) => json!(*f),

--- a/crates/web-host/src/host/props.rs
+++ b/crates/web-host/src/host/props.rs
@@ -65,10 +65,10 @@ pub async fn properties_handler(
                 .iter()
                 .map(|prop| {
                     json!({
-                        "definer": prop.definer.id().0,
-                        "location": prop.location.id().0,
+                        "definer": prop.definer.as_u64(),
+                        "location": prop.location.as_u64(),
                         "name": prop.name.to_string(),
-                        "owner": prop.owner.id().0,
+                        "owner": prop.owner.as_u64(),
                         "r": prop.r,
                         "w": prop.w,
                         "chown": prop.chown,
@@ -141,10 +141,10 @@ pub async fn property_retrieval_handler(
         )) => {
             debug!("Property value: {:?}", value);
             Json(json!({
-                "definer": definer.id().0,
+                "definer": definer.as_u64(),
                 "name": name.to_string(),
-                "location": location.id().0,
-                "owner": owner.id().0,
+                "location": location.as_u64(),
+                "owner": owner.as_u64(),
                 "r": r,
                 "w": w,
                 "chown": chown,

--- a/crates/web-host/src/host/verbs.rs
+++ b/crates/web-host/src/host/verbs.rs
@@ -75,7 +75,7 @@ pub async fn verb_program_handler(
             objid,
             verb_name,
         ))) => Json(json!({
-            "location": objid.id().0,
+            "location": objid.as_u64(),
             "name": verb_name,
         }))
         .into_response(),
@@ -157,8 +157,8 @@ pub async fn verb_retrieval_handler(
             },
             code,
         )) => Json(json!({
-            "location": location.id().0,
-            "owner": owner.id().0,
+            "location": location.as_u64(),
+            "owner": owner.as_u64(),
             "names": names.iter().map(|s| s.to_string()).collect::<Vec<String>>(),
             "code": code,
             "r": r,
@@ -218,8 +218,8 @@ pub async fn verbs_handler(
                 .iter()
                 .map(|verb| {
                     json!({
-                        "location": verb.location.id().0,
-                        "owner": verb.owner.id().0,
+                        "location": verb.location.as_u64(),
+                        "owner": verb.owner.as_u64(),
                         "names": verb.names.iter().map(|s| s.to_string()).collect::<Vec<String>>(),
                         "r": verb.r,
                         "w": verb.w,

--- a/tools/moorc/src/feature_args.rs
+++ b/tools/moorc/src/feature_args.rs
@@ -90,6 +90,13 @@ pub struct FeatureArgs {
                 Note that this is the default behaviour in LambdaMOO."
     )]
     pub persistent_tasks: Option<bool>,
+
+    #[arg(
+        long,
+        help = "Create objects using uuobjids (UUID-based object IDs) instead of objids (integer-based object IDs). \
+                This provides better uniqueness guarantees and avoids integer overflow issues."
+    )]
+    pub use_uuobjids: Option<bool>,
 }
 
 impl FeatureArgs {
@@ -129,6 +136,9 @@ impl FeatureArgs {
         }
         if let Some(args) = self.list_comprehensions {
             config.list_comprehensions = args;
+        }
+        if let Some(args) = self.use_uuobjids {
+            config.use_uuobjids = args;
         }
         Ok(())
     }

--- a/tools/moorc/src/main.rs
+++ b/tools/moorc/src/main.rs
@@ -342,10 +342,10 @@ fn main() -> Result<(), eyre::Report> {
     let mut unit_tests = vec![];
     if args.run_tests == Some(true) {
         let tx = db.new_world_state().unwrap();
-        let mo = tx.max_object(&wizard).unwrap().id().0;
+        let mo = tx.max_object(&wizard).unwrap().as_u64();
         info!("Scanning objects 0..{} for tests", mo);
         for o in 0..=mo {
-            let o = Obj::mk_id(o);
+            let o = Obj::mk_id(o as i32);
             if let Ok(verbs) = tx.verbs(&wizard, &o) {
                 for verb in verbs.iter() {
                     for name in verb.names() {


### PR DESCRIPTION
this PR adds a new type of object ID called uuobjids, and adds a flag for manually overriding the functionality of create() to make objects in that space.

There's a few reasons for this change:
- Separating world data from user data
- Enabling random non-sequential object identifiers to allow multiple versions of a game to operate at the same time without collisions (IE: A dev env and a prod env where objects are synchronized)
- Support the development of a VMS where numbered objects are tracked but guid objects are not

This is backed up in design theory / practice where non-generic instances of objects (that do not contain verb definitions) are rarely / never referenced in code and live in a perpetual state of simulation rather than insighted moderation. Cardinality in identity is irrelevant except in a handful of cases where intervention is necessary. By adding uuid objects we can delineate these spaces and enforce a useful paradigm.