### PR TITLE
Improve bf_verb compatibility with LambdaMOO

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,13 @@ development-export/
 node_modules/
 dist/
 
+# Claude artifacts
 CLAUDE.md
+CLAUDE.sessions.md
+sessions/
+/.claude/
 
+development.db/
 moor-data/
+/connections.db/
+/development.db/

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ target/
 .target
 .vscode/
 .cargo/
+.claude/
 
 /.idea/.gitignore
 /.idea/modules.xml
@@ -25,7 +26,6 @@ CLAUDE.sessions.md
 sessions/
 /.claude/
 
+connections.db/
 development.db/
 moor-data/
-/connections.db/
-/development.db/

--- a/crates/compiler/src/decompile.rs
+++ b/crates/compiler/src/decompile.rs
@@ -51,6 +51,12 @@ pub enum DecompileError {
     UnsupportedConstruct(String),
 }
 
+impl From<std::fmt::Error> for DecompileError {
+    fn from(_: std::fmt::Error) -> Self {
+        DecompileError::MalformedProgram("Format error during unparsing".to_string())
+    }
+}
+
 struct Decompile {
     /// The program we are decompiling.
     program: Program,

--- a/crates/kernel/src/tasks/world_state_executor.rs
+++ b/crates/kernel/src/tasks/world_state_executor.rs
@@ -284,7 +284,7 @@ impl WorldStateActionExecutor {
                     )))
                 })?;
 
-                let unparsed = unparse(&decompiled).map_err(|e| {
+                let unparsed = unparse(&decompiled, false, true).map_err(|e| {
                     SchedulerError::VerbRetrievalFailed(WorldStateError::DatabaseError(format!(
                         "Could not unparse decompiled verb: {e:?}"
                     )))

--- a/crates/kernel/src/vm/builtins/bf_verbs.rs
+++ b/crates/kernel/src/vm/builtins/bf_verbs.rs
@@ -359,7 +359,19 @@ fn bf_verb_code(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
     }
     let verbdef = get_verbdef(&obj, bf_args.args[1].clone(), bf_args)?;
 
-    // TODO: bf_verbs: fully-paren and indent options. For now we ignore these.
+    // Parse optional fully_paren parameter (defaults to false)
+    let fully_paren = if bf_args.args.len() > 2 {
+        bf_args.args[2].as_bool().unwrap_or(false)
+    } else {
+        false
+    };
+
+    // Parse optional indent parameter (defaults to true)  
+    let indent = if bf_args.args.len() > 3 {
+        bf_args.args[3].as_bool().unwrap_or(true)
+    } else {
+        true
+    };
 
     // Retrieve the binary for the verb.
     let verb_info = with_current_transaction(|world_state| {
@@ -386,7 +398,7 @@ fn bf_verb_code(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
         }
     };
 
-    let unparsed = match unparse(&decompiled) {
+    let unparsed = match unparse(&decompiled, fully_paren, indent) {
         Ok(unparsed) => unparsed,
         Err(e) => {
             warn!(object=?bf_args.args[0], verb=?bf_args.args[1], error = ?e, "verb_code: verb program could not be unparsed");

--- a/crates/kernel/src/vm/builtins/bf_verbs.rs
+++ b/crates/kernel/src/vm/builtins/bf_verbs.rs
@@ -366,7 +366,7 @@ fn bf_verb_code(bf_args: &mut BfCallState<'_>) -> Result<BfRet, BfErr> {
         false
     };
 
-    // Parse optional indent parameter (defaults to true)  
+    // Parse optional indent parameter (defaults to true)
     let indent = if bf_args.args.len() > 3 {
         bf_args.args[3].as_bool().unwrap_or(true)
     } else {

--- a/crates/kernel/testsuite/moot/bitwise.moot
+++ b/crates/kernel/testsuite/moot/bitwise.moot
@@ -1,0 +1,94 @@
+// Test bitwise operations
+@programmer
+
+// test_bitwise_and
+; return 3 &. 1;
+1
+
+; return 5 &. 3;
+1
+
+; return 15 &. 7;
+7
+
+; return 0 &. 255;
+0
+
+// test_bitwise_or
+; return 5 |. 2;
+7
+
+; return 1 |. 2;
+3
+
+; return 8 |. 4;
+12
+
+; return 0 |. 255;
+255
+
+// test_bitwise_xor
+; return 6 ^. 3;
+5
+
+; return 15 ^. 7;
+8
+
+; return 255 ^. 0;
+255
+
+; return 5 ^. 5;
+0
+
+// test_left_shift
+; return 8 << 1;
+16
+
+; return 1 << 3;
+8
+
+; return 7 << 2;
+28
+
+; return 0 << 5;
+0
+
+// test_right_shift
+; return 16 >> 2;
+4
+
+; return 8 >> 1;
+4
+
+; return 28 >> 2;
+7
+
+; return 0 >> 5;
+0
+
+// test_bitwise_not
+; return ~5;
+-6
+
+; return ~0;
+-1
+
+; return ~(-1);
+0
+
+; return ~42;
+-43
+
+// test_bitwise_precedence - bitwise operators should bind tighter than logical
+; return 1 |. 2 && 3 &. 4;
+0
+
+; return 0 || 5 &. 3;
+1
+
+// test_bitwise_complex_expressions
+; return (15 &. 7) |. (8 ^. 12);
+7
+
+; return ~(5 &. 3) ^. (7 |. 1);
+-7

--- a/crates/objdef/src/dump.rs
+++ b/crates/objdef/src/dump.rs
@@ -533,7 +533,7 @@ fn dump_verb(
     let ProgramType::MooR(program) = &v.program;
     let decompiled =
         program_to_tree(program).map_err(|_| ObjectDumpError::DecompileError { obj: *obj })?;
-    let unparsed = unparse(&decompiled).map_err(|_| ObjectDumpError::UnparseError { obj: *obj })?;
+    let unparsed = unparse(&decompiled, false, true).map_err(|_| ObjectDumpError::UnparseError { obj: *obj })?;
 
     verb_lines.push(format!(
         "{indent}verb {names} ({verbargsspec}) owner: {owner} flags: \"{vflags}\""

--- a/crates/objdef/src/dump.rs
+++ b/crates/objdef/src/dump.rs
@@ -533,7 +533,8 @@ fn dump_verb(
     let ProgramType::MooR(program) = &v.program;
     let decompiled =
         program_to_tree(program).map_err(|_| ObjectDumpError::DecompileError { obj: *obj })?;
-    let unparsed = unparse(&decompiled, false, true).map_err(|_| ObjectDumpError::UnparseError { obj: *obj })?;
+    let unparsed = unparse(&decompiled, false, true)
+        .map_err(|_| ObjectDumpError::UnparseError { obj: *obj })?;
 
     verb_lines.push(format!(
         "{indent}verb {names} ({verbargsspec}) owner: {owner} flags: \"{vflags}\""

--- a/crates/textdump/src/write.rs
+++ b/crates/textdump/src/write.rs
@@ -123,7 +123,7 @@ impl<W: io::Write> TextdumpWriter<W> {
         let decompiled = program_to_tree(&lambda.0.body)
             .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
         let unparsed =
-            unparse(&decompiled).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+            unparse(&decompiled, false, true).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
 
         // Write the source code
         writeln!(self.writer, "{}", unparsed.len())?;

--- a/crates/textdump/src/write.rs
+++ b/crates/textdump/src/write.rs
@@ -122,8 +122,8 @@ impl<W: io::Write> TextdumpWriter<W> {
         // Decompile the lambda body to source code, just like we do for verbs
         let decompiled = program_to_tree(&lambda.0.body)
             .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
-        let unparsed =
-            unparse(&decompiled, false, true).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+        let unparsed = unparse(&decompiled, false, true)
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
 
         // Write the source code
         writeln!(self.writer, "{}", unparsed.len())?;

--- a/crates/textdump/src/write_textdump.rs
+++ b/crates/textdump/src/write_textdump.rs
@@ -49,7 +49,7 @@ fn cv_arg(flags: BitEnum<VerbFlag>, arg: VerbArgsSpec) -> (u16, i16) {
     (flags | arg_flags, prepflags)
 }
 
-/// Take a transaction, and scan the relations and build a Textdump representing a snapshot of the world as it
+/// Take a transaction and scan the relations and build a Textdump representing a snapshot of the world as it
 /// exists in the transaction.
 pub fn make_textdump(tx: &dyn SnapshotInterface, version: String) -> Textdump {
     // To create the objects list, we need to scan all objects.
@@ -180,7 +180,7 @@ pub fn make_textdump(tx: &dyn SnapshotInterface, version: String) -> Textdump {
                 let ast = moor_compiler::program_to_tree(&program)
                     .expect("Failed to decompile verb binary");
                 let program =
-                    moor_compiler::unparse(&ast).expect("Failed to decompile verb binary");
+                    moor_compiler::unparse(&ast, false, true).expect("Failed to decompile verb binary");
                 Some(program.join("\n"))
             } else {
                 None

--- a/crates/textdump/src/write_textdump.rs
+++ b/crates/textdump/src/write_textdump.rs
@@ -179,8 +179,8 @@ pub fn make_textdump(tx: &dyn SnapshotInterface, version: String) -> Textdump {
             let prgstr = if !program.main_vector().is_empty() {
                 let ast = moor_compiler::program_to_tree(&program)
                     .expect("Failed to decompile verb binary");
-                let program =
-                    moor_compiler::unparse(&ast, false, true).expect("Failed to decompile verb binary");
+                let program = moor_compiler::unparse(&ast, false, true)
+                    .expect("Failed to decompile verb binary");
                 Some(program.join("\n"))
             } else {
                 None


### PR DESCRIPTION
So, broad strokes, this adds optional support for fully_paren and the indent flag to the verb function (Issue #250). 

In the process of fixing this, I discovered a few places where our precedent tables weren't aligned with lambda's while trying to match parens. I decided that it would make sense to tackle #205.